### PR TITLE
Target is added to patchTrigger.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -97,6 +97,7 @@ extension ThingIFAPI {
         triggerID:String,
         schemaName:String?,
         schemaVersion:Int?,
+        commandTarget:Target?,
         actions:[Dictionary<String, AnyObject>]?,
         predicate:Predicate?,
         completionHandler: (Trigger?, ThingIFError?) -> Void
@@ -129,6 +130,9 @@ extension ThingIFAPI {
             }
             if schemaVersion != nil {
                 commandDict["schemaVersion"] = schemaVersion!
+            }
+            if commandTarget != nil {
+                commandDict["target"] = commandTarget!.typedID.toString()
             }
             if actions != nil {
                 commandDict["actions"] = actions

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -449,7 +449,7 @@ public class ThingIFAPI: NSObject, NSCoding {
         completionHandler: (Trigger?, ThingIFError?)-> Void
         )
     {
-        _patchTrigger(triggerID, schemaName: schemaName, schemaVersion: schemaVersion, actions: actions, predicate: predicate, completionHandler: completionHandler)
+        _patchTrigger(triggerID, schemaName: schemaName, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: actions, predicate: predicate, completionHandler: completionHandler)
     }
     
     /** Apply patch to a registered Trigger

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -433,7 +433,8 @@ public class ThingIFAPI: NSObject, NSCoding {
     Trigger is defined.
     - Parameter schemaVersion: Version of the Schema of which the Command
     specified in Trigger is defined.
-    - Parameter commandTarget: new target for Command in Trigger. This is optional.
+    - Parameter commandTarget: new target for Command in Trigger. Every kind of target can be set.
+    But the owner has to be identical in Command and ThingIFAPI. This is optional.
     - Parameter actions: Modified Actions to be applied as patch.
     - Parameter predicate: Modified Predicate to be applied as patch.
     - Parameter completionHandler: A closure to be executed once finished. The closure takes 2 arguments: 1st one is the modified Trigger instance, 2nd one is an ThingIFError instance when failed.

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -433,6 +433,7 @@ public class ThingIFAPI: NSObject, NSCoding {
     Trigger is defined.
     - Parameter schemaVersion: Version of the Schema of which the Command
     specified in Trigger is defined.
+    - Parameter commandTarget: new target for Command in Trigger. This is optional.
     - Parameter actions: Modified Actions to be applied as patch.
     - Parameter predicate: Modified Predicate to be applied as patch.
     - Parameter completionHandler: A closure to be executed once finished. The closure takes 2 arguments: 1st one is the modified Trigger instance, 2nd one is an ThingIFError instance when failed.
@@ -441,6 +442,7 @@ public class ThingIFAPI: NSObject, NSCoding {
         triggerID:String,
         schemaName:String?,
         schemaVersion:Int?,
+        commandTarget:Target? = nil,
         actions:[Dictionary<String, AnyObject>]?,
         predicate:Predicate?,
         completionHandler: (Trigger?, ThingIFError?)-> Void

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -26,6 +26,7 @@ class PatchTriggerTests: SmallTestBase {
 
         let schemaName: String?
         let schemaVersion: Int?
+        let commandTarget: Target?
         let actions: [Dictionary<String, AnyObject>]?
 
         let predicate: Predicate?
@@ -45,6 +46,9 @@ class PatchTriggerTests: SmallTestBase {
             }
             if schemaVersion != nil {
                 commandDict["schemaVersion"] = schemaVersion!
+            }
+            if commandTarget != nil {
+                commandDict["target"] = commandTarget!.typedID.toString()
             }
             if actions != nil {
                 commandDict["actions"] = actions!
@@ -79,16 +83,46 @@ class PatchTriggerTests: SmallTestBase {
 
         let testsCases: [TestCase] = [
             //
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: NotEqualsClause(field: "power", boolValue: true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "not", "clause": ["type":"eq","field":"power", "value": true]], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: nil, actions: nil, predicate: StatePredicate(condition: Condition(clause: RangeClause(field: "color", upperLimitInt: 255, upperIncluded:true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "range", "field": "color", "upperLimit": 255, "upperIncluded": true], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: expectedActions, predicate: ScheduleOncePredicate(scheduleAt: NSDate(timeIntervalSinceNow: 1000)), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: schemaVersion, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: nil, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: nil, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: NotEqualsClause(field: "power", boolValue: true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "not", "clause": ["type":"eq","field":"power", "value": true]], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: nil, commandTarget: nil, actions: nil, predicate: StatePredicate(condition: Condition(clause: RangeClause(field: "color", upperLimitInt: 255, upperIncluded:true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "range", "field": "color", "upperLimit": 255, "upperIncluded": true], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: ScheduleOncePredicate(scheduleAt: NSDate(timeIntervalSinceNow: 1000)), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: nil, commandTarget: nil, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: nil, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
             
         ]
+        for (index,testCase) in testsCases.enumerate() {
+            patchTrigger("testPatchTrigger_\(index)", testcase: testCase)
+        }
+    }
+
+    func testPatchTriggerWithCommandTarget() {
+
+        let expectedActions: [Dictionary<String, AnyObject>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+        let owner = setting.owner
+        let schema = setting.schema
+        let schemaVersion = setting.schemaVersion
+        let commandTarget = StandaloneThing(thingID: "commandThingID", vendorThingID: "commandVendorThingID")
+
+        // perform onboarding
+        api._target = setting.target
+
+        let testsCases: [TestCase] = [
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: NotEqualsClause(field: "power", boolValue: true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "not", "clause": ["type":"eq","field":"power", "value": true]], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: nil, commandTarget: commandTarget, actions: nil, predicate: StatePredicate(condition: Condition(clause: RangeClause(field: "color", upperLimitInt: 255, upperIncluded:true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "range", "field": "color", "upperLimit": 255, "upperIncluded": true], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: ScheduleOncePredicate(scheduleAt: NSDate(timeIntervalSinceNow: 1000)), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: nil, commandTarget: commandTarget, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: nil, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+
+            ]
         for (index,testCase) in testsCases.enumerate() {
             patchTrigger("testPatchTrigger_\(index)", testcase: testCase)
         }
@@ -167,7 +201,7 @@ class PatchTriggerTests: SmallTestBase {
 
 
         api._target = setting.target
-        api.patchTrigger(expectedTriggerID, schemaName: testcase.schemaName, schemaVersion: testcase.schemaVersion, actions: testcase.actions, predicate: testcase.predicate, completionHandler: { (trigger, error) -> Void in
+        api.patchTrigger(expectedTriggerID, schemaName: testcase.schemaName, schemaVersion: testcase.schemaVersion, commandTarget: testcase.commandTarget, actions: testcase.actions, predicate: testcase.predicate, completionHandler: { (trigger, error) -> Void in
             if testcase.success {
                 if error == nil{
                     XCTAssertEqual(trigger!.triggerID, expectedTriggerID, tag)


### PR DESCRIPTION
To patch cross thing trigger, I added commandTarget argument to `patchTrigger(triggerID:schemaName:schemaVersion:actions:predicate:completionHandler)`.

target argument has default value and can be nil. If nil, target is not send.

Related issue: No. 953
#153
