### PR TITLE
Fix small test

### DIFF
--- a/ThingIFSDK/ThingIFSDKTests/DeleteTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/DeleteTriggerTests.swift
@@ -53,7 +53,7 @@ class DeleteTriggerTests: SmallTestBase {
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -112,7 +112,7 @@ class DeleteTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -140,7 +140,7 @@ class DeleteTriggerTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/EnableTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/EnableTriggerTests.swift
@@ -88,7 +88,7 @@ class EnableTriggerTests: SmallTestBase {
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -148,7 +148,7 @@ class EnableTriggerTests: SmallTestBase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -204,7 +204,7 @@ class EnableTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -232,7 +232,7 @@ class EnableTriggerTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
@@ -54,7 +54,10 @@ class GetCommandTests: SmallTestBase {
 
     func getCommandSuccess(tag: String, testcase: TestCase, setting: TestSetting) {
 
-        let expectation = self.expectationWithDescription(tag)
+        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        defer{
+            expectation = nil
+        }
 
         do{
 

--- a/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
@@ -130,7 +130,7 @@ class GetCommandTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -191,7 +191,7 @@ class GetCommandTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -219,7 +219,7 @@ class GetCommandTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
@@ -63,7 +63,7 @@ class GetStateTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -123,7 +123,7 @@ class GetStateTests: SmallTestBase {
 
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -179,7 +179,7 @@ class GetStateTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -237,7 +237,7 @@ class GetStateTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -317,7 +317,7 @@ class GetStateTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -345,7 +345,7 @@ class GetStateTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
@@ -66,8 +66,12 @@ class GetTriggerTests: SmallTestBase {
     }
 
     func getTriggerSuccess(tag: String, statementToTest: Dictionary<String, AnyObject>, triggersWhen: String, setting:TestSetting) {
-        let expectation = self.expectationWithDescription(tag)
 
+        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        defer{
+            expectation = nil
+        }
+        
         do{
             let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
             let expectedActionsDict: [Dictionary<String, AnyObject>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]

--- a/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
@@ -121,7 +121,7 @@ class GetTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -193,7 +193,7 @@ class GetTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -251,7 +251,7 @@ class GetTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -304,7 +304,7 @@ class GetTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -60,7 +60,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -74,7 +74,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -88,7 +88,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -130,7 +130,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -144,7 +144,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -158,7 +158,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -212,7 +212,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -228,7 +228,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -256,7 +256,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -309,7 +309,7 @@ class ThingIFSDKTests: SmallTestBase {
             XCTAssertNotNil(installID,"Should not nil")
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -322,7 +322,7 @@ class ThingIFSDKTests: SmallTestBase {
             XCTAssertNotNil(installID,"Should not nil")
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -335,7 +335,7 @@ class ThingIFSDKTests: SmallTestBase {
             XCTAssertNotNil(installID,"Should not nil")
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
@@ -89,7 +89,10 @@ class ListCommandsTests: SmallTestBase {
 
     func listCommandsSuccess(tag: String, testcase: TestCase) {
 
-        let expectation = self.expectationWithDescription(tag)
+        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        defer{
+            expectation = nil
+        }
         let setting = TestSetting()
         let api = setting.api
         let owner = setting.owner

--- a/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
@@ -181,7 +181,7 @@ class ListCommandsTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -243,7 +243,7 @@ class ListCommandsTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -272,7 +272,7 @@ class ListCommandsTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ListTriggeredServerCodeResultsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListTriggeredServerCodeResultsTests.swift
@@ -78,7 +78,7 @@ class ListTriggeredServerCodeResultsTests: SmallTestBase {
             print(e)
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for testListTriggeredServerCodeResultsTests_success")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ListTriggersTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListTriggersTests.swift
@@ -123,7 +123,7 @@ class ListTriggersTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -179,7 +179,7 @@ class ListTriggersTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -207,7 +207,7 @@ class ListTriggersTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
@@ -83,7 +83,7 @@ class OnboardingTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -142,7 +142,7 @@ class OnboardingTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -171,7 +171,7 @@ class OnboardingTests: SmallTestBase {
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -230,7 +230,7 @@ class OnboardingTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
@@ -97,7 +97,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -176,7 +176,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -207,7 +207,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -237,7 +237,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -93,7 +93,10 @@ class PatchTriggerTests: SmallTestBase {
     }
 
     func patchTrigger(tag: String, testcase: TestCase) {
-        let expectation = self.expectationWithDescription(tag)
+        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        defer{
+            expectation = nil
+        }
         let setting = TestSetting()
         let api = setting.api
 

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -191,7 +191,7 @@ class PatchTriggerTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -222,7 +222,7 @@ class PatchTriggerTests: SmallTestBase {
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -250,7 +250,7 @@ class PatchTriggerTests: SmallTestBase {
             expectation.fulfill()
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -49,9 +49,11 @@ class PostNewCommandTests: SmallTestBase {
 
     func postCommandSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
 
-        let expectation = self.expectationWithDescription(tag)
-
-
+        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        defer{
+            expectation = nil
+        }
+        
         do {
             let expectedCommandID = "c6f1b8d0-46ea-11e5-a5eb-06d9d1527620"
 

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -104,7 +104,7 @@ class PostNewCommandTests: SmallTestBase {
             XCTFail("should not throw error")
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -176,7 +176,7 @@ class PostNewCommandTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -203,7 +203,7 @@ class PostNewCommandTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
@@ -198,7 +198,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
             XCTFail("should not throw error")
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -274,7 +274,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -301,7 +301,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
@@ -136,7 +136,10 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
             testcase: TestCase,
             setting:TestSetting) {
 
-        let expectation = self.expectationWithDescription(tag)
+        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        defer{
+            expectation = nil
+        }
 
         do {
             let expectedCommandID = "c6f1b8d0-46ea-11e5-a5eb-06d9d1527620"

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
@@ -81,7 +81,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -159,7 +159,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -189,7 +189,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -218,7 +218,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
@@ -128,7 +128,7 @@ class PostNewTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -207,7 +207,7 @@ class PostNewTriggerTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -238,7 +238,7 @@ class PostNewTriggerTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -269,7 +269,7 @@ class PostNewTriggerTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
@@ -27,7 +27,10 @@ class PostNewTriggerTests: SmallTestBase {
     }
 
     func testPostNewTrigger_success() {
-        var expectation : XCTestExpectation!
+        weak var expectation : XCTestExpectation!
+        defer {
+            expectation = nil
+        }
         func postNewTriggerSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
             expectation = self.expectationWithDescription(tag)
 

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
@@ -27,6 +27,73 @@ class PostNewTriggerTests: SmallTestBase {
     }
 
     func testPostNewTrigger_success() {
+        var expectation : XCTestExpectation!
+        func postNewTriggerSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
+            expectation = self.expectationWithDescription(tag)
+
+            do{
+                let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
+                let actions: [Dictionary<String, AnyObject>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
+                let condition = Condition(clause: testcase.clause)
+                let predicate = StatePredicate(condition: condition, triggersWhen: testcase.triggersWhen)
+
+                let expectedActions = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
+                let expectedClause = testcase.expectedClauseDict
+                let expectedEventSource = "STATES"
+                let expectedTriggerWhen = testcase.expectedTriggersWhenString
+                let expectedPredicateDict = ["eventSource":expectedEventSource, "triggersWhen":expectedTriggerWhen, "condition":expectedClause]
+
+                // mock response
+                let dict = ["triggerID": expectedTriggerID]
+                let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
+                let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!, statusCode: 201, HTTPVersion: nil, headerFields: nil)
+
+                // verify request
+                let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
+                    XCTAssertEqual(request.HTTPMethod, "POST")
+                    //verify header
+                    let expectedHeader = ["authorization": "Bearer \(setting.owner.accessToken)", "Content-type":"application/json"]
+                    for (key, value) in expectedHeader {
+                        XCTAssertEqual(value, request.valueForHTTPHeaderField(key), tag)
+                    }
+                    //verify body
+
+                    let expectedBody = ["predicate": expectedPredicateDict, "command":["issuer":setting.owner.typedID.toString(), "target": setting.target.typedID.toString(), "schema": setting.schema, "schemaVersion": setting.schemaVersion,"actions":expectedActions, "triggersWhat":"COMMAND"]]
+                    do {
+                        let expectedBodyData = try NSJSONSerialization.dataWithJSONObject(expectedBody, options: NSJSONWritingOptions(rawValue: 0))
+                        let actualBodyData = request.HTTPBody
+                        XCTAssertTrue(expectedBodyData.length == actualBodyData!.length, tag)
+                    }catch(_){
+                        XCTFail(tag)
+                    }
+
+                    XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/triggers")
+                }
+                MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+                MockSession.requestVerifier = requestVerifier
+                iotSession = MockSession.self
+
+                setting.api.postNewTrigger(setting.schema, schemaVersion: setting.schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
+                    if error == nil{
+                        XCTAssertEqual(trigger!.triggerID, expectedTriggerID, tag)
+                        XCTAssertEqual(trigger!.enabled, true, tag)
+                        XCTAssertNotNil(trigger!.predicate, tag)
+                        XCTAssertEqual(trigger!.command!.commandID, "", tag)
+                    }else {
+                        XCTFail("should success for \(tag)")
+                    }
+                    expectation.fulfill()
+                })
+            }catch(let e){
+                print(e)
+            }
+            self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+                if error != nil {
+                    XCTFail("execution timeout for \(tag)")
+                }
+            }
+        }
+
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -69,71 +136,6 @@ class PostNewTriggerTests: SmallTestBase {
 
     }
 
-    func postNewTriggerSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
-        let expectation = self.expectationWithDescription(tag)
-
-        do{
-            let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-            let actions: [Dictionary<String, AnyObject>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
-            let condition = Condition(clause: testcase.clause)
-            let predicate = StatePredicate(condition: condition, triggersWhen: testcase.triggersWhen)
-
-            let expectedActions = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
-            let expectedClause = testcase.expectedClauseDict
-            let expectedEventSource = "STATES"
-            let expectedTriggerWhen = testcase.expectedTriggersWhenString
-            let expectedPredicateDict = ["eventSource":expectedEventSource, "triggersWhen":expectedTriggerWhen, "condition":expectedClause]
-
-            // mock response
-            let dict = ["triggerID": expectedTriggerID]
-            let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
-            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!, statusCode: 201, HTTPVersion: nil, headerFields: nil)
-
-            // verify request
-            let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
-                XCTAssertEqual(request.HTTPMethod, "POST")
-                //verify header
-                let expectedHeader = ["authorization": "Bearer \(setting.owner.accessToken)", "Content-type":"application/json"]
-                for (key, value) in expectedHeader {
-                    XCTAssertEqual(value, request.valueForHTTPHeaderField(key), tag)
-                }
-                //verify body
-
-                let expectedBody = ["predicate": expectedPredicateDict, "command":["issuer":setting.owner.typedID.toString(), "target": setting.target.typedID.toString(), "schema": setting.schema, "schemaVersion": setting.schemaVersion,"actions":expectedActions, "triggersWhat":"COMMAND"]]
-                do {
-                    let expectedBodyData = try NSJSONSerialization.dataWithJSONObject(expectedBody, options: NSJSONWritingOptions(rawValue: 0))
-                    let actualBodyData = request.HTTPBody
-                    XCTAssertTrue(expectedBodyData.length == actualBodyData!.length, tag)
-                }catch(_){
-                    XCTFail(tag)
-                }
-                
-                XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/triggers")
-            }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
-            iotSession = MockSession.self
-
-            setting.api.postNewTrigger(setting.schema, schemaVersion: setting.schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
-                if error == nil{
-                    XCTAssertEqual(trigger!.triggerID, expectedTriggerID, tag)
-                    XCTAssertEqual(trigger!.enabled, true, tag)
-                    XCTAssertNotNil(trigger!.predicate, tag)
-                    XCTAssertEqual(trigger!.command!.commandID, "", tag)
-                }else {
-                    XCTFail("should success for \(tag)")
-                }
-                expectation.fulfill()
-            })
-        }catch(let e){
-            print(e)
-        }
-        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
-            if error != nil {
-                XCTFail("execution timeout for \(tag)")
-            }
-        }
-    }
 
     func testPostNewTrigger_http_404() {
         let expectation = self.expectationWithDescription("postNewTrigger404Error")

--- a/ThingIFSDK/ThingIFSDKTests/PushInstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushInstallationTests.swift
@@ -75,7 +75,7 @@ class PushInstallationTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -123,7 +123,7 @@ class PushInstallationTests: SmallTestBase {
             XCTAssertNotNil(installID,"Should not nil")
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -183,7 +183,7 @@ class PushInstallationTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -244,7 +244,7 @@ class PushInstallationTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -305,7 +305,7 @@ class PushInstallationTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
@@ -73,7 +73,7 @@ class PushUninstallationTests: SmallTestBase {
         }catch(let e){
             print(e)
         }
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -109,7 +109,7 @@ class PushUninstallationTests: SmallTestBase {
             XCTAssertNil(setting.api._installationID,"Should be nil")
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -167,7 +167,7 @@ class PushUninstallationTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -225,7 +225,7 @@ class PushUninstallationTests: SmallTestBase {
             }
             expectation.fulfill()
         }
-        self.waitForExpectationsWithTimeout(30.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/TestHelpers.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TestHelpers.swift
@@ -9,6 +9,8 @@
 import Foundation
 import XCTest
 
+public let TEST_TIMEOUT = 5.0
+
 func failIfNotRunningOnDevice(){
     let environment = NSProcessInfo.processInfo().environment
     


### PR DESCRIPTION
## Problem
- On circleci, the test often failed because of timeout which is should never happen on a small test
- On local environment, sometimes it failed same as above if we run it several times.
## Root cause
- XCTestExpectations has some gotchas according [this link](https://jeremywsherman.com/blog/2016/03/19/xctestexpectation-gotchas/)
## solutions and improvement
- change some expectations declarations that called inside the loop from let to weak var
- improve timeout by make it in a constant (public let)
