### PR TITLE
All fields in Command are serialized and deserialized.

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		A56B0A431C5B43B100E653EF /* TriggeredServerCodeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B0A421C5B43B100E653EF /* TriggeredServerCodeResult.swift */; };
 		A56B0A471C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B0A461C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift */; };
 		A56B0A491C62143000E653EF /* PatchServerCodeTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B0A481C62143000E653EF /* PatchServerCodeTriggerTests.swift */; };
+		B68227F41C85823A00AB85D0 /* CommandSerializationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68227F31C85823A00AB85D0 /* CommandSerializationTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -156,6 +157,7 @@
 		A56B0A421C5B43B100E653EF /* TriggeredServerCodeResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TriggeredServerCodeResult.swift; sourceTree = "<group>"; };
 		A56B0A461C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewServerCodeTriggerTests.swift; sourceTree = "<group>"; };
 		A56B0A481C62143000E653EF /* PatchServerCodeTriggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchServerCodeTriggerTests.swift; sourceTree = "<group>"; };
+		B68227F31C85823A00AB85D0 /* CommandSerializationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandSerializationTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -295,6 +297,7 @@
 				743800F91C2930C9005D8458 /* testapp.plist */,
 				A529D2A21C7444DE00C892D2 /* TriggeredServerCodeResultTest.swift */,
 				A54EFC2D1C7D9EF500BCF4D2 /* SmallTestBase.swift */,
+				B68227F31C85823A00AB85D0 /* CommandSerializationTest.swift */,
 			);
 			path = ThingIFSDKTests;
 			sourceTree = "<group>";
@@ -469,6 +472,7 @@
 				7D36B6AB1BD4D0CC00D9B821 /* OnboardingTests.swift in Sources */,
 				A54EFC2E1C7D9EF500BCF4D2 /* SmallTestBase.swift in Sources */,
 				7D36B6A21BD4D0CC00D9B821 /* EnableTriggerTests.swift in Sources */,
+				B68227F41C85823A00AB85D0 /* CommandSerializationTest.swift in Sources */,
 				7D36B6AE1BD4D0CC00D9B821 /* PostNewTriggerTests.swift in Sources */,
 				7D36B6A11BD4D0CC00D9B821 /* DeleteTriggerTests.swift in Sources */,
 				7D36B6A31BD4D0CC00D9B821 /* EntitySerializationTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/Command.swift
+++ b/ThingIFSDK/ThingIFSDK/Command.swift
@@ -15,7 +15,7 @@ public class Command: NSObject, NSCoding {
         aCoder.encodeObject(self.schemaName, forKey: "schemaName")
         aCoder.encodeInteger(self.schemaVersion, forKey: "schemaVersion")
         aCoder.encodeObject(self.actions, forKey: "actions")
-        aCoder.encodeObject(self.actionResults, forKey: "actionsResults")
+        aCoder.encodeObject(self.actionResults, forKey: "actionResults")
         aCoder.encodeInteger(self.commandState.rawValue, forKey: "commandState")
         aCoder.encodeObject(self.firedByTriggerID, forKey: "firedByTriggerID")
         if let date = self.created {

--- a/ThingIFSDK/ThingIFSDK/Command.swift
+++ b/ThingIFSDK/ThingIFSDK/Command.swift
@@ -17,6 +17,7 @@ public class Command: NSObject, NSCoding {
         aCoder.encodeObject(self.firedByTriggerID, forKey: "firedByTriggerID")
         aCoder.encodeObject(self.actions, forKey: "actions")
         aCoder.encodeObject(self.actionResults, forKey: "actionsResults")
+        aCoder.encodeInteger(self.commandState.rawValue, forKey: "commandState")
         if let date = self.created {
             aCoder.encodeDouble(date.timeIntervalSince1970, forKey: "created")
         }
@@ -36,11 +37,11 @@ public class Command: NSObject, NSCoding {
         self.schemaName = aDecoder.decodeObjectForKey("schemaName") as! String
         self.schemaVersion = aDecoder.decodeIntegerForKey("schemaVersion")
         self.actions = aDecoder.decodeObjectForKey("actions")
-                as! Dictionary<String, AnyObject>;
+                as! [Dictionary<String, AnyObject>];
         self.actionResults = aDecoder.decodeObjectForKey("actionResults")
-                as! Dictionary<String, AnyObject>;
-        self.actionResults = []
-        self.commandState = CommandState.SENDING
+                as! [Dictionary<String, AnyObject>];
+        self.commandState =
+            CommandState(rawValue: aDecoder.decodeIntegerForKey("commandState"))!;
         self.firedByTriggerID = aDecoder.decodeObjectForKey("firedByTriggerID") as? String
         if aDecoder.containsValueForKey("created") {
             self.created = NSDate(timeIntervalSince1970: aDecoder.decodeDoubleForKey("created"))
@@ -209,13 +210,17 @@ public class Command: NSObject, NSCoding {
 }
 
 /** Enum represents state of the Command. */
-public enum CommandState {
+public enum CommandState: Int {
+    /* NOTE: These numbers must not be changed.
+       These numbers are used serialization and deserialization
+       If thses numbers are changed, then serialization and deserialization
+       is broken. */
     /** SENDING Command */
-    case SENDING
+    case SENDING = 1
     /** Command is published to the Target. */
-    case DELIVERED
+    case DELIVERED = 2
     /** Target returns execution result but not completed all actions successfully. */
-    case INCOMPLETE
+    case INCOMPLETE = 3
     /** Target returns execution result and all actions successfully done. */
-    case DONE
+    case DONE = 4
 }

--- a/ThingIFSDK/ThingIFSDK/Command.swift
+++ b/ThingIFSDK/ThingIFSDK/Command.swift
@@ -14,10 +14,10 @@ public class Command: NSObject, NSCoding {
         aCoder.encodeObject(self.issuerID, forKey: "issuerID")
         aCoder.encodeObject(self.schemaName, forKey: "schemaName")
         aCoder.encodeInteger(self.schemaVersion, forKey: "schemaVersion")
-        aCoder.encodeObject(self.firedByTriggerID, forKey: "firedByTriggerID")
         aCoder.encodeObject(self.actions, forKey: "actions")
         aCoder.encodeObject(self.actionResults, forKey: "actionsResults")
         aCoder.encodeInteger(self.commandState.rawValue, forKey: "commandState")
+        aCoder.encodeObject(self.firedByTriggerID, forKey: "firedByTriggerID")
         if let date = self.created {
             aCoder.encodeDouble(date.timeIntervalSince1970, forKey: "created")
         }

--- a/ThingIFSDK/ThingIFSDK/Command.swift
+++ b/ThingIFSDK/ThingIFSDK/Command.swift
@@ -15,6 +15,8 @@ public class Command: NSObject, NSCoding {
         aCoder.encodeObject(self.schemaName, forKey: "schemaName")
         aCoder.encodeInteger(self.schemaVersion, forKey: "schemaVersion")
         aCoder.encodeObject(self.firedByTriggerID, forKey: "firedByTriggerID")
+        aCoder.encodeObject(self.actions, forKey: "actions")
+        aCoder.encodeObject(self.actionResults, forKey: "actionsResults")
         if let date = self.created {
             aCoder.encodeDouble(date.timeIntervalSince1970, forKey: "created")
         }
@@ -33,7 +35,10 @@ public class Command: NSObject, NSCoding {
         self.issuerID = aDecoder.decodeObjectForKey("issuerID") as! TypedID
         self.schemaName = aDecoder.decodeObjectForKey("schemaName") as! String
         self.schemaVersion = aDecoder.decodeIntegerForKey("schemaVersion")
-        self.actions = []
+        self.actions = aDecoder.decodeObjectForKey("actions")
+                as! Dictionary<String, AnyObject>;
+        self.actionResults = aDecoder.decodeObjectForKey("actionResults")
+                as! Dictionary<String, AnyObject>;
         self.actionResults = []
         self.commandState = CommandState.SENDING
         self.firedByTriggerID = aDecoder.decodeObjectForKey("firedByTriggerID") as? String

--- a/ThingIFSDK/ThingIFSDKTests/CommandSerializationTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/CommandSerializationTest.swift
@@ -1,0 +1,20 @@
+//
+//  CommandSerializationTest.swift
+//  ThingIFSDK
+//
+//  Created on 2016/03/01.
+//  Copyright (c) 2016 Kii. All rights reserved.
+//
+
+import XCTest
+
+class CommandSerializationTest: SmallTestBase {
+
+    override func setUp() {
+        super.setUp()
+    }
+    override func tearDown() {
+        super.tearDown()
+    }
+
+}

--- a/ThingIFSDK/ThingIFSDKTests/CommandSerializationTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/CommandSerializationTest.swift
@@ -18,33 +18,111 @@ class CommandSerializationTest: SmallTestBase {
         super.tearDown()
     }
 
+    class func isSameArray(
+            source: [Dictionary<String, AnyObject>],
+            target: [Dictionary<String, AnyObject>]) -> Bool {
+        if source.count != target.count {
+            return false;
+        }
+        for index in 0..<source.count {
+            if !CommandSerializationTest.isSameDictionary(
+                   source[index], target: target[index]) {
+                return false;
+            }
+        }
+        return true
+    }
+
+    class func isSameDictionary(
+            source: Dictionary<String, AnyObject>,
+            target: Dictionary<String, AnyObject>) -> Bool {
+        if source.count != target.count {
+            return false;
+        }
+        for (key, value) in source {
+            let targetValue = target[key];
+            if targetValue == nil {
+                return false;
+            }
+
+            if value is Dictionary<String, AnyObject> &&
+                     targetValue is Dictionary<String, AnyObject> {
+                CommandSerializationTest.isSameDictionary(
+                    value as! Dictionary<String, AnyObject>,
+                    target: targetValue as! Dictionary<String, AnyObject>);
+            } else if value is Int && targetValue is Int {
+                if value as! Int != targetValue as! Int {
+                    return false;
+                }
+                continue;
+            } else if value is Double && targetValue is Double {
+                if value as! Double != targetValue as! Double {
+                    return false;
+                }
+                continue;
+            } else if value is Float && targetValue is Float {
+                if value as! Float != targetValue as! Float {
+                    return false;
+                }
+                continue;
+            } else if value is Bool && targetValue is Bool {
+                if value as! Bool != targetValue as! Bool {
+                    return false;
+                }
+                continue;
+            } else if value is String && targetValue is String {
+                if value as! String != targetValue as! String {
+                    return false;
+                }
+                continue;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
     func testSerializeCommand() {
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver =
-            NSKeyedArchiver(forWritingWithMutableData: data);
         let created = NSDate(timeIntervalSince1970: 100);
         let modified = NSDate(timeIntervalSince1970: 200);
+        let actions: [Dictionary<String, AnyObject>] =
+            [
+                [ "turnPower" : [ "power" : true ] ],
+                [ "setFanSpeed" : [ "fanSpeed": 100] ]
+            ];
+        let actionResults: [Dictionary<String, AnyObject>] =
+            [
+                [ "turnPower" :
+                    [
+                        "succeeded" : true,
+                        "data": [
+                            "time": 100
+                        ]
+                    ]
+                ],
+                [ "setFanSpeed" :
+                    [
+                        "succeeded" : false,
+                        "errorMessage" : "failed to set fan spped"
+                    ]
+                ]
+            ];
+        let metadata: Dictionary<String, AnyObject> = [ "sound" : "noisy.mp3" ];
         let source: Command = Command(
                 commandID: "testCommandID",
                 targetID: TypedID(type: "testTargetType", id: "testTargetID"),
                 issuerID: TypedID(type: "testIssuerType", id: "testIssuerID"),
                 schemaName:"testSchemaName",
                 schemaVersion: 1,
-                actions: [],
-                actionResults: [],
+                actions: actions,
+                actionResults: actionResults,
                 commandState: CommandState.SENDING);
         source.firedByTriggerID = "testFiredByTriggerID";
         source.created = created;
         source.modified = modified;
         source.title = "testTitle";
         source.commandDescription = "testCommandDescription";
-        source.encodeWithCoder(coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-            NSKeyedUnarchiver(forReadingWithData: data);
-        let target: Command = Command(coder: decoder);
-        decoder.finishDecoding();
+        source.metadata = metadata;
 
         XCTAssertEqual(source.commandID, "testCommandID");
         XCTAssertEqual(source.targetID.type, "testTargetType");
@@ -53,11 +131,32 @@ class CommandSerializationTest: SmallTestBase {
         XCTAssertEqual(source.issuerID.id, "testIssuerID");
         XCTAssertEqual(source.schemaName, "testSchemaName");
         XCTAssertEqual(source.schemaVersion, 1);
+        XCTAssertEqual(source.actions.count, 2);
+        XCTAssertTrue(
+            CommandSerializationTest.isSameArray(
+                source.actions, target: actions));
+        XCTAssertTrue(
+            CommandSerializationTest.isSameArray(
+                source.actionResults, target: actionResults));
         XCTAssertEqual(source.firedByTriggerID, "testFiredByTriggerID");
         XCTAssertEqual(source.created, created);
         XCTAssertEqual(source.modified, modified);
         XCTAssertEqual(source.title, "testTitle");
         XCTAssertEqual(source.commandDescription, "testCommandDescription");
+        XCTAssertTrue(
+            CommandSerializationTest.isSameDictionary(
+                source.metadata!, target: metadata));
+
+        let data: NSMutableData = NSMutableData(capacity: 1024)!;
+        let coder: NSKeyedArchiver =
+            NSKeyedArchiver(forWritingWithMutableData: data);
+        source.encodeWithCoder(coder);
+        coder.finishEncoding();
+
+        let decoder: NSKeyedUnarchiver =
+            NSKeyedUnarchiver(forReadingWithData: data);
+        let target: Command = Command(coder: decoder);
+        decoder.finishDecoding();
 
         XCTAssertEqual(source.commandID, target.commandID);
         XCTAssertEqual(source.targetID.type, target.targetID.type);
@@ -66,11 +165,20 @@ class CommandSerializationTest: SmallTestBase {
         XCTAssertEqual(source.issuerID.id, target.issuerID.id);
         XCTAssertEqual(source.schemaName, target.schemaName);
         XCTAssertEqual(source.schemaVersion, target.schemaVersion);
+        XCTAssertTrue(
+            CommandSerializationTest.isSameArray(
+                source.actions, target: target.actions));
+        XCTAssertTrue(
+            CommandSerializationTest.isSameArray(
+                source.actionResults, target: target.actionResults));
         XCTAssertEqual(source.commandState, target.commandState);
         XCTAssertEqual(source.firedByTriggerID, target.firedByTriggerID);
         XCTAssertEqual(source.created, target.created);
         XCTAssertEqual(source.modified, target.modified);
         XCTAssertEqual(source.title, target.title);
         XCTAssertEqual(source.commandDescription, target.commandDescription);
+        XCTAssertTrue(
+            CommandSerializationTest.isSameDictionary(
+                source.metadata!, target: target.metadata!));
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/CommandSerializationTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/CommandSerializationTest.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+@testable import ThingIFSDK
 
 class CommandSerializationTest: SmallTestBase {
 
@@ -17,4 +18,59 @@ class CommandSerializationTest: SmallTestBase {
         super.tearDown()
     }
 
+    func testSerializeCommand() {
+        let data: NSMutableData = NSMutableData(capacity: 1024)!;
+        let coder: NSKeyedArchiver =
+            NSKeyedArchiver(forWritingWithMutableData: data);
+        let created = NSDate(timeIntervalSince1970: 100);
+        let modified = NSDate(timeIntervalSince1970: 200);
+        let source: Command = Command(
+                commandID: "testCommandID",
+                targetID: TypedID(type: "testTargetType", id: "testTargetID"),
+                issuerID: TypedID(type: "testIssuerType", id: "testIssuerID"),
+                schemaName:"testSchemaName",
+                schemaVersion: 1,
+                actions: [],
+                actionResults: [],
+                commandState: CommandState.SENDING);
+        source.firedByTriggerID = "testFiredByTriggerID";
+        source.created = created;
+        source.modified = modified;
+        source.title = "testTitle";
+        source.commandDescription = "testCommandDescription";
+        source.encodeWithCoder(coder);
+        coder.finishEncoding();
+
+        let decoder: NSKeyedUnarchiver =
+            NSKeyedUnarchiver(forReadingWithData: data);
+        let target: Command = Command(coder: decoder);
+        decoder.finishDecoding();
+
+        XCTAssertEqual(source.commandID, "testCommandID");
+        XCTAssertEqual(source.targetID.type, "testTargetType");
+        XCTAssertEqual(source.targetID.id, "testTargetID");
+        XCTAssertEqual(source.issuerID.type, "testIssuerType");
+        XCTAssertEqual(source.issuerID.id, "testIssuerID");
+        XCTAssertEqual(source.schemaName, "testSchemaName");
+        XCTAssertEqual(source.schemaVersion, 1);
+        XCTAssertEqual(source.firedByTriggerID, "testFiredByTriggerID");
+        XCTAssertEqual(source.created, created);
+        XCTAssertEqual(source.modified, modified);
+        XCTAssertEqual(source.title, "testTitle");
+        XCTAssertEqual(source.commandDescription, "testCommandDescription");
+
+        XCTAssertEqual(source.commandID, target.commandID);
+        XCTAssertEqual(source.targetID.type, target.targetID.type);
+        XCTAssertEqual(source.targetID.id, target.targetID.id);
+        XCTAssertEqual(source.issuerID.type, target.issuerID.type);
+        XCTAssertEqual(source.issuerID.id, target.issuerID.id);
+        XCTAssertEqual(source.schemaName, target.schemaName);
+        XCTAssertEqual(source.schemaVersion, target.schemaVersion);
+        XCTAssertEqual(source.commandState, target.commandState);
+        XCTAssertEqual(source.firedByTriggerID, target.firedByTriggerID);
+        XCTAssertEqual(source.created, target.created);
+        XCTAssertEqual(source.modified, target.modified);
+        XCTAssertEqual(source.title, target.title);
+        XCTAssertEqual(source.commandDescription, target.commandDescription);
+    }
 }


### PR DESCRIPTION
Commadクラスの中の全てのフィールドがserialize/deserializeされるよう修正しました。

Commandの方にはカスタムクラスが存在しないので、クラスの方でNSCodingを実装しなければならないという問題はありませんでした。

唯一 `CommandState` enumがそのままではシリアライズ/デシリアライズが出来ないので修正しました。

``` swift
public enum CommandState
```

を

``` swift
public enum CommandState: Int 
```

この形にすると、各enumの各要素に数値をバインドできるので、その値を保存する形で対応しました。

また `actions` 、 `actionResults` や `metadata` が `Dictionary<String, AnyObject>` なので、値の方にNSCodingをimplementしていないクラスを入れることも可能になっているのですが、これらの値にはJSON Object相当のものが入るはずなので、そのままシリアライズ/デシリアライズしています。

これについてはAPIドキュメント等で制限として記載しておくべきかと思います。
