### PR TITLE
TypedID.type is always lower case.

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		B6651A221CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6651A211CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift */; };
 		B68227F41C85823A00AB85D0 /* CommandSerializationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68227F31C85823A00AB85D0 /* CommandSerializationTest.swift */; };
 		B683A31B1CBB807A00742570 /* CommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B683A31A1CBB807A00742570 /* CommandFormTests.swift */; };
+		B68D7BE31CF83DFC00D69149 /* TypedIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68D7BE21CF83DFC00D69149 /* TypedIDTests.swift */; };
 		B6F9F2BD1CB22A4C009A990F /* CommandForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9F2BC1CB22A4C009A990F /* CommandForm.swift */; };
 		D5521C741CCDFDA200037C9F /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5521C731CCDFDA200037C9F /* Predicate.swift */; };
 		D5521C761CCDFE7600037C9F /* ServerCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5521C751CCDFE7600037C9F /* ServerCode.swift */; };
@@ -227,6 +228,7 @@
 		B6651A211CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewCommandWithCommandFormTests.swift; sourceTree = "<group>"; };
 		B68227F31C85823A00AB85D0 /* CommandSerializationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandSerializationTest.swift; sourceTree = "<group>"; };
 		B683A31A1CBB807A00742570 /* CommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandFormTests.swift; sourceTree = "<group>"; };
+		B68D7BE21CF83DFC00D69149 /* TypedIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedIDTests.swift; sourceTree = "<group>"; };
 		B6F9F2BC1CB22A4C009A990F /* CommandForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandForm.swift; sourceTree = "<group>"; };
 		D5521C731CCDFDA200037C9F /* Predicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Predicate.swift; sourceTree = "<group>"; };
 		D5521C751CCDFE7600037C9F /* ServerCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerCode.swift; sourceTree = "<group>"; };
@@ -417,6 +419,7 @@
 				2242770F1CEB2BB9004369EE /* GatewayAPIRestoreTests.swift */,
 				2255434C1CEC34A900C73418 /* GatewayAPIStoredInstanceTests.swift */,
 				2268EBA81CF2DA2E007F54E6 /* ListOnboardedEndNodesTests.swift */,
+				B68D7BE21CF83DFC00D69149 /* TypedIDTests.swift */,
 			);
 			path = ThingIFSDKTests;
 			sourceTree = "<group>";
@@ -642,6 +645,7 @@
 				7D36B6A11BD4D0CC00D9B821 /* DeleteTriggerTests.swift in Sources */,
 				7D36B6A31BD4D0CC00D9B821 /* EntitySerializationTests.swift in Sources */,
 				2254F2151CE9929E00703185 /* GetGatewayInformationTests.swift in Sources */,
+				B68D7BE31CF83DFC00D69149 /* TypedIDTests.swift in Sources */,
 				22537F8A1CE44E8C006C214D /* UpdateVendorThingIDTests.swift in Sources */,
 				22537F881CE44E42006C214D /* OnboardEndnodeWithGatewayTests.swift in Sources */,
 				A56B0A491C62143000E653EF /* PatchServerCodeTriggerTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/TypedID.swift
+++ b/ThingIFSDK/ThingIFSDK/TypedID.swift
@@ -30,8 +30,8 @@ public class TypedID : NSObject, NSCoding {
 
     /** Ininitialize TypedID with type and id.
 
-    - Parameter type: Type of the entity. If characters in this string
-      is upper case, characters in type property becomes low case.
+    - Parameter type: Type of the entity. All upper case characters in
+      given string are converted to lower case.
     - Parameter id: ID of the entity.
      */
     public init(type:String, id:String) {

--- a/ThingIFSDK/ThingIFSDK/TypedID.swift
+++ b/ThingIFSDK/ThingIFSDK/TypedID.swift
@@ -15,22 +15,27 @@ public class TypedID : NSObject, NSCoding {
 
     // MARK: - Implements NSCoding protocol
     public required init(coder aDecoder: NSCoder) {
-        self.type = aDecoder.decodeObjectForKey("type") as! String
+        self.type =
+            (aDecoder.decodeObjectForKey("type") as! String).lowercaseString
         self.id = aDecoder.decodeObjectForKey("id") as! String
     }
 
-    /** Type of the ID */
+    /** Type of the ID
+
+     All characters in this string are lower case.
+     */
     public let type:String
     /** ID of the entity. */
     public let id:String
 
     /** Ininitialize TypedID with type and id.
 
-    - Parameter type: Type of the entity.
+    - Parameter type: Type of the entity. If characters in this string
+      is upper case, characters in type property becomes low case.
     - Parameter id: ID of the entity.
      */
     public init(type:String, id:String) {
-        self.type = type
+        self.type = type.lowercaseString
         self.id = id
     }
 

--- a/ThingIFSDK/ThingIFSDKTests/TypedIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TypedIDTests.swift
@@ -1,0 +1,43 @@
+//
+//  TypedIDTests.swift
+//  ThingIFSDK
+//
+//  Created on 2016/05/27.
+//  Copyright 2016 Kii. All rights reserved.
+//
+
+import XCTest
+@testable import ThingIFSDK
+
+class TypedIDTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testTypedID() {
+        let typedID_A = TypedID(type: "THING", id: "id")
+        let typedID_B = TypedID(type: "thing", id: "id")
+        let typedID_C = TypedID(type: "Thing", id: "id")
+
+        XCTAssertEqual(typedID_A, typedID_B)
+        XCTAssertEqual(typedID_A, typedID_C)
+        XCTAssertEqual(typedID_B, typedID_C)
+
+        XCTAssertEqual(typedID_A.type, typedID_B.type)
+        XCTAssertEqual(typedID_A.type, typedID_C.type)
+        XCTAssertEqual(typedID_B.type, typedID_C.type)
+
+        XCTAssertEqual("thing", typedID_A.type)
+        XCTAssertEqual("thing", typedID_B.type)
+        XCTAssertEqual("thing", typedID_C.type)
+
+        XCTAssertEqual("id", typedID_A.id)
+        XCTAssertEqual("id", typedID_B.id)
+        XCTAssertEqual("id", typedID_C.id)
+
+    }
+}


### PR DESCRIPTION
`TypedID.type` should be case ignored but current SDK implementation does not satisfy this specification.

Type of `ThingIFAPI.target.typedID" is uppercase "THING" but Type of`Trigger.command.targetID" which is retrieved by `ThingIFAPI#listTriggers()` is lowercase "thing".

`TypedID.type` is string, so using `String#caseInsensitiveCompare()` is OK but it is little troublesome for application programmer, I think.

In this PR, I fixed that `TypeID.type` becomes always lowercase.

Related spreadsheet issue: No 873
Related github issue: #123 
