### PR TITLE
Expectations optimize

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
+++ b/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
@@ -11,12 +11,12 @@ public class SDKVersion: NSObject {
     public static let sharedInstance = SDKVersion()
     /** Version of the Thing-IF SDK */
     public var versionString:String?
-    internal var kiiSDKHeader:String?
+    internal let kiiSDKHeader:String = "sn=it;sv=1.1.1;pv=\(UIDevice.currentDevice().systemVersion)"
     private override init() {
-        let b:NSBundle? = NSBundle.allFrameworks().filter{$0.bundleIdentifier == "Kii-Corporation.ThingIFSDK"}.first
-        versionString = b?.infoDictionary?["CFBundleShortVersionString"] as! String?
-        if let v = versionString {
-            kiiSDKHeader = "sn=it;sv=\(v);pv=\(UIDevice.currentDevice().systemVersion)"
-        }
+//        let b:NSBundle? = NSBundle.allFrameworks().filter{$0.bundleIdentifier == "Kii-Corporation.ThingIFSDK"}.first
+//        versionString = b?.infoDictionary?["CFBundleShortVersionString"] as! String?
+//        if let v = versionString {
+//            kiiSDKHeader = "sn=it;sv=\(v);pv=\(UIDevice.currentDevice().systemVersion)"
+//        }
     }
 }

--- a/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
+++ b/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
@@ -10,13 +10,17 @@ import UIKit
 public class SDKVersion: NSObject {
     public static let sharedInstance = SDKVersion()
     /** Version of the Thing-IF SDK */
-    public var versionString:String?
-    internal let kiiSDKHeader:String = "sn=it;sv=1.1.1;pv=\(UIDevice.currentDevice().systemVersion)"
+    private var _header : String?
+    private var _versionString : String?
+    private func getVersionString() -> String{
+        if _versionString == nil {
+            let b:NSBundle? = NSBundle.allFrameworks().filter{$0.bundleIdentifier == "Kii-Corporation.ThingIFSDK"}.first
+            _versionString = b?.infoDictionary?["CFBundleShortVersionString"] as! String?
+        }
+        return _versionString!
+    }
+     public var versionString:String { return getVersionString() }
+    internal var kiiSDKHeader:String { return "sn=it;sv=\(getVersionString());pv=\(UIDevice.currentDevice().systemVersion)" }
     private override init() {
-//        let b:NSBundle? = NSBundle.allFrameworks().filter{$0.bundleIdentifier == "Kii-Corporation.ThingIFSDK"}.first
-//        versionString = b?.infoDictionary?["CFBundleShortVersionString"] as! String?
-//        if let v = versionString {
-//            kiiSDKHeader = "sn=it;sv=\(v);pv=\(UIDevice.currentDevice().systemVersion)"
-//        }
     }
 }

--- a/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
+++ b/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
@@ -12,15 +12,20 @@ public class SDKVersion: NSObject {
     /** Version of the Thing-IF SDK */
     private var _header : String?
     private var _versionString : String?
-    private func getVersionString() -> String{
-        if _versionString == nil {
-            let b:NSBundle? = NSBundle.allFrameworks().filter{$0.bundleIdentifier == "Kii-Corporation.ThingIFSDK"}.first
-            _versionString = b?.infoDictionary?["CFBundleShortVersionString"] as! String?
+
+    public var versionString:String { if _versionString == nil {
+        let b:NSBundle? = NSBundle.allFrameworks().filter{$0.bundleIdentifier == "Kii-Corporation.ThingIFSDK"}.first
+        _versionString = b?.infoDictionary?["CFBundleShortVersionString"] as! String?
         }
         return _versionString!
     }
-     public var versionString:String { return getVersionString() }
-    internal var kiiSDKHeader:String { return "sn=it;sv=\(getVersionString());pv=\(UIDevice.currentDevice().systemVersion)" }
+    internal var kiiSDKHeader:String {
+        if _header == nil {
+            _header = "sn=it;sv=\(versionString);pv=\(UIDevice.currentDevice().systemVersion)"
+        }
+
+        return _header!
+    }
     private override init() {
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/DeleteTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/DeleteTriggerTests.swift
@@ -21,7 +21,7 @@ class DeleteTriggerTests: SmallTestBase {
     func testDeleteTrigger_success() {
         let setting:TestSetting = TestSetting()
         let api = setting.api
-        let expectation = self.expectationWithDescription("enableTriggerTests")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("enableTriggerTests")
 
         // perform onboarding
         api._target = setting.target
@@ -53,6 +53,7 @@ class DeleteTriggerTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -64,7 +65,7 @@ class DeleteTriggerTests: SmallTestBase {
         let api = setting.api
         let owner = setting.owner
         let target = setting.target
-        let expectation = self.expectationWithDescription("enableTrigger404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("enableTrigger404Error")
 
         // perform onboarding
         api._target = setting.target
@@ -112,6 +113,7 @@ class DeleteTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -121,7 +123,7 @@ class DeleteTriggerTests: SmallTestBase {
     func testDeleteTrigger_trigger_not_available_error() {
         let setting:TestSetting = TestSetting()
         let api = setting.api
-        let expectation = self.expectationWithDescription("testDeleteTrigger_trigger_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testDeleteTrigger_trigger_not_available_error")
 
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
 
@@ -140,6 +142,7 @@ class DeleteTriggerTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/EnableTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/EnableTriggerTests.swift
@@ -23,7 +23,7 @@ class EnableTriggerTests: SmallTestBase {
     func testEnableTrigger_success() {
         let setting:TestSetting = TestSetting()
         let api:ThingIFAPI = setting.api
-        let expectation = self.expectationWithDescription("enableTriggerTests")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("enableTriggerTests")
 
         // perform onboarding
         api._target = setting.target
@@ -89,6 +89,7 @@ class EnableTriggerTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -98,7 +99,7 @@ class EnableTriggerTests: SmallTestBase {
     func testDisableTrigger_success() {
         let setting:TestSetting = TestSetting()
         let api:ThingIFAPI = setting.api
-        let expectation = self.expectationWithDescription("enableTriggerTests")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("enableTriggerTests")
         
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
         
@@ -149,6 +150,7 @@ class EnableTriggerTests: SmallTestBase {
         }
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -156,7 +158,7 @@ class EnableTriggerTests: SmallTestBase {
     }
 
     func testEnableTrigger_404_error() {
-        let expectation = self.expectationWithDescription("enableTrigger404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("enableTrigger404Error")
         let setting = TestSetting()
         let api = setting.api
         // perform onboarding
@@ -205,6 +207,7 @@ class EnableTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -213,7 +216,7 @@ class EnableTriggerTests: SmallTestBase {
     }
 
     func testEnableTrigger_trigger_not_available_error() {
-        let expectation = self.expectationWithDescription("testEnableTrigger_trigger_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testEnableTrigger_trigger_not_available_error")
         let setting = TestSetting()
         let api = setting.api
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
@@ -233,6 +236,7 @@ class EnableTriggerTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
@@ -22,7 +22,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
 
     func testSuccess()
     {
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
         let setting = TestSetting()
         let username = "dummyUser"
         let password = "dummyPass"
@@ -72,6 +72,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -80,7 +81,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
 
     func testEmptyUsernameError()
     {
-        let expectation = self.expectationWithDescription("testEmptyUsernameError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testEmptyUsernameError")
         let setting = TestSetting()
         let password = "dummyPass"
 
@@ -97,6 +98,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -105,7 +107,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
 
     func testEmptyPasswordError()
     {
-        let expectation = self.expectationWithDescription("testEmptyPasswordError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testEmptyPasswordError")
         let setting = TestSetting()
         let username = "dummyUser"
 
@@ -122,6 +124,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -130,7 +133,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
 
     func test400Error()
     {
-        let expectation = self.expectationWithDescription("test400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test400Error")
         let setting = TestSetting()
         let username = "dummyUser"
         let password = "dummyPass"
@@ -180,6 +183,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -188,7 +192,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
 
     func test401Error()
     {
-        let expectation = self.expectationWithDescription("test401Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test401Error")
         let setting = TestSetting()
         let username = "dummyUser"
         let password = "dummyPass"
@@ -238,6 +242,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
@@ -71,7 +71,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -96,7 +96,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -121,7 +121,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -179,7 +179,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -237,7 +237,7 @@ class GatewayAPILoginTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPINSCodingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPINSCodingTests.swift
@@ -22,7 +22,7 @@ class GatewayAPINSCodingTests: GatewayAPITestBase {
 
     func testSuccess()
     {
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
         let setting = TestSetting()
 
         do {
@@ -44,6 +44,7 @@ class GatewayAPINSCodingTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPINSCodingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPINSCodingTests.swift
@@ -43,7 +43,7 @@ class GatewayAPINSCodingTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
@@ -54,7 +54,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -78,7 +78,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -125,7 +125,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -172,7 +172,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -219,7 +219,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
@@ -23,7 +23,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
     func testSuccess()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -55,6 +55,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -65,7 +66,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
     {
         let setting = TestSetting()
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
-        let expectation = self.expectationWithDescription("testNoLoggedInError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testNoLoggedInError")
 
         api.restore({ (error:ThingIFError?) -> Void in
             XCTAssertNotNil(error)
@@ -79,6 +80,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -88,7 +90,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
     func test400Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test400Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -126,6 +128,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -135,7 +138,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
     func test401Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test401Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test401Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -173,6 +176,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -182,7 +186,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
     func test409Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test409Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test409Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -220,6 +224,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
@@ -44,7 +44,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
         })
         XCTAssertNil(api.tag)
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -89,7 +89,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
         })
         XCTAssertEqual(tag, api.tag)
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
@@ -22,7 +22,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
 
     func testLoadFromStoredInstance()
     {
-        let expectation = self.expectationWithDescription("testLoadFromStoredInstanceWithTag")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testLoadFromStoredInstanceWithTag")
         let setting = TestSetting()
 
         do {
@@ -45,6 +45,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
         XCTAssertNil(api.tag)
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -66,7 +67,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
 
     func testLoadFromStoredInstanceWithTag()
     {
-        let expectation = self.expectationWithDescription("testLoadFromStoredInstanceWithTag")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testLoadFromStoredInstanceWithTag")
         let setting = TestSetting()
         let tag = "dummyTag"
 
@@ -90,6 +91,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
         XCTAssertEqual(tag, api.tag)
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
@@ -12,7 +12,7 @@ class GatewayAPITestBase: SmallTestBase {
     let ACCESSTOKEN: String = "token-0000-1111-aaaa-bbbb"
 
     func getLoggedInGatewayAPI() -> GatewayAPI {
-        let expectation = self.expectationWithDescription("getLoggedInGatewayAPI")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("getLoggedInGatewayAPI")
         let setting = TestSetting()
 
         do {
@@ -34,6 +34,7 @@ class GatewayAPITestBase: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
@@ -12,7 +12,6 @@ class GatewayAPITestBase: SmallTestBase {
     let ACCESSTOKEN: String = "token-0000-1111-aaaa-bbbb"
 
     func getLoggedInGatewayAPI() -> GatewayAPI {
-        self.continueAfterFailure = false
         let expectation = self.expectationWithDescription("getLoggedInGatewayAPI")
         let setting = TestSetting()
 

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
@@ -12,6 +12,7 @@ class GatewayAPITestBase: SmallTestBase {
     let ACCESSTOKEN: String = "token-0000-1111-aaaa-bbbb"
 
     func getLoggedInGatewayAPI() -> GatewayAPI {
+        self.continueAfterFailure = false
         let expectation = self.expectationWithDescription("getLoggedInGatewayAPI")
         let setting = TestSetting()
 
@@ -33,7 +34,7 @@ class GatewayAPITestBase: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
@@ -54,10 +54,7 @@ class GetCommandTests: SmallTestBase {
 
     func getCommandSuccess(tag: String, testcase: TestCase, setting: TestSetting) {
 
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
 
         do{
 

--- a/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
@@ -54,7 +54,7 @@ class GetCommandTests: SmallTestBase {
 
     func getCommandSuccess(tag: String, testcase: TestCase, setting: TestSetting) {
 
-        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
 
         do{
 
@@ -131,6 +131,7 @@ class GetCommandTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -138,7 +139,7 @@ class GetCommandTests: SmallTestBase {
     }
 
     func testGetCommand_404_error() {
-        let expectation = self.expectationWithDescription("getCommand404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("getCommand404Error")
         let setting = TestSetting()
         let api = setting.api
         do{
@@ -192,6 +193,7 @@ class GetCommandTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -199,7 +201,7 @@ class GetCommandTests: SmallTestBase {
     }
 
     func testGetCommand_trigger_not_available_error() {
-        let expectation = self.expectationWithDescription("testGetCommand_trigger_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetCommand_trigger_not_available_error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -220,6 +222,7 @@ class GetCommandTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
@@ -62,7 +62,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
             XCTFail("should not throw error")
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -87,7 +87,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -135,7 +135,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -183,7 +183,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -231,7 +231,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -279,7 +279,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -327,7 +327,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
@@ -24,7 +24,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
         let gatewayID = "dummyGatewayID"
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
 
         do {
             // verify request
@@ -63,6 +63,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -73,7 +74,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
     {
         let setting = TestSetting()
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
-        let expectation = self.expectationWithDescription("testNoLoggedInError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testNoLoggedInError")
 
         api.getGatewayID( { (id:String?, error:ThingIFError?) -> Void in
             XCTAssertNil(id)
@@ -88,6 +89,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -97,7 +99,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
     func test400Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test400Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -136,6 +138,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -145,7 +148,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
     func test401Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test401Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test401Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -184,6 +187,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -193,7 +197,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
     func test404Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test404Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -232,6 +236,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -241,7 +246,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
     func test409Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test409Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test409Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -280,6 +285,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -289,7 +295,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
     func test503Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test503Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test503Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -328,6 +334,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
@@ -62,7 +62,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
             XCTFail("should not throw error")
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -87,7 +87,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -135,7 +135,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
@@ -24,7 +24,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
         let vendorThingID = "dummyID"
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
 
         do {
             // verify request
@@ -63,6 +63,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -73,7 +74,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
     {
         let setting = TestSetting()
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
-        let expectation = self.expectationWithDescription("testNoLoggedInError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testNoLoggedInError")
 
         api.getGatewayInformation( { (info:GatewayInformation?, error:ThingIFError?) -> Void in
             XCTAssertNil(info)
@@ -88,6 +89,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -97,7 +99,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
     func test401Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test401Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test401Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -136,6 +138,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
@@ -23,7 +23,7 @@ class GetStateTests: SmallTestBase {
     }
 
     func onboard(setting:TestSetting){
-        let expectation = self.expectationWithDescription("onboardWithVendorThingID")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("onboardWithVendorThingID")
 
         do{
             let thingProperties:Dictionary<String, AnyObject> = ["key1":"value1", "key2":"value2"]
@@ -64,6 +64,7 @@ class GetStateTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -74,7 +75,7 @@ class GetStateTests: SmallTestBase {
         let setting = TestSetting()
 
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testGetStates_success")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetStates_success")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -124,6 +125,7 @@ class GetStateTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -132,7 +134,7 @@ class GetStateTests: SmallTestBase {
     func testGetStates_http_404() {
         let setting = TestSetting()
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testGetStates_http_404")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetStates_http_404")
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
@@ -180,6 +182,7 @@ class GetStateTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -189,7 +192,7 @@ class GetStateTests: SmallTestBase {
     func testGetStates_http_401() {
         let setting = TestSetting()
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testGetStates_http_401")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetStates_http_401")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -238,6 +241,7 @@ class GetStateTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -249,7 +253,7 @@ class GetStateTests: SmallTestBase {
         let setting = TestSetting()
         self.onboard(setting)
         iotSession = MockMultipleSession.self
-        let expectation = self.expectationWithDescription("testGetStates_success")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetStates_success")
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
@@ -318,6 +322,7 @@ class GetStateTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -326,7 +331,7 @@ class GetStateTests: SmallTestBase {
 
     func testGetStates_target_not_available_error() {
         let setting = TestSetting()
-        let expectation = self.expectationWithDescription("testGetStates_target_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetStates_target_not_available_error")
 
         setting.api.getState() { (result, error) -> Void in
 
@@ -346,6 +351,7 @@ class GetStateTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
@@ -67,11 +67,8 @@ class GetTriggerTests: SmallTestBase {
 
     func getTriggerSuccess(tag: String, statementToTest: Dictionary<String, AnyObject>, triggersWhen: String, setting:TestSetting) {
 
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
-        
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+
         do{
             let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
             let expectedActionsDict: [Dictionary<String, AnyObject>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]

--- a/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
@@ -67,7 +67,7 @@ class GetTriggerTests: SmallTestBase {
 
     func getTriggerSuccess(tag: String, statementToTest: Dictionary<String, AnyObject>, triggersWhen: String, setting:TestSetting) {
 
-        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
 
         do{
             let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
@@ -123,6 +123,7 @@ class GetTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -133,7 +134,7 @@ class GetTriggerTests: SmallTestBase {
         let setting = TestSetting()
         let api = setting.api
         // perform onboarding
-        let expectation = self.expectationWithDescription("testGetServerCodeTrigger_success")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetServerCodeTrigger_success")
         
         do{
             let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
@@ -195,6 +196,7 @@ class GetTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -203,7 +205,7 @@ class GetTriggerTests: SmallTestBase {
 
     
     func testGetTrigger_404_error() {
-        let expectation = self.expectationWithDescription("getTrigger403Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("getTrigger403Error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -253,6 +255,7 @@ class GetTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -260,7 +263,7 @@ class GetTriggerTests: SmallTestBase {
     }
 
     func testGetTrigger_Target_not_available_error() {
-        let expectation = self.expectationWithDescription("testGetTrigger_Target_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetTrigger_Target_not_available_error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -306,6 +309,7 @@ class GetTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
@@ -70,7 +70,7 @@ class GetVendorThingIDTests: SmallTestBase {
             XCTFail("should not throw error")
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -126,7 +126,7 @@ class GetVendorThingIDTests: SmallTestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
@@ -22,7 +22,7 @@ class GetVendorThingIDTests: SmallTestBase {
 
     func testGetVendorThingIDSuccess()
     {
-        let expectation = self.expectationWithDescription("testGetVendorThingIDSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetVendorThingIDSuccess")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -71,6 +71,7 @@ class GetVendorThingIDTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -79,7 +80,7 @@ class GetVendorThingIDTests: SmallTestBase {
 
     func testGetVendorThingID404Error()
     {
-        let expectation = self.expectationWithDescription("testGetVendorThingID404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testGetVendorThingID404Error")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -127,6 +128,7 @@ class GetVendorThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -52,7 +52,7 @@ class ThingIFSDKTests: SmallTestBase {
         let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
         let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
         
-        let expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
         api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
@@ -61,34 +61,37 @@ class ThingIFSDKTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
         }
         
-        let expectation1 = self.expectationWithDescription("testSavedInstanceWithOnboard1")
+        expectation = self.expectationWithDescription("testSavedInstanceWithOnboard1")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
         api2.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation1.fulfill()
+            expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
         }
         
-        let expectation2 = self.expectationWithDescription("testSavedInstanceWithOnboard2")
+        expectation = self.expectationWithDescription("testSavedInstanceWithOnboard2")
         setMockResponse4Onboard("access-token-00000003", thingID: "th.00000003", setting: setting)
         api3.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation2.fulfill()
+            expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -122,7 +125,7 @@ class ThingIFSDKTests: SmallTestBase {
         let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
         let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
         
-        let expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
         api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
@@ -131,34 +134,37 @@ class ThingIFSDKTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
         }
 
-        let expectation1 = self.expectationWithDescription("testSavedInstanceWithOnboard1")
+        expectation = self.expectationWithDescription("testSavedInstanceWithOnboard1")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
         api2.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation1.fulfill()
+            expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
         }
 
-        let expectation2 = self.expectationWithDescription("testSavedInstanceWithOnboard2")
+        expectation = self.expectationWithDescription("testSavedInstanceWithOnboard2")
         setMockResponse4Onboard("access-token-00000003", thingID: "th.00000003", setting: setting)
         api3.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation2.fulfill()
+            expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -204,7 +210,7 @@ class ThingIFSDKTests: SmallTestBase {
         
         let api1 = ThingIFAPIBuilder(app:app1, owner:owner1, tag: tag).build()
         
-        let expectation = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
         api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
@@ -213,6 +219,7 @@ class ThingIFSDKTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -220,15 +227,16 @@ class ThingIFSDKTests: SmallTestBase {
         
         let api2 = ThingIFAPIBuilder(app:app2, owner:owner2, tag: tag).build()
 
-        let expectation2 = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard2")
+        expectation = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard2")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
         api2.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation2.fulfill()
+            expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -248,7 +256,7 @@ class ThingIFSDKTests: SmallTestBase {
         
         let api1 = ThingIFAPIBuilder(app:setting.app, owner:setting.owner!, tag: "tag1").build()
         
-        let expectation = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
         api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
@@ -257,6 +265,7 @@ class ThingIFSDKTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -302,7 +311,7 @@ class ThingIFSDKTests: SmallTestBase {
         let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
         let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
         
-        let expectation = self.expectationWithDescription("testSavedInstanceWithInstallPush")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSavedInstanceWithInstallPush")
         setMockResponse4InstallPush("installationID-0001", setting: setting);
         api1.installPush("deviceToken-0001".dataUsingEncoding(NSUTF8StringEncoding)!, development: false) { (installID, error) -> Void in
             XCTAssertNil(error,"should not error")
@@ -310,32 +319,35 @@ class ThingIFSDKTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
         }
         
-        let expectation1 = self.expectationWithDescription("testSavedInstanceWithInstallPush1")
+        expectation = self.expectationWithDescription("testSavedInstanceWithInstallPush1")
         setMockResponse4InstallPush("installationID-0002", setting: setting);
         api2.installPush("deviceToken-0002".dataUsingEncoding(NSUTF8StringEncoding)!, development: false) { (installID, error) -> Void in
             XCTAssertNil(error,"should not error")
             XCTAssertNotNil(installID,"Should not nil")
-            expectation1.fulfill()
+            expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
         }
 
-        let expectation2 = self.expectationWithDescription("testSavedInstanceWithInstallPush2")
+        expectation = self.expectationWithDescription("testSavedInstanceWithInstallPush2")
         setMockResponse4InstallPush("installationID-0003", setting: setting);
         api3.installPush("deviceToken-0003".dataUsingEncoding(NSUTF8StringEncoding)!, development: false) { (installID, error) -> Void in
             XCTAssertNil(error,"should not error")
             XCTAssertNotNil(installID,"Should not nil")
-            expectation2.fulfill()
+            expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -52,7 +52,7 @@ class ThingIFSDKTests: SmallTestBase {
         let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
         let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
         
-        var expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
+        let expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
         api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
@@ -66,13 +66,13 @@ class ThingIFSDKTests: SmallTestBase {
             }
         }
         
-        expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
+        let expectation1 = self.expectationWithDescription("testSavedInstanceWithOnboard1")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
         api2.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation.fulfill()
+            expectation1.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
@@ -80,13 +80,13 @@ class ThingIFSDKTests: SmallTestBase {
             }
         }
         
-        expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
+        let expectation2 = self.expectationWithDescription("testSavedInstanceWithOnboard2")
         setMockResponse4Onboard("access-token-00000003", thingID: "th.00000003", setting: setting)
         api3.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation.fulfill()
+            expectation2.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
@@ -122,7 +122,7 @@ class ThingIFSDKTests: SmallTestBase {
         let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
         let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
         
-        var expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
+        let expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
         api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
@@ -136,13 +136,13 @@ class ThingIFSDKTests: SmallTestBase {
             }
         }
 
-        expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
+        let expectation1 = self.expectationWithDescription("testSavedInstanceWithOnboard1")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
         api2.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation.fulfill()
+            expectation1.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
@@ -150,13 +150,13 @@ class ThingIFSDKTests: SmallTestBase {
             }
         }
 
-        expectation = self.expectationWithDescription("testSavedInstanceWithOnboard")
+        let expectation2 = self.expectationWithDescription("testSavedInstanceWithOnboard2")
         setMockResponse4Onboard("access-token-00000003", thingID: "th.00000003", setting: setting)
         api3.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation.fulfill()
+            expectation2.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
@@ -204,7 +204,7 @@ class ThingIFSDKTests: SmallTestBase {
         
         let api1 = ThingIFAPIBuilder(app:app1, owner:owner1, tag: tag).build()
         
-        var expectation = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard")
+        let expectation = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
         api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
@@ -220,13 +220,13 @@ class ThingIFSDKTests: SmallTestBase {
         
         let api2 = ThingIFAPIBuilder(app:app2, owner:owner2, tag: tag).build()
 
-        expectation = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard")
+        let expectation2 = self.expectationWithDescription("testOverwriteSavedInstanceWithOnboard2")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
         api2.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
-            expectation.fulfill()
+            expectation2.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
@@ -302,7 +302,7 @@ class ThingIFSDKTests: SmallTestBase {
         let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
         let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
         
-        var expectation = self.expectationWithDescription("testSavedInstanceWithInstallPush")
+        let expectation = self.expectationWithDescription("testSavedInstanceWithInstallPush")
         setMockResponse4InstallPush("installationID-0001", setting: setting);
         api1.installPush("deviceToken-0001".dataUsingEncoding(NSUTF8StringEncoding)!, development: false) { (installID, error) -> Void in
             XCTAssertNil(error,"should not error")
@@ -315,12 +315,12 @@ class ThingIFSDKTests: SmallTestBase {
             }
         }
         
-        expectation = self.expectationWithDescription("testSavedInstanceWithInstallPush")
+        let expectation1 = self.expectationWithDescription("testSavedInstanceWithInstallPush1")
         setMockResponse4InstallPush("installationID-0002", setting: setting);
         api2.installPush("deviceToken-0002".dataUsingEncoding(NSUTF8StringEncoding)!, development: false) { (installID, error) -> Void in
             XCTAssertNil(error,"should not error")
             XCTAssertNotNil(installID,"Should not nil")
-            expectation.fulfill()
+            expectation1.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
@@ -328,12 +328,12 @@ class ThingIFSDKTests: SmallTestBase {
             }
         }
 
-        expectation = self.expectationWithDescription("testSavedInstanceWithInstallPush")
+        let expectation2 = self.expectationWithDescription("testSavedInstanceWithInstallPush2")
         setMockResponse4InstallPush("installationID-0003", setting: setting);
         api3.installPush("deviceToken-0003".dataUsingEncoding(NSUTF8StringEncoding)!, development: false) { (installID, error) -> Void in
             XCTAssertNil(error,"should not error")
             XCTAssertNotNil(installID,"Should not nil")
-            expectation.fulfill()
+            expectation2.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {

--- a/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
@@ -89,10 +89,8 @@ class ListCommandsTests: SmallTestBase {
 
     func listCommandsSuccess(tag: String, testcase: TestCase) {
 
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        
         let setting = TestSetting()
         let api = setting.api
         let owner = setting.owner

--- a/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
@@ -89,7 +89,7 @@ class ListCommandsTests: SmallTestBase {
 
     func listCommandsSuccess(tag: String, testcase: TestCase) {
 
-        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
         
         let setting = TestSetting()
         let api = setting.api
@@ -183,6 +183,7 @@ class ListCommandsTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -190,7 +191,7 @@ class ListCommandsTests: SmallTestBase {
     }
 
     func testListCommand_404_error() {
-        let expectation = self.expectationWithDescription("getCommand404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("getCommand404Error")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -245,6 +246,7 @@ class ListCommandsTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -253,7 +255,7 @@ class ListCommandsTests: SmallTestBase {
     }
     
     func testListCommand_target_not_available_error() {
-        let expectation = self.expectationWithDescription("testListCommand_target_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testListCommand_target_not_available_error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -274,6 +276,7 @@ class ListCommandsTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
@@ -23,7 +23,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
     func testSuccess()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
         let list = [
             [ "thingID": "thing-0001", "vendorThingID": "abcd-1234" ],
             [ "thingID": "thing-0002", "vendorThingID": "efgh-5678" ],
@@ -74,6 +74,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         }
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -83,7 +84,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
     func testEmpty()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testEmpty")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testEmpty")
         let list = [
         ]
         
@@ -125,6 +126,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         }
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -135,7 +137,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
     {
         let setting = TestSetting()
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
-        let expectation = self.expectationWithDescription("testNoLoggedInError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testNoLoggedInError")
         
         api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
@@ -150,6 +152,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -159,7 +162,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
     func test400Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test400Error")
         
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -198,6 +201,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -207,7 +211,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
     func test401Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test401Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test401Error")
         
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -246,6 +250,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -255,7 +260,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
     func test404Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test404Error")
         
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -294,6 +299,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -303,7 +309,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
     func test409Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test409Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test409Error")
         
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -342,6 +348,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -351,7 +358,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
     func test503Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test503Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test503Error")
         
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -390,6 +397,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
@@ -73,7 +73,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             XCTFail("should not throw error")
         }
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -124,7 +124,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             XCTFail("should not throw error")
         }
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -149,7 +149,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -197,7 +197,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -245,7 +245,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -293,7 +293,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -341,7 +341,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -389,7 +389,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
         
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
@@ -74,7 +74,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             XCTFail("should not throw error")
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -125,7 +125,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             XCTFail("should not throw error")
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -150,7 +150,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -198,7 +198,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -246,7 +246,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -294,7 +294,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -342,7 +342,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -390,7 +390,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
@@ -23,7 +23,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
     func testSuccess()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
         let propeties:Dictionary<String, AnyObject> = [ "debug": true ]
         let list = [
             [ "vendorThingID": "abcd-1234" ],
@@ -75,6 +75,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -84,7 +85,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
     func testEmpty()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testEmpty")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testEmpty")
         let list = [
         ]
 
@@ -126,6 +127,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -136,7 +138,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
     {
         let setting = TestSetting()
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
-        let expectation = self.expectationWithDescription("testNoLoggedInError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testNoLoggedInError")
 
         api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
@@ -151,6 +153,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -160,7 +163,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
     func test400Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test400Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -199,6 +202,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -208,7 +212,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
     func test401Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test401Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test401Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -247,6 +251,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -256,7 +261,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
     func test404Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test404Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -295,6 +300,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -304,7 +310,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
     func test409Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test409Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test409Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -343,6 +349,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -352,7 +359,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
     func test503Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test503Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test503Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -391,6 +398,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ListTriggeredServerCodeResultsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListTriggeredServerCodeResultsTests.swift
@@ -14,7 +14,7 @@ class ListTriggeredServerCodeResultsTests: SmallTestBase {
     func testListTriggeredServerCodeResultsTests_success() {
         let setting:TestSetting = TestSetting()
         let api = setting.api
-        let expectation = self.expectationWithDescription("testPostNewServerCodeTrigger_success")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success")
         let triggerID = "abcdefgHIJKLMN1234567"
         
         do{
@@ -79,6 +79,7 @@ class ListTriggeredServerCodeResultsTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout for testListTriggeredServerCodeResultsTests_success")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ListTriggersTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListTriggersTests.swift
@@ -56,7 +56,7 @@ class ListTriggersTests: SmallTestBase {
         ]
 
 
-        let expectation = self.expectationWithDescription("testListTriggers_success_predicates")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testListTriggers_success_predicates")
 
         do{
             let expectedActionsDict: [Dictionary<String, AnyObject>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
@@ -124,6 +124,7 @@ class ListTriggersTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -131,7 +132,7 @@ class ListTriggersTests: SmallTestBase {
     }
     
     func testListTriggers_404_error() {
-        let expectation = self.expectationWithDescription("getTrigger403Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("getTrigger403Error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -180,6 +181,7 @@ class ListTriggersTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -187,7 +189,7 @@ class ListTriggersTests: SmallTestBase {
     }
 
     func testListTriggers_target_not_available_error() {
-        let expectation = self.expectationWithDescription("testListTriggers_target_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testListTriggers_target_not_available_error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -208,6 +210,7 @@ class ListTriggersTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
@@ -61,7 +61,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -88,7 +88,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -113,7 +113,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -138,7 +138,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -192,7 +192,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -246,7 +246,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -300,7 +300,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -354,7 +354,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -408,7 +408,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
@@ -23,7 +23,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
     func testSuccess()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
         let endNode = EndNode(thingID: thingID, vendorThingID: vendorThingID)
@@ -62,6 +62,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -72,7 +73,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
     {
         let setting = TestSetting()
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
-        let expectation = self.expectationWithDescription("testNoLoggedInError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testNoLoggedInError")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
         let endNode = EndNode(thingID: thingID, vendorThingID: vendorThingID)
@@ -89,6 +90,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -98,7 +100,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
     func testEmptyThingIDError()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testEmptyThingIDError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testEmptyThingIDError")
         let vendorThingID = "dummyVendorThingID"
         let endNode = EndNode(thingID: "", vendorThingID: vendorThingID)
 
@@ -114,6 +116,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -123,7 +126,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
     func testEmptyVendorThingIDError()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testEmptyVendorThingIDError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testEmptyVendorThingIDError")
         let thingID = "dummyThingID"
         let endNode = EndNode(thingID: thingID, vendorThingID: "")
 
@@ -139,6 +142,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -148,7 +152,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
     func test400Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test400Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
         let endNode = EndNode(thingID: thingID, vendorThingID: vendorThingID)
@@ -193,6 +197,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -202,7 +207,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
     func test401Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test401Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test401Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
         let endNode = EndNode(thingID: thingID, vendorThingID: vendorThingID)
@@ -247,6 +252,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -256,7 +262,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
     func test404Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test404Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
         let endNode = EndNode(thingID: thingID, vendorThingID: vendorThingID)
@@ -301,6 +307,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -310,7 +317,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
     func test409Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test409Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test409Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
         let endNode = EndNode(thingID: thingID, vendorThingID: vendorThingID)
@@ -355,6 +362,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -364,7 +372,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
     func test503Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test503Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test503Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
         let endNode = EndNode(thingID: thingID, vendorThingID: vendorThingID)
@@ -409,6 +417,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
@@ -108,7 +108,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
             XCTFail("should not throw error")
         }
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -198,7 +198,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -288,7 +288,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -378,7 +378,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -416,7 +416,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -457,7 +457,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -499,7 +499,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -541,7 +541,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
@@ -22,7 +22,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
 
     func testOnboardEndnodeWithGatewaySuccess()
     {
-        let expectation = self.expectationWithDescription("testOnboardEndnodeWithGatewayThingIDSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOnboardEndnodeWithGatewayThingIDSuccess")
         let setting = TestSetting()
         let gatewayThingID = "dummyGatewayThingID"
         let vendorThingID = "dummyVendorThingID"
@@ -109,6 +109,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -117,7 +118,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
 
     func testOnboardEndnodeWithGateway403Error()
     {
-        let expectation = self.expectationWithDescription("testOnboardEndnodeWithGatewayThingID403Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOnboardEndnodeWithGatewayThingID403Error")
         let setting = TestSetting()
         let gatewayThingID = "dummyGatewayThingID"
         let vendorThingID = "dummyVendorThingID"
@@ -199,6 +200,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -207,7 +209,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
 
     func testOnboardEndnodeWithGateway404Error()
     {
-        let expectation = self.expectationWithDescription("testOnboardEndnodeWithGatewayThingID404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOnboardEndnodeWithGatewayThingID404Error")
         let setting = TestSetting()
         let gatewayThingID = "dummyGatewayThingID"
         let vendorThingID = "dummyVendorThingID"
@@ -289,6 +291,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -297,7 +300,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
 
     func testOnboardEndnodeWithGateway500Error()
     {
-        let expectation = self.expectationWithDescription("testOnboardEndnodeWithGatewayThingID500Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOnboardEndnodeWithGatewayThingID500Error")
         let setting = TestSetting()
         let gatewayThingID = "dummyGatewayThingID"
         let vendorThingID = "dummyVendorThingID"
@@ -379,6 +382,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -387,7 +391,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
 
     func testOboardEndnodeWithGatewayWithoutOnboardingGatewayError()
     {
-        let expectation = self.expectationWithDescription("testOboardEndnodeWithGatewayWithoutOnboardingGatewayError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOboardEndnodeWithGatewayWithoutOnboardingGatewayError")
         let setting = TestSetting()
         let vendorThingID = "dummyVendorThingID"
         let password = "dummyPassword"
@@ -417,6 +421,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -425,7 +430,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
 
     func testOboardEndnodeWithGatewayWithNilVendorThingIDError()
     {
-        let expectation = self.expectationWithDescription("testOboardEndnodeWithGatewayWithNilVendorThingIDError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOboardEndnodeWithGatewayWithNilVendorThingIDError")
         let setting = TestSetting()
         let gatewayThingID = "dummyGatewayThingID"
         let vendorThingID = "dummyVendorThingID"
@@ -458,6 +463,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -466,7 +472,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
 
     func testOboardEndnodeWithGatewayWithEmptyVendorThingIDError()
     {
-        let expectation = self.expectationWithDescription("testOboardEndnodeWithGatewayWithEmptyVendorThingIDError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOboardEndnodeWithGatewayWithEmptyVendorThingIDError")
         let setting = TestSetting()
         let gatewayThingID = "dummyGatewayThingID"
         let vendorThingID = "dummyVendorThingID"
@@ -500,6 +506,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -508,7 +515,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
 
     func testOboardEndnodeWithGatewayWithEmptyVendorThingPasswordError()
     {
-        let expectation = self.expectationWithDescription("testOboardEndnodeWithGatewayWithEmptyVendorThingPasswordError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOboardEndnodeWithGatewayWithEmptyVendorThingPasswordError")
         let setting = TestSetting()
         let gatewayThingID = "dummyGatewayThingID"
         let vendorThingID = "dummyVendorThingID"
@@ -542,6 +549,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
@@ -23,7 +23,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
     func testSuccess()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
 
@@ -65,6 +65,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -75,7 +76,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
     {
         let setting = TestSetting()
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
-        let expectation = self.expectationWithDescription("testNoLoggedInError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testNoLoggedInError")
 
         api.onboardGateway( { (gateway:Gateway?, error:ThingIFError?) -> Void in
             XCTAssertNil(gateway)
@@ -90,6 +91,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -99,7 +101,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
     func test400Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test400Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -138,6 +140,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -147,7 +150,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
     func test401Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test401Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test401Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -186,6 +189,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -195,7 +199,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
     func test409Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test409Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test409Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -234,6 +238,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -243,7 +248,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
     func test503Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test503Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test503Error")
 
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -282,6 +287,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
@@ -64,7 +64,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -89,7 +89,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -137,7 +137,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -185,7 +185,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -233,7 +233,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -281,7 +281,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
             expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
@@ -31,7 +31,7 @@ class OnboardingTests: SmallTestBase {
 
     func testOnboardWithThingIDFail() {
         
-        let expectation = self.expectationWithDescription("onboardWithThingID")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("onboardWithThingID")
         let setting = TestSetting()
         let api = setting.api
         let owner = setting.owner
@@ -84,6 +84,7 @@ class OnboardingTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -93,7 +94,7 @@ class OnboardingTests: SmallTestBase {
     
     func testOnboardWithVendorThingIDSuccess() {
         
-        let expectation = self.expectationWithDescription("onboardWithVendorThingID")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("onboardWithVendorThingID")
         let setting = TestSetting()
         let api = setting.api
         let owner = setting.owner
@@ -143,6 +144,7 @@ class OnboardingTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -152,7 +154,7 @@ class OnboardingTests: SmallTestBase {
     }
 
     func testOnboardWithThingID_already_onboarded_error() {
-        let expectation = self.expectationWithDescription("testOnboardWithThingID_already_onboarded_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testOnboardWithThingID_already_onboarded_error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -172,6 +174,7 @@ class OnboardingTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -180,7 +183,7 @@ class OnboardingTests: SmallTestBase {
 
     func testOnboardWithVendorThingIDAndImplementTag() {
 
-        let expectation = self.expectationWithDescription("onboardWithVendorThingID")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("onboardWithVendorThingID")
         let setting = TestSetting()
         let owner = setting.owner
         let app = setting.app
@@ -231,6 +234,7 @@ class OnboardingTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
@@ -25,7 +25,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_success"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
@@ -126,7 +126,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let api = setting.api
         let tag = "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_http_404"
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
         let expectedTargetAppID = "app000001"
@@ -202,7 +202,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_UnsupportError")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_UnsupportError")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         let predicate = SchedulePredicate(schedule: "'*/15 * * * *")
@@ -243,7 +243,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_target_not_available_error_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_target_not_available_error_\(predicate.getEventSource().rawValue)")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
@@ -25,7 +25,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_success"
-        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
@@ -106,6 +106,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -126,7 +127,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let api = setting.api
         let tag = "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_http_404"
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
         let expectedTargetAppID = "app000001"
@@ -192,6 +193,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -202,7 +204,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        let expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_UnsupportError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_UnsupportError")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         let predicate = SchedulePredicate(schedule: "'*/15 * * * *")
@@ -223,6 +225,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -243,7 +246,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        let expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_target_not_available_error_\(predicate.getEventSource().rawValue)")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_target_not_available_error_\(predicate.getEventSource().rawValue)")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         
@@ -262,6 +265,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -95,10 +95,8 @@ class PatchTriggerTests: SmallTestBase {
     }
 
     func patchTrigger(tag: String, testcase: TestCase) {
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        
         let setting = TestSetting()
         let api = setting.api
 
@@ -204,7 +202,7 @@ class PatchTriggerTests: SmallTestBase {
     }
 
     func testPatchTrigger_UnsupportError() {
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("patchTriggerUnsupportError")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("patchTriggerUnsupportError")
         let setting = TestSetting()
         let api = setting.api
 
@@ -234,7 +232,7 @@ class PatchTriggerTests: SmallTestBase {
         }
     }
     func testPatchTrigger_target_not_available_error() {
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPatchTrigger_target_not_available_error")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPatchTrigger_target_not_available_error")
         let setting = TestSetting()
         let api = setting.api
 

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -95,7 +95,7 @@ class PatchTriggerTests: SmallTestBase {
     }
 
     func patchTrigger(tag: String, testcase: TestCase) {
-        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
         
         let setting = TestSetting()
         let api = setting.api
@@ -195,6 +195,7 @@ class PatchTriggerTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -202,7 +203,7 @@ class PatchTriggerTests: SmallTestBase {
     }
 
     func testPatchTrigger_UnsupportError() {
-        let expectation : XCTestExpectation! = self.expectationWithDescription("patchTriggerUnsupportError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("patchTriggerUnsupportError")
         let setting = TestSetting()
         let api = setting.api
 
@@ -226,13 +227,14 @@ class PatchTriggerTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
         }
     }
     func testPatchTrigger_target_not_available_error() {
-        let expectation : XCTestExpectation! = self.expectationWithDescription("testPatchTrigger_target_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPatchTrigger_target_not_available_error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -254,6 +256,7 @@ class PatchTriggerTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -49,7 +49,7 @@ class PostNewCommandTests: SmallTestBase {
 
     func postCommandSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
 
-        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
         
         do {
             let expectedCommandID = "c6f1b8d0-46ea-11e5-a5eb-06d9d1527620"
@@ -104,6 +104,7 @@ class PostNewCommandTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -112,7 +113,7 @@ class PostNewCommandTests: SmallTestBase {
 
     func testPostNewCommand_400_error() {
 
-        let expectation = self.expectationWithDescription("testPostNewCommand_400_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewCommand_400_error")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -176,6 +177,7 @@ class PostNewCommandTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -184,7 +186,7 @@ class PostNewCommandTests: SmallTestBase {
 
     func testPostNewCommand_target_not_available_error() {
 
-        let expectation = self.expectationWithDescription("testPostNewCommand_target_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewCommand_target_not_available_error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -203,6 +205,7 @@ class PostNewCommandTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -49,10 +49,7 @@ class PostNewCommandTests: SmallTestBase {
 
     func postCommandSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
 
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
         
         do {
             let expectedCommandID = "c6f1b8d0-46ea-11e5-a5eb-06d9d1527620"

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
@@ -135,10 +135,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
             tag: String,
             testcase: TestCase,
             setting:TestSetting) {
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
 
         do {
             let expectedCommandID = "c6f1b8d0-46ea-11e5-a5eb-06d9d1527620"

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
@@ -135,7 +135,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
             tag: String,
             testcase: TestCase,
             setting:TestSetting) {
-        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
 
         do {
             let expectedCommandID = "c6f1b8d0-46ea-11e5-a5eb-06d9d1527620"
@@ -198,6 +198,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
         }
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -206,7 +207,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
 
     func testPostNewCommand_400_error() {
 
-        let expectation = self.expectationWithDescription("testPostNewCommand_400_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewCommand_400_error")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -274,6 +275,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -282,7 +284,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
 
     func testPostNewCommand_target_not_available_error() {
 
-        let expectation = self.expectationWithDescription("testPostNewCommand_target_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewCommand_target_not_available_error")
         let setting = TestSetting()
         let api = setting.api
 
@@ -301,6 +303,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
@@ -26,7 +26,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PostNewServerCodeTriggerTests.testPostNewTrigger_success"
-        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
@@ -92,6 +92,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -113,7 +114,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PostNewServerCodeTriggerTests.testPostNewServerCodeTrigger_http_404"
-        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
         let expectedTargetAppID = "app000001"
@@ -179,6 +180,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout for \(tag)")
             }
@@ -188,7 +190,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
     func testPostNewServerCodeTrigger_UnsupportError() {
         let setting:TestSetting = TestSetting()
         let api = setting.api
-        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_UnsupportError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_UnsupportError")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         let predicate = SchedulePredicate(schedule: "'*/15 * * * *")
@@ -209,6 +211,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -218,7 +221,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
     func testPostNewServerCodeTrigger_target_not_available_error() {
         let setting:TestSetting = TestSetting()
         let api = setting.api
-        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_target_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_target_not_available_error")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         let predicate = StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE)
@@ -238,6 +241,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         })
         
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
@@ -26,7 +26,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PostNewServerCodeTriggerTests.testPostNewTrigger_success"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
@@ -113,7 +113,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PostNewServerCodeTriggerTests.testPostNewServerCodeTrigger_http_404"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
         let expectedTargetAppID = "app000001"
@@ -188,7 +188,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
     func testPostNewServerCodeTrigger_UnsupportError() {
         let setting:TestSetting = TestSetting()
         let api = setting.api
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_UnsupportError")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_UnsupportError")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         let predicate = SchedulePredicate(schedule: "'*/15 * * * *")
@@ -218,7 +218,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
     func testPostNewServerCodeTrigger_target_not_available_error() {
         let setting:TestSetting = TestSetting()
         let api = setting.api
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_target_not_available_error")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_target_not_available_error")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         let predicate = StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE)

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
@@ -39,12 +39,10 @@ class PostNewTriggerTests: SmallTestBase {
     }
 
     func testPostNewTrigger_success() {
-        weak var expectation : XCTestExpectation!
-        defer {
-            expectation = nil
-        }
+
+
         func postNewTriggerSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
-            expectation = self.expectationWithDescription(tag)
+            let expectation = self.expectationWithDescription(tag)
 
             do{
                 let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
@@ -42,7 +42,7 @@ class PostNewTriggerTests: SmallTestBase {
 
 
         func postNewTriggerSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
-            let expectation = self.expectationWithDescription(tag)
+            var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
 
             do{
                 let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
@@ -114,6 +114,7 @@ class PostNewTriggerTests: SmallTestBase {
                 print(e)
             }
             self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
                 if error != nil {
                     XCTFail("execution timeout for \(tag)")
                 }
@@ -166,7 +167,7 @@ class PostNewTriggerTests: SmallTestBase {
 
 
     func testPostNewTrigger_http_404() {
-        let expectation = self.expectationWithDescription("postNewTrigger404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("postNewTrigger404Error")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -238,6 +239,7 @@ class PostNewTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -245,7 +247,7 @@ class PostNewTriggerTests: SmallTestBase {
     }
 
     func testPostNewTrigger_http_400() {
-        let expectation = self.expectationWithDescription("postNewTrigger400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("postNewTrigger400Error")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -317,6 +319,7 @@ class PostNewTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -324,7 +327,7 @@ class PostNewTriggerTests: SmallTestBase {
     }
 
     func testPostNewTrigger_http_400_invalidTimestamp() {
-        let expectation = self.expectationWithDescription("postNewTrigger400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("postNewTrigger400Error")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -392,6 +395,7 @@ class PostNewTriggerTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -399,7 +403,7 @@ class PostNewTriggerTests: SmallTestBase {
     }
 
     func testPostNewTrigger_UnsupportError() {
-        let expectation = self.expectationWithDescription("postNewTriggerUnsupportError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("postNewTriggerUnsupportError")
         let setting = TestSetting()
         let api = setting.api
         let schema = setting.schema
@@ -423,6 +427,7 @@ class PostNewTriggerTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -430,7 +435,7 @@ class PostNewTriggerTests: SmallTestBase {
     }
     
     func testPostTrigger_target_not_available_error() {
-        let expectation = self.expectationWithDescription("testPostTrigger_target_not_available_error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPostTrigger_target_not_available_error")
         let setting = TestSetting()
         let api = setting.api
         let schema = setting.schema
@@ -454,6 +459,7 @@ class PostNewTriggerTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PushInstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushInstallationTests.swift
@@ -35,7 +35,7 @@ class PushInstallationTests: SmallTestBase {
         }
     }
     func onboard(setting:TestSetting){
-        let expectation = self.expectationWithDescription("onboardWithVendorThingID")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("onboardWithVendorThingID")
         
         do{
             let thingProperties:Dictionary<String, AnyObject> = ["key1":"value1", "key2":"value2"]
@@ -76,6 +76,7 @@ class PushInstallationTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -85,7 +86,7 @@ class PushInstallationTests: SmallTestBase {
     func testPushInstallation_success() {
         let setting = TestSetting()
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testPushInstallation_success")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPushInstallation_success")
         //iotSession = NSURLSession.self
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -124,6 +125,7 @@ class PushInstallationTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -134,7 +136,7 @@ class PushInstallationTests: SmallTestBase {
     func testPushInstallation_http_404() {
         let setting = TestSetting()
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testPushInstallation_http_404")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPushInstallation_http_404")
         //iotSession = NSURLSession.self
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -184,6 +186,7 @@ class PushInstallationTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -195,7 +198,7 @@ class PushInstallationTests: SmallTestBase {
     func testPushInstallation_http_400() {
         let setting = TestSetting()
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testPushInstallation_http_400")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPushInstallation_http_400")
         //iotSession = NSURLSession.self
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -245,6 +248,7 @@ class PushInstallationTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -256,7 +260,7 @@ class PushInstallationTests: SmallTestBase {
     func testPushInstallation_http_401() {
         let setting = TestSetting()
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testPushInstallation_http_401")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPushInstallation_http_401")
         //iotSession = NSURLSession.self
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -306,6 +310,7 @@ class PushInstallationTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
@@ -33,7 +33,7 @@ class PushUninstallationTests: SmallTestBase {
     }
 
     func onboard(setting:TestSetting){
-        let expectation = self.expectationWithDescription("onboardWithVendorThingID")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("onboardWithVendorThingID")
         
         do{
             let thingProperties:Dictionary<String, AnyObject> = ["key1":"value1", "key2":"value2"]
@@ -74,6 +74,7 @@ class PushUninstallationTests: SmallTestBase {
             print(e)
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -83,7 +84,7 @@ class PushUninstallationTests: SmallTestBase {
     func testPushUninstallation_success() {
         let setting = TestSetting()
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testPushUninstallation_success")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPushUninstallation_success")
         let installID = "dummyInstallId"
         
         // verify request
@@ -110,6 +111,7 @@ class PushUninstallationTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -119,7 +121,7 @@ class PushUninstallationTests: SmallTestBase {
     func testPushUninstallation_http_404() {
         let setting = TestSetting()
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testPushUninstallation_http_404")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPushUninstallation_http_404")
         let installID = "dummyInstallId"
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -168,6 +170,7 @@ class PushUninstallationTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -177,7 +180,7 @@ class PushUninstallationTests: SmallTestBase {
     func testPushUninstallation_http_401() {
         let setting = TestSetting()
         self.onboard(setting)
-        let expectation = self.expectationWithDescription("testPushUninstallation_http_401")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testPushUninstallation_http_401")
         let installID = "dummyInstallId"
         // verify request
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
@@ -226,6 +229,7 @@ class PushUninstallationTests: SmallTestBase {
             expectation.fulfill()
         }
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
@@ -23,7 +23,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
     func testSuccess()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testSuccess")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
 
@@ -65,6 +65,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         )
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -75,7 +76,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
     {
         let setting = TestSetting()
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
-        let expectation = self.expectationWithDescription("testNoLoggedInError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testNoLoggedInError")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
 
@@ -95,6 +96,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         )
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -104,7 +106,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
     func testEmptyThingIDError()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testEmptyThingIDError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testEmptyThingIDError")
         let vendorThingID = "dummyVendorThingID"
 
         api.replaceEndNode(
@@ -123,6 +125,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         )
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -132,7 +135,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
     func testEmptyVendorThingIDError()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("testEmptyThingIDError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testEmptyThingIDError")
         let thingID = "dummyThingID"
 
         api.replaceEndNode(
@@ -151,6 +154,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         )
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -160,7 +164,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
     func test400Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test400Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
 
@@ -208,6 +212,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         )
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -217,7 +222,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
     func test401Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test401Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test401Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
 
@@ -265,6 +270,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         )
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -274,7 +280,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
     func test404Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test404Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test404Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
 
@@ -322,6 +328,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         )
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -331,7 +338,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
     func test409Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test409Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test409Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
 
@@ -379,6 +386,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         )
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -388,7 +396,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
     func test503Error()
     {
         let api:GatewayAPI = getLoggedInGatewayAPI()
-        let expectation = self.expectationWithDescription("test503Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("test503Error")
         let thingID = "dummyThingID"
         let vendorThingID = "dummyVendorThingID"
 
@@ -436,6 +444,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         )
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
@@ -64,7 +64,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
             }
         )
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -94,7 +94,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
             }
         )
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -122,7 +122,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
             }
         )
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -150,7 +150,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
             }
         )
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -207,7 +207,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
             }
         )
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -264,7 +264,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
             }
         )
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -321,7 +321,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
             }
         )
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -378,7 +378,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
             }
         )
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -435,7 +435,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
             }
         )
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/SmallTestBase.swift
+++ b/ThingIFSDK/ThingIFSDKTests/SmallTestBase.swift
@@ -3,6 +3,7 @@ import XCTest
 
 class SmallTestBase: XCTestCase {
     override func setUp() {
+        self.continueAfterFailure = true
         super.setUp()
         MockSession.mockResponse = (data: nil, urlResponse: nil, error: nil)
         MockSession.requestVerifier = {(request) in }

--- a/ThingIFSDK/ThingIFSDKTests/SmallTestBase.swift
+++ b/ThingIFSDK/ThingIFSDKTests/SmallTestBase.swift
@@ -3,7 +3,6 @@ import XCTest
 
 class SmallTestBase: XCTestCase {
     override func setUp() {
-        self.continueAfterFailure = true
         super.setUp()
         MockSession.mockResponse = (data: nil, urlResponse: nil, error: nil)
         MockSession.requestVerifier = {(request) in }

--- a/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
@@ -84,7 +84,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -161,7 +161,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -238,7 +238,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -271,7 +271,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -304,7 +304,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
                 expectation.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+        self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout")
             }

--- a/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
@@ -22,7 +22,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
 
     func testUpdateVendorThingIDSuccess()
     {
-        let expectation = self.expectationWithDescription("testUpdateVendorThingIDSuccess")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testUpdateVendorThingIDSuccess")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -85,6 +85,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -93,7 +94,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
 
     func testUpdateVendorThingID400Error()
     {
-        let expectation = self.expectationWithDescription("testUpdateVendorThingID400Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testUpdateVendorThingID400Error")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -162,6 +163,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -170,7 +172,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
 
     func testUpdateVendorThingID409Error()
     {
-        let expectation = self.expectationWithDescription("testUpdateVendorThingID409Error")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testUpdateVendorThingID409Error")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -239,6 +241,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -247,7 +250,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
 
     func testUpdateVendorThingIDWithEmptyVendorThingIDError()
     {
-        let expectation = self.expectationWithDescription("testUpdateVendorThingIDWithEmptyVendorThingIDError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testUpdateVendorThingIDWithEmptyVendorThingIDError")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -272,6 +275,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }
@@ -280,7 +284,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
 
     func testUpdateVendorThingIDWithEmptyPasswordError()
     {
-        let expectation = self.expectationWithDescription("testUpdateVendorThingIDWithEmptyPasswordError")
+        var expectation : XCTestExpectation! = self.expectationWithDescription("testUpdateVendorThingIDWithEmptyPasswordError")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -305,6 +309,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         })
 
         self.waitForExpectationsWithTimeout(TEST_TIMEOUT) { (error) -> Void in
+expectation = nil
             if error != nil {
                 XCTFail("execution timeout")
             }


### PR DESCRIPTION
- Optimize SDK version generation. [ref](http://stackoverflow.com/questions/27096023/semaphore-wait-trap-when-accessing-class-singleton-using-swift)
- Unify expectation timeout.
- Unify expectations declarations as `let`
