### PR TITLE
Handle '/' in branch name.

### DIFF
--- a/ThingIFSDK/Documentation/generateDocs.py
+++ b/ThingIFSDK/Documentation/generateDocs.py
@@ -65,7 +65,7 @@ class SwiftDocGenerator(object):
         if not branchStr:
             branchStr = subprocess.Popen("git branch | grep -e '^\*' | sed -e 's/^\* //g'", stdout=subprocess.PIPE, shell=True).communicate()[0].split()[0]
         p = re.compile('[\/ ]')
-        branchStr = p.sub('_', branchStr)
+        branchStr = p.sub('-', branchStr)
         print ('branchStr: ' + branchStr)
         self.gitBranch = branchStr
 

--- a/ThingIFSDK/Makefile
+++ b/ThingIFSDK/Makefile
@@ -1,7 +1,7 @@
 all:clean build archive doc
 
 DIST_DIR = dist
-GIT_BRANCH_NAME := $(shell git branch | grep -e '^\*' | sed -e 's/^\* //g')
+GIT_BRANCH_NAME := $(shell git branch | grep -e '^\*' | sed -e 's/^\* //g' | sed -e 's/\//-/g')
 GIT_COMMIT_ID := $(shell git rev-list -n 1 --abbrev-commit HEAD)
 
 .PHONY: clean carthage-build archive doc


### PR DESCRIPTION
Build fails when '/' is included in branch name.
This PR fixes the issue.
'/' is replaced with '-'
In documentation build, '/' was replaced with '_'. I unified replacement with '-'.
