### PR TITLE
fix verifyDict(expectedDict: actualData:)

### DIFF
--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -25,20 +25,8 @@ extension XCTestCase {
         
         do{
             let actualDict: NSDictionary = try NSJSONSerialization.JSONObjectWithData(actualData, options: NSJSONReadingOptions.AllowFragments) as! NSDictionary
-            for (key, value) in actualDict {
-                if value is String {
-                    XCTAssertEqual(value as? String, expectedDict[key as! String] as? String)
-                }else if value is NSDictionary{
-                    let valueDict = value as! NSDictionary
-                    if let expectedValueDict = expectedDict[key as! String] as? Dictionary<String, String> {
-                        for (key1, value1) in valueDict {
-                            XCTAssertEqual(value1 as? String, expectedValueDict[key1 as! String]! )
-                        }
-                    }else{
-                        XCTFail()
-                    }
-                }
-            }
+            let s = "\nexpected=" + expectedDict.description + "\nactual" + actualDict.description
+            XCTAssertTrue(NSDictionary(dictionary: expectedDict).isEqualToDictionary(actualDict as [NSObject : AnyObject]), s)
         }catch(_){
             XCTFail()
         }


### PR DESCRIPTION
verifyDictが正しくチェックできるように修正しました。

この修正によりPushInstallationTests下で失敗するケースが4件見受けられましたが、こちらはテストケースとAPI実装双方に間違いが存在するようなので別途Issueを立てます。

Issue: #105 
