### PR TITLE
Create new ThingIFAPI instance with target without using ThingIFAPI#createWithTarget()

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPIBuilder.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPIBuilder.swift
@@ -8,20 +8,30 @@ import Foundation
 /** Builder class of ThingIFAPI */
 public class ThingIFAPIBuilder {
 
-    var thingIFAPI: ThingIFAPI!
+    var app: App
+    var owner: Owner
+    var target: Target?
+    var tag: String?
 
     /** Initialize builder.
     - Parameter app: Kii Cloud Application.
     - Parameter owner: Owner who consumes ThingIFAPI.
+    - Parameter target: target of the ThingIFAPI instance.
     - Parameter tag: tag of the ThingIFAPI instance.
      */
-    public init(app:App, owner:Owner, tag:String?=nil) {
-        thingIFAPI = ThingIFAPI(app: app, owner: owner, tag: tag)
+    public init(app:App, owner:Owner, target: Target?=nil, tag:String?=nil) {
+        self.app = app
+        self.owner = owner
+        self.target = target
+        self.tag = tag
     }
+
     /** Build ThingIFAPI instance.
     - Returns: ThingIFAPI instance.
      */
     public func build() -> ThingIFAPI {
+        let thingIFAPI = ThingIFAPI(app: self.app, owner: self.owner, tag: self.tag)
+        thingIFAPI._target = self.target
         return thingIFAPI
     }
 }


### PR DESCRIPTION
https://github.com/KiiCorp/kiidocs/pull/2335 にて異なるTargetを持つThingIFAPIインスタンスの作成にcopyWithTargetを使用していました。しかし、それだとインスタンス内のinstallationIDが2つのインスタンス間で同じ値となってしまう問題があると判明しました。

それを解消するための方法の一つはThingIFAPIBuilderで新たなインスタンスを作成すればいいはずです。ただ、現在のThingIFAPIBuilderの実装ではTargetを設定できません。よってTargetを指定できるように修正しました。また内部実装をよりビルダーらしい内容に修正しました。

レビューをお願いします。

他の修正案としてはinstalationIDをコピーしないcopyWithTargetを作成するなどがあります。
そちらが良いのであればそちらで修正します。
