### PR TITLE
Smalltest optimize

### DIFF
--- a/ThingIFSDK/ThingIFSDKTests/DeleteTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/DeleteTriggerTests.swift
@@ -39,8 +39,8 @@ class DeleteTriggerTests: SmallTestBase {
             XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/triggers/\(expectedTriggerID)")
         }
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!, statusCode: 204, HTTPVersion: nil, headerFields: nil)
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = deleteRequestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = deleteRequestVerifier
         iotSession = MockSession.self
 
         api.deleteTrigger(expectedTriggerID) { (triggerID, error) -> Void in
@@ -88,8 +88,8 @@ class DeleteTriggerTests: SmallTestBase {
                 }
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/triggers/\(triggerID)")
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             api.deleteTrigger(triggerID, completionHandler: { (triggerID, error) -> Void in
                 if error == nil{

--- a/ThingIFSDK/ThingIFSDKTests/EnableTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/EnableTriggerTests.swift
@@ -71,7 +71,7 @@ class EnableTriggerTests: SmallTestBase {
         let mockResponse2 = NSHTTPURLResponse(URL: NSURL(string: setting.app.baseURL)!, statusCode: 201, HTTPVersion: nil, headerFields: nil)
 
         iotSession = MockMultipleSession.self
-        MockMultipleSession.responsePairs = [
+        sharedMockMultipleSession.responsePairs = [
             ((data: nil, urlResponse: mockResponse1, error: nil),putRequestVerifier),
             ((data: jsonData!, urlResponse: mockResponse2, error: nil),getRequestVerifier)
         ]
@@ -130,7 +130,7 @@ class EnableTriggerTests: SmallTestBase {
         let mockResponse2 = NSHTTPURLResponse(URL: NSURL(string: setting.app.baseURL)!, statusCode: 201, HTTPVersion: nil, headerFields: nil)
         
         iotSession = MockMultipleSession.self
-        MockMultipleSession.responsePairs = [
+        sharedMockMultipleSession.responsePairs = [
             ((data: nil, urlResponse: mockResponse1, error: nil),putRequestVerifier),
             ((data: jsonData!, urlResponse: mockResponse2, error: nil),getRequestVerifier)
         ]
@@ -181,8 +181,8 @@ class EnableTriggerTests: SmallTestBase {
                 }
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/triggers/\(triggerID)/disable")
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             api.enableTrigger(triggerID, enable: false, completionHandler: { (trigger, error) -> Void in
                 if error == nil{

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
@@ -58,8 +58,8 @@ class GatewayAPILoginTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
         } catch(_) {
             XCTFail("should not throw error")
@@ -163,8 +163,8 @@ class GatewayAPILoginTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         let gatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
@@ -221,8 +221,8 @@ class GatewayAPILoginTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         let gatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPINSCodingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPINSCodingTests.swift
@@ -31,7 +31,7 @@ class GatewayAPINSCodingTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             iotSession = MockSession.self
         } catch(_) {
             XCTFail("should not throw error")

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
@@ -45,8 +45,8 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 204, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.restore({ (error:ThingIFError?) -> Void in
@@ -110,8 +110,8 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.restore( { (error:ThingIFError?) -> Void in
@@ -157,8 +157,8 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.restore( { (error:ThingIFError?) -> Void in
@@ -204,8 +204,8 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.restore( { (error:ThingIFError?) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
@@ -31,7 +31,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             iotSession = MockSession.self
         } catch(_) {
             XCTFail("should not throw error")
@@ -76,7 +76,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             iotSession = MockSession.self
         } catch(_) {
             XCTFail("should not throw error")

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
@@ -8,37 +8,45 @@
 import XCTest
 @testable import ThingIFSDK
 
+private var sharedGatewayAPI : GatewayAPI!
+
 class GatewayAPITestBase: SmallTestBase {
     let ACCESSTOKEN: String = "token-0000-1111-aaaa-bbbb"
 
     func getLoggedInGatewayAPI() -> GatewayAPI {
-        let expectation = self.expectationWithDescription("getLoggedInGatewayAPI")
-        let setting = TestSetting()
 
-        do {
-            let dict = ["accessToken": ACCESSTOKEN]
-            let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
-            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
-                statusCode: 200, HTTPVersion: nil, headerFields: nil)
-        
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            iotSession = MockSession.self
-        } catch(_) {
-            XCTFail("should not throw error")
-        }
+        if sharedGatewayAPI == nil {
+            let expectation = self.expectationWithDescription("getLoggedInGatewayAPI")
+            let setting = TestSetting()
 
-        let gatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
-        gatewayAPI.login("dummy", password: "dummy", completionHandler: { (error:ThingIFError?) -> Void in
-            XCTAssertNil(error)
-            expectation.fulfill()
-        })
+            do {
+                let dict = ["accessToken": ACCESSTOKEN]
+                let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
+                let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
+                                                    statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-        self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
-            if error != nil {
-                XCTFail("execution timeout")
+                MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+                iotSession = MockSession.self
+            } catch(_) {
+                XCTFail("should not throw error")
             }
+
+            let gatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: NSURL(string: setting.app.baseURL)!)
+            gatewayAPI.login("dummy", password: "dummy", completionHandler: { (error:ThingIFError?) -> Void in
+                XCTAssertNil(error)
+                expectation.fulfill()
+            })
+
+            self.waitForExpectationsWithTimeout(20.0) { (error) -> Void in
+                if error != nil {
+                    XCTFail("execution timeout")
+                }
+            }
+
+            sharedGatewayAPI = gatewayAPI
+
         }
 
-        return gatewayAPI
+        return sharedGatewayAPI
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPITestBase.swift
@@ -25,7 +25,7 @@ class GatewayAPITestBase: SmallTestBase {
                 let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
                                                     statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-                MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+                sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
                 iotSession = MockSession.self
             } catch(_) {
                 XCTFail("should not throw error")

--- a/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
@@ -54,10 +54,7 @@ class GetCommandTests: SmallTestBase {
 
     func getCommandSuccess(tag: String, testcase: TestCase, setting: TestSetting) {
 
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
 
         do{
 

--- a/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
@@ -93,8 +93,8 @@ class GetCommandTests: SmallTestBase {
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/commands/\(commandID)")
 
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             setting.api.getCommand(commandID, completionHandler: { (command, error) -> Void in
@@ -167,8 +167,8 @@ class GetCommandTests: SmallTestBase {
                 }
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/commands/\(commandID)")
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             api.getCommand(commandID, completionHandler: { (command, error) -> Void in
                  if error == nil{

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
@@ -49,8 +49,8 @@ class GetGatewayIDTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.getGatewayID( { (id:String?, error:ThingIFError?) -> Void in
@@ -119,8 +119,8 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.getGatewayID( { (id:String?, error:ThingIFError?) -> Void in
@@ -167,8 +167,8 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.getGatewayID( { (id:String?, error:ThingIFError?) -> Void in
@@ -215,8 +215,8 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.getGatewayID( { (id:String?, error:ThingIFError?) -> Void in
@@ -263,8 +263,8 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.getGatewayID( { (id:String?, error:ThingIFError?) -> Void in
@@ -311,8 +311,8 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.getGatewayID( { (id:String?, error:ThingIFError?) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
@@ -49,8 +49,8 @@ class GetGatewayInformationTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.getGatewayInformation( { (info:GatewayInformation?, error:ThingIFError?) -> Void in
@@ -119,8 +119,8 @@ class GetGatewayInformationTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.getGatewayInformation( { (info:GatewayInformation?, error:ThingIFError?) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
@@ -49,8 +49,8 @@ class GetStateTests: SmallTestBase {
                 }
 
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             setting.api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
                 if error == nil{
@@ -98,8 +98,8 @@ class GetStateTests: SmallTestBase {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict!, options: .PrettyPrinted)
 
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 200, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
         }catch(_){
             //should never reach this
@@ -151,8 +151,8 @@ class GetStateTests: SmallTestBase {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
 
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 404, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
         }catch(_){
             //should never reach this
@@ -209,8 +209,8 @@ class GetStateTests: SmallTestBase {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
 
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 401, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
         }catch(_){
             //should never reach this
@@ -274,7 +274,7 @@ class GetStateTests: SmallTestBase {
             let mockResponse1 = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 200, HTTPVersion: nil, headerFields: nil)
             let mockResponse2 = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 401, HTTPVersion: nil, headerFields: nil)
             iotSession = MockMultipleSession.self
-            MockMultipleSession.responsePairs = [
+            sharedMockMultipleSession.responsePairs = [
                 ((data: jsonData, urlResponse: mockResponse1, error: nil),requestVerifier),
                 ((data: errorJson, urlResponse: mockResponse2, error: nil),requestVerifier)
             ]

--- a/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
@@ -67,11 +67,8 @@ class GetTriggerTests: SmallTestBase {
 
     func getTriggerSuccess(tag: String, statementToTest: Dictionary<String, AnyObject>, triggersWhen: String, setting:TestSetting) {
 
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
-        
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+
         do{
             let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
             let expectedActionsDict: [Dictionary<String, AnyObject>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]

--- a/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
@@ -92,8 +92,8 @@ class GetTriggerTests: SmallTestBase {
                 }
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/triggers/\(expectedTriggerID)")
              }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             setting.api.getTrigger(expectedTriggerID, completionHandler: { (trigger, error) -> Void in
@@ -166,8 +166,8 @@ class GetTriggerTests: SmallTestBase {
                 }
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/triggers/\(expectedTriggerID)")
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
             api._target = setting.target
@@ -229,8 +229,8 @@ class GetTriggerTests: SmallTestBase {
                     XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/triggers/\(triggerID)")
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             api.getTrigger(triggerID, completionHandler: { (trigger, error) -> Void in
                 if error == nil{
@@ -282,8 +282,8 @@ class GetTriggerTests: SmallTestBase {
                     XCTAssertEqual(value, request.valueForHTTPHeaderField(key))
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             api.getTrigger(triggerID, completionHandler: { (trigger, error) -> Void in
                 if error == nil{

--- a/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
@@ -57,8 +57,8 @@ class GetVendorThingIDTests: SmallTestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             setting.api.getVendorThingID( { (gotID: String?, error: ThingIFError?) -> Void in
@@ -110,8 +110,8 @@ class GetVendorThingIDTests: SmallTestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         setting.api.getVendorThingID( { (gotID: String?, error: ThingIFError?) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -284,7 +284,7 @@ class ThingIFSDKTests: SmallTestBase {
         do {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: setting.app.baseURL)!, statusCode: 200, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             iotSession = MockSession.self
         } catch {
             //should never reach this
@@ -377,7 +377,7 @@ class ThingIFSDKTests: SmallTestBase {
         do {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: setting.app.baseURL)!, statusCode: 200, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             iotSession = MockSession.self
         } catch {
             //should never reach this

--- a/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
@@ -89,10 +89,8 @@ class ListCommandsTests: SmallTestBase {
 
     func listCommandsSuccess(tag: String, testcase: TestCase) {
 
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        
         let setting = TestSetting()
         let api = setting.api
         let owner = setting.owner

--- a/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
@@ -140,8 +140,8 @@ class ListCommandsTests: SmallTestBase {
                     XCTAssertEqual(value, request.valueForHTTPHeaderField(key))
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api._target = setting.target
@@ -219,8 +219,8 @@ class ListCommandsTests: SmallTestBase {
                     XCTAssertEqual(value, request.valueForHTTPHeaderField(key))
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             api.listCommands(nil, paginationKey: nil, completionHandler: { (commands, paginationKey, error) -> Void in
                 if error == nil{

--- a/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
@@ -53,8 +53,8 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
             
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
             api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
@@ -110,8 +110,8 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
             
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
             api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
@@ -181,8 +181,8 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
         
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
         api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
@@ -229,8 +229,8 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
         
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
         api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
@@ -277,8 +277,8 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
         
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
         api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
@@ -325,8 +325,8 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
         
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
         api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
@@ -373,8 +373,8 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
         
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
         api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
@@ -54,8 +54,8 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
@@ -111,8 +111,8 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
@@ -182,8 +182,8 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
@@ -230,8 +230,8 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
@@ -278,8 +278,8 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
@@ -326,8 +326,8 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
@@ -374,8 +374,8 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/ListTriggeredServerCodeResultsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListTriggeredServerCodeResultsTests.swift
@@ -55,7 +55,7 @@ class ListTriggeredServerCodeResultsTests: SmallTestBase {
             }
             
             iotSession = MockMultipleSession.self
-            MockMultipleSession.responsePairs = [
+            sharedMockMultipleSession.responsePairs = [
                 ((data: resJson1, urlResponse: urlResponse1, error: nil), requestVerifier1),
                 ((data: resJson2, urlResponse: urlResponse2, error: nil), requestVerifier2)
             ]

--- a/ThingIFSDK/ThingIFSDKTests/ListTriggersTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListTriggersTests.swift
@@ -83,8 +83,8 @@ class ListTriggersTests: SmallTestBase {
                 }
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/triggers")
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.listTriggers(nil, paginationKey: nil, completionHandler: { (triggers, paginationKey, error) -> Void in
@@ -156,8 +156,8 @@ class ListTriggersTests: SmallTestBase {
                     XCTAssertEqual(value, request.valueForHTTPHeaderField(key))
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             api.getTrigger(triggerID, completionHandler: { (trigger, error) -> Void in
                 if error == nil{

--- a/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
@@ -52,8 +52,8 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 204, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.notifyOnboardingCompletion(endNode, completionHandler: { (error:ThingIFError?) -> Void in
@@ -177,8 +177,8 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.notifyOnboardingCompletion(endNode, completionHandler: { (error:ThingIFError?) -> Void in
@@ -231,8 +231,8 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.notifyOnboardingCompletion(endNode, completionHandler: { (error:ThingIFError?) -> Void in
@@ -285,8 +285,8 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.notifyOnboardingCompletion(endNode, completionHandler: { (error:ThingIFError?) -> Void in
@@ -339,8 +339,8 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.notifyOnboardingCompletion(endNode, completionHandler: { (error:ThingIFError?) -> Void in
@@ -393,8 +393,8 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.notifyOnboardingCompletion(endNode, completionHandler: { (error:ThingIFError?) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
@@ -84,8 +84,8 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             let src = [
@@ -174,8 +174,8 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
             statusCode: 403, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         let src = [
@@ -264,8 +264,8 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         let src = [
@@ -354,8 +354,8 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
             statusCode: 500, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         let src = [

--- a/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
@@ -50,8 +50,8 @@ class OnboardGatewayTests: GatewayAPITestBase {
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
         } catch(_) {
             XCTFail("should not throw error")
@@ -121,8 +121,8 @@ class OnboardGatewayTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.onboardGateway( { (gateway:Gateway?, error:ThingIFError?) -> Void in
@@ -169,8 +169,8 @@ class OnboardGatewayTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.onboardGateway( { (gateway:Gateway?, error:ThingIFError?) -> Void in
@@ -217,8 +217,8 @@ class OnboardGatewayTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.onboardGateway( { (gateway:Gateway?, error:ThingIFError?) -> Void in
@@ -265,8 +265,8 @@ class OnboardGatewayTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.onboardGateway( { (gateway:Gateway?, error:ThingIFError?) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
@@ -58,8 +58,8 @@ class OnboardingTests: SmallTestBase {
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/onboardings")
             }
             
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             
             iotSession = MockSession.self
             api.onboard("th.0267251d9d60-1858-5e11-3dc3-00f3f0b5", thingPassword: "dummyPassword") { ( target, error) -> Void in
@@ -126,8 +126,8 @@ class OnboardingTests: SmallTestBase {
                 self.verifyDict(expectedBody as! Dictionary<String, AnyObject>, actualData: request.HTTPBody!)
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/onboardings")
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
                 if error == nil{
@@ -214,8 +214,8 @@ class OnboardingTests: SmallTestBase {
                 self.verifyDict(expectedBody as! Dictionary<String, AnyObject>, actualData: request.HTTPBody!)
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/onboardings")
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
                 if error == nil{

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
@@ -25,7 +25,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_success"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
@@ -126,7 +126,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let api = setting.api
         let tag = "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_http_404"
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
         let expectedTargetAppID = "app000001"
@@ -202,7 +202,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_UnsupportError")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_UnsupportError")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         let predicate = SchedulePredicate(schedule: "'*/15 * * * *")
@@ -243,7 +243,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_target_not_available_error_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("PatchServerCodeTriggerTests.testPatchServerCodeTrigger_target_not_available_error_\(predicate.getEventSource().rawValue)")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
@@ -81,7 +81,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
                 }
             }
             iotSession = MockMultipleSession.self
-            MockMultipleSession.responsePairs = [
+            sharedMockMultipleSession.responsePairs = [
                 ((data: jsonData4Patch, urlResponse: urlResponse4Patch, error: nil), patchRequestVerifier),
                 ((data: jsonData4Get, urlResponse: urlResponse4Get, error: nil),getRequestVerifier)
             ]
@@ -166,8 +166,8 @@ class PatchServerCodeTriggerTests: SmallTestBase {
                     XCTFail(tag)
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
             api._target = setting.target

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -95,10 +95,8 @@ class PatchTriggerTests: SmallTestBase {
     }
 
     func patchTrigger(tag: String, testcase: TestCase) {
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
+        
         let setting = TestSetting()
         let api = setting.api
 
@@ -204,7 +202,7 @@ class PatchTriggerTests: SmallTestBase {
     }
 
     func testPatchTrigger_UnsupportError() {
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("patchTriggerUnsupportError")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("patchTriggerUnsupportError")
         let setting = TestSetting()
         let api = setting.api
 
@@ -234,7 +232,7 @@ class PatchTriggerTests: SmallTestBase {
         }
     }
     func testPatchTrigger_target_not_available_error() {
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPatchTrigger_target_not_available_error")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPatchTrigger_target_not_available_error")
         let setting = TestSetting()
         let api = setting.api
 

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -150,7 +150,7 @@ class PatchTriggerTests: SmallTestBase {
 
         if testcase.success {
             iotSession = MockMultipleSession.self
-            MockMultipleSession.responsePairs = [
+            sharedMockMultipleSession.responsePairs = [
                 ((data: nil, urlResponse: mockResponse1, error: nil),patchRequestVerifier),
                 ((data: jsonData!, urlResponse: mockResponse2, error: nil),getRequestVerifier)
             ]
@@ -160,8 +160,8 @@ class PatchTriggerTests: SmallTestBase {
             }catch(_){
                 XCTFail(tag)
             }
-            MockSession.mockResponse = (jsonData, urlResponse: mockResponse3, error: nil)
-            MockSession.requestVerifier = patchRequestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: mockResponse3, error: nil)
+            sharedMockSession.requestVerifier = patchRequestVerifier
             iotSession = MockSession.self
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -49,10 +49,7 @@ class PostNewCommandTests: SmallTestBase {
 
     func postCommandSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
 
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
         
         do {
             let expectedCommandID = "c6f1b8d0-46ea-11e5-a5eb-06d9d1527620"

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -84,8 +84,8 @@ class PostNewCommandTests: SmallTestBase {
                     XCTFail(tag)
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             setting.api.postNewCommand(testcase.schema, schemaVersion: testcase.schemaVersion, actions: testcase.actions, completionHandler: { (command, error) -> Void in
@@ -151,8 +151,8 @@ class PostNewCommandTests: SmallTestBase {
                     XCTFail()
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.postNewCommand("", schemaVersion: setting.schemaVersion, actions: [], completionHandler: { (command, error) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
@@ -135,10 +135,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
             tag: String,
             testcase: TestCase,
             setting:TestSetting) {
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription(tag)
-        defer{
-            expectation = nil
-        }
+        let expectation : XCTestExpectation! = self.expectationWithDescription(tag)
 
         do {
             let expectedCommandID = "c6f1b8d0-46ea-11e5-a5eb-06d9d1527620"

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
@@ -171,8 +171,8 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
                 expectedBody["metadata"] = testcase.metadata;
                 self.verifyDict(expectedBody, actualData: request.HTTPBody!)
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             setting.api.postNewCommand(
@@ -245,8 +245,8 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
                     XCTFail()
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.postNewCommand(CommandForm(

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
@@ -26,7 +26,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PostNewServerCodeTriggerTests.testPostNewTrigger_success"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
@@ -113,7 +113,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PostNewServerCodeTriggerTests.testPostNewServerCodeTrigger_http_404"
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
         let expectedTargetAppID = "app000001"
@@ -188,7 +188,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
     func testPostNewServerCodeTrigger_UnsupportError() {
         let setting:TestSetting = TestSetting()
         let api = setting.api
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_UnsupportError")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_UnsupportError")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         let predicate = SchedulePredicate(schedule: "'*/15 * * * *")
@@ -218,7 +218,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
     func testPostNewServerCodeTrigger_target_not_available_error() {
         let setting:TestSetting = TestSetting()
         let api = setting.api
-        weak var expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_target_not_available_error")
+        let expectation : XCTestExpectation! = self.expectationWithDescription("testPostNewServerCodeTrigger_target_not_available_error")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         let predicate = StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE)

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
@@ -68,8 +68,8 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
                 }
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/triggers")
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
             api._target = setting.target
@@ -153,8 +153,8 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
                     XCTFail(tag)
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
             api._target = setting.target

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
@@ -39,12 +39,10 @@ class PostNewTriggerTests: SmallTestBase {
     }
 
     func testPostNewTrigger_success() {
-        weak var expectation : XCTestExpectation!
-        defer {
-            expectation = nil
-        }
+
+
         func postNewTriggerSuccess(tag: String, testcase: TestCase, setting:TestSetting) {
-            expectation = self.expectationWithDescription(tag)
+            let expectation = self.expectationWithDescription(tag)
 
             do{
                 let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
@@ -95,8 +95,8 @@ class PostNewTriggerTests: SmallTestBase {
 
                     XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/triggers")
                 }
-                MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-                MockSession.requestVerifier = requestVerifier
+                sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+                sharedMockSession.requestVerifier = requestVerifier
                 iotSession = MockSession.self
 
                 setting.api.postNewTrigger(setting.schema, schemaVersion: setting.schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
@@ -213,8 +213,8 @@ class PostNewTriggerTests: SmallTestBase {
                     XCTFail()
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.postNewTrigger(schema, schemaVersion: schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
@@ -292,8 +292,8 @@ class PostNewTriggerTests: SmallTestBase {
                     XCTFail()
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.postNewTrigger(schema, schemaVersion: schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
@@ -367,8 +367,8 @@ class PostNewTriggerTests: SmallTestBase {
                     XCTFail()
                 }
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
             api.postNewTrigger(schema, schemaVersion: schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/PushInstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushInstallationTests.swift
@@ -61,8 +61,8 @@ class PushInstallationTests: SmallTestBase {
                 }
                 XCTAssertEqual(request.URL?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/onboardings")
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             setting.api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
                 if error == nil{
@@ -107,8 +107,8 @@ class PushInstallationTests: SmallTestBase {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
             
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 200, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
         }catch(_){
@@ -155,8 +155,8 @@ class PushInstallationTests: SmallTestBase {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
             
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 404, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
         }catch(_){
@@ -216,8 +216,8 @@ class PushInstallationTests: SmallTestBase {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
             
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 400, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
         }catch(_){
@@ -277,8 +277,8 @@ class PushInstallationTests: SmallTestBase {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
             
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 401, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
         }catch(_){

--- a/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
@@ -59,8 +59,8 @@ class PushUninstallationTests: SmallTestBase {
                 }
                 
             }
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             setting.api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
                 if error == nil{
@@ -100,8 +100,8 @@ class PushUninstallationTests: SmallTestBase {
         }
         
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 204, HTTPVersion: nil, headerFields: nil)
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
         setting.api.uninstallPush(installID) { (error) -> Void in
@@ -139,8 +139,8 @@ class PushUninstallationTests: SmallTestBase {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
             
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 404, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
         }catch(_){
@@ -197,8 +197,8 @@ class PushUninstallationTests: SmallTestBase {
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
             
             let urlResponse = NSHTTPURLResponse(URL: NSURL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 401, HTTPVersion: nil, headerFields: nil)
-            MockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
-            MockSession.requestVerifier = requestVerifier
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
         }catch(_){

--- a/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
@@ -51,8 +51,8 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 204, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.replaceEndNode(
@@ -188,8 +188,8 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.replaceEndNode(
@@ -245,8 +245,8 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.replaceEndNode(
@@ -302,8 +302,8 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.replaceEndNode(
@@ -359,8 +359,8 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.replaceEndNode(
@@ -416,8 +416,8 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         api.replaceEndNode(

--- a/ThingIFSDK/ThingIFSDKTests/SmallTestBase.swift
+++ b/ThingIFSDK/ThingIFSDKTests/SmallTestBase.swift
@@ -4,9 +4,9 @@ import XCTest
 class SmallTestBase: XCTestCase {
     override func setUp() {
         super.setUp()
-        MockSession.mockResponse = (data: nil, urlResponse: nil, error: nil)
-        MockSession.requestVerifier = {(request) in }
-        MockMultipleSession.responsePairs = [MockResponsePair?]()
+        sharedMockSession.mockResponse = (data: nil, urlResponse: nil, error: nil)
+        sharedMockSession.requestVerifier = {(request) in }
+        sharedMockMultipleSession.responsePairs = [MockResponsePair?]()
         ThingIFAPI.removeAllStoredInstances()
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/TestHelpers.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TestHelpers.swift
@@ -21,7 +21,6 @@ func failIfNotRunningOnDevice(){
 }
 typealias MockResponse = (data: NSData?, urlResponse: NSURLResponse?, error: NSError?)
 typealias MockResponsePair = (response: MockResponse,requestVerifier: ((NSURLRequest) -> Void))
-
 let sharedMockSession = MockSession()
 private class MockTask: NSURLSessionDataTask {
 
@@ -41,24 +40,26 @@ class MockSession: NSURLSession {
     var mockResponse: (data: NSData?, urlResponse: NSURLResponse?, error: NSError?) = (data: nil, urlResponse: nil, error: nil)
 
     override class func sharedSession() -> NSURLSession {
-        return MockSession()
+        return sharedMockSession
     }
 
     override func dataTaskWithRequest(request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask {
         self.requestVerifier(request)
 
+        self.completionHandler = completionHandler
         completionHandler(mockResponse.data, mockResponse.urlResponse, mockResponse.error)
         return MockTask()
     }
 
 }
-
+let sharedMockMultipleSession = MockMultipleSession()
 class MockMultipleSession: NSURLSession {
+
     var completionHandler: ((NSData!, NSURLResponse!, NSError!) -> Void)?
     var responsePairs = [MockResponsePair?]()
 
     override class func sharedSession() -> NSURLSession {
-        return MockMultipleSession()
+        return sharedMockMultipleSession
     }
 
     override func dataTaskWithRequest(request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask {

--- a/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
@@ -72,8 +72,8 @@ class UpdateVendorThingIDTests: SmallTestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
             statusCode: 204, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         setting.api.updateVendorThingID(
@@ -143,8 +143,8 @@ class UpdateVendorThingIDTests: SmallTestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         setting.api.updateVendorThingID(
@@ -220,8 +220,8 @@ class UpdateVendorThingIDTests: SmallTestBase {
         let urlResponse = NSHTTPURLResponse(URL: NSURL(string:setting.app.baseURL)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
-        MockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
-        MockSession.requestVerifier = requestVerifier
+        sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
+        sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
         setting.api.updateVendorThingID(


### PR DESCRIPTION
Problem : 
- Sometimes test is failed because of expiration timeout

Root cause : 
- Sometimes `NSOperationQueue` does not execute `MockingTask.resume()` on cumulative test execution.

Solution : 
- fix mocking by execute callback immediately (solve the expirations fail)

Improvements : 
- revert expectations declarations as let.
- load gateway api only once (improve test runtime)
- Make mocking as singleton (design improvement)
