### PR TITLE
Fix request error handling bug

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		B6F9F2BD1CB22A4C009A990F /* CommandForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F9F2BC1CB22A4C009A990F /* CommandForm.swift */; };
 		D5521C741CCDFDA200037C9F /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5521C731CCDFDA200037C9F /* Predicate.swift */; };
 		D5521C761CCDFE7600037C9F /* ServerCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5521C751CCDFE7600037C9F /* ServerCode.swift */; };
+		D55D26291D3DFD8F00745A17 /* IoTRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55D26281D3DFD8F00745A17 /* IoTRequestTests.swift */; };
 		D5636AFB1CE1E9E000760564 /* ScheduleOncePredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5636AFA1CE1E9E000760564 /* ScheduleOncePredicate.swift */; };
 		D5636AFD1CE1EAFC00760564 /* StatePredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5636AFC1CE1EAFC00760564 /* StatePredicate.swift */; };
 		D5636AFF1CE1EB4200760564 /* SchedulePredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5636AFE1CE1EB4200760564 /* SchedulePredicate.swift */; };
@@ -251,6 +252,7 @@
 		B6F9F2BC1CB22A4C009A990F /* CommandForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandForm.swift; sourceTree = "<group>"; };
 		D5521C731CCDFDA200037C9F /* Predicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Predicate.swift; sourceTree = "<group>"; };
 		D5521C751CCDFE7600037C9F /* ServerCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerCode.swift; sourceTree = "<group>"; };
+		D55D26281D3DFD8F00745A17 /* IoTRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IoTRequestTests.swift; sourceTree = "<group>"; };
 		D5636AFA1CE1E9E000760564 /* ScheduleOncePredicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduleOncePredicate.swift; sourceTree = "<group>"; };
 		D5636AFC1CE1EAFC00760564 /* StatePredicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatePredicate.swift; sourceTree = "<group>"; };
 		D5636AFE1CE1EB4200760564 /* SchedulePredicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchedulePredicate.swift; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 				2242770F1CEB2BB9004369EE /* GatewayAPIRestoreTests.swift */,
 				2255434C1CEC34A900C73418 /* GatewayAPIStoredInstanceTests.swift */,
 				2268EBA81CF2DA2E007F54E6 /* ListOnboardedEndNodesTests.swift */,
+				D55D26281D3DFD8F00745A17 /* IoTRequestTests.swift */,
 			);
 			path = ThingIFSDKTests;
 			sourceTree = "<group>";
@@ -697,6 +700,7 @@
 				B683A31B1CBB807A00742570 /* CommandFormTests.swift in Sources */,
 				743800F81C29303A005D8458 /* TestSetting.swift in Sources */,
 				7D36B6A01BD4D0CC00D9B821 /* copyWithTarget.swift in Sources */,
+				D55D26291D3DFD8F00745A17 /* IoTRequestTests.swift in Sources */,
 				7D36B6AC1BD4D0CC00D9B821 /* PatchTriggerTests.swift in Sources */,
 				7D36B6A51BD4D0CC00D9B821 /* GetStateTests.swift in Sources */,
 				7D36B6A91BD4D0CC00D9B821 /* ListCommandsTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/IoTOperations/IoTRequestOperation.swift
+++ b/ThingIFSDK/ThingIFSDK/IoTOperations/IoTRequestOperation.swift
@@ -195,6 +195,8 @@ class IoTRequestOperation<T>: GroupOperation {
                 }else {
                     completionHandler(response: nil, error: nil)
                 }
+            }else{
+                completionHandler(response: nil, error: ThingIFError.ERROR_REQUEST(required: errorOptional!))
             }
         })
         let taskOperation = URLSessionTaskOperation(task: task)
@@ -246,6 +248,8 @@ class IoTRequestOperation<T>: GroupOperation {
                     kiiDebugLog("Response Body serialized: \(serialized)")
                     completionHandler(response: serialized, error: nil)
                 }
+            }else{
+                completionHandler(response: nil, error: ThingIFError.ERROR_REQUEST(required: errorOptional!))
             }
         })
         let taskOperation = URLSessionTaskOperation(task: task)

--- a/ThingIFSDK/ThingIFSDK/ThingIFError.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFError.swift
@@ -34,4 +34,6 @@ public enum ThingIFError : ErrorType {
     case INVALID_STORED_API
     /** when trying to access Gateway but user is not logged in*/
     case USER_IS_NOT_LOGGED_IN
+    /** whenever request operation is failed. (i.e invalid URL) */
+    case ERROR_REQUEST(required: NSError)
 }

--- a/ThingIFSDK/ThingIFSDKTests/IoTRequestTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTRequestTests.swift
@@ -1,0 +1,66 @@
+//
+//  IoTRequestTests.swift
+//  ThingIFSDK
+//
+//  Created by syahRiza on 7/19/16.
+//  Copyright © 2016 Kii. All rights reserved.
+//
+
+import XCTest
+@testable import ThingIFSDK
+
+class IoTRequestTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testRequestInvalidURL(){
+        let operationQueue = OperationQueue()
+        let expectation = self.expectationWithDescription("testRequestInvalidURL")
+        let appID = "dummyApp"
+        let targetStr = "dummy_target"
+        let triggerID = "dummy_id"
+        let baseURL = "https://https://dummy"
+        let accessToken = "accessToken"
+
+        let enableString = "enable"
+
+        let requestURL = "\(baseURL)/thing-if/apps/\(appID)/targets/\(targetStr)/triggers/\(triggerID)/\(enableString)"
+
+        // generate header
+        let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(accessToken)", "content-type": "application/json"]
+
+        let request = buildDefaultRequest(HTTPMethod.PUT,urlString: requestURL, requestHeaderDict: requestHeaderDict, requestBodyData: nil, completionHandler: { (response, error) -> Void in
+            if error == nil {
+                XCTFail("Should not be nil")
+            }else{
+                switch error! {
+                case .CONNECTION:
+                    XCTFail(": should not be connection")
+                case .ERROR_REQUEST(let actualErrorRequest):
+                    XCTAssertEqual("A server with the specified hostname could not be found.",
+                        actualErrorRequest.localizedDescription)
+                default:
+                    XCTFail("Invalid error")
+                }
+            }
+            expectation.fulfill()
+        })
+
+        let operation = IoTRequestOperation(request: request)
+        operationQueue.addOperation(operation)
+        self.waitForExpectationsWithTimeout(30) { (error) in
+            if error != nil {
+                XCTFail()
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Problem

Apps that use thing-if-iosSDK could be not responsive if developer define (accidentally/intentionally) invalid baseURL.
## Root cause

There is no error handling on IoT request operation.
## Changes
- Add ThingIFError enum for request error
- Fix IoTRequestOperations
- Add test case
