### PR TITLE
Adapt swift2.3

### DIFF
--- a/ThingIFSDK/Documentation/jazzy-options.js
+++ b/ThingIFSDK/Documentation/jazzy-options.js
@@ -6,7 +6,7 @@
     "author_url": "http://kii.com",
     "github_url": "https://github.com/KiiPlatform/thing-if-iOSSDK",
     "output": "docs",
-    "swift-version": "2",
+    "swift-version": "3",
 
     "doc-archive-prefix": "ThingIFSDK-Documentation",
 

--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -577,8 +577,15 @@
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Kii;
 				TargetAttributes = {
+					7DD44DB91BD4B7CD00AE0249 = {
+						LastSwiftMigration = 0800;
+					};
+					7DD44DEB1BD4B88A00AE0249 = {
+						LastSwiftMigration = 0800;
+					};
 					B63FC8A81CEEDBFF0042C747 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -890,6 +897,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -910,6 +918,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Kii-Corporation.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -925,6 +934,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "Kii-Corporation.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -936,6 +946,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "Kii-Corporation.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -950,6 +961,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kii.ThingIFSDKLargeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -962,6 +974,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kii.ThingIFSDKLargeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -17,6 +17,9 @@ public class GatewayAPI: NSObject, NSCoding {
     public let tag: String?
     public let app: App
     public let gatewayAddress: NSURL
+    private var gatewayAddressString: String {
+        return self.gatewayAddress.absoluteString!
+    }
 
     private var accessToken: String?
 
@@ -67,7 +70,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/token"
+        let requestURL = "\(self.gatewayAddressString)/\(self.app.siteName)/token"
 
         // generate header
         let credential = "\(self.app.appID):\(self.app.appKey)"
@@ -125,7 +128,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/onboarding"
+        let requestURL = "\(self.gatewayAddressString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/onboarding"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -167,7 +170,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/id"
+        let requestURL = "\(self.gatewayAddressString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/id"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -202,7 +205,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/onboarded"
+        let requestURL = "\(self.gatewayAddressString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/onboarded"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -250,7 +253,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/pending"
+        let requestURL = "\(self.gatewayAddressString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/pending"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -305,7 +308,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(endNode.vendorThingID)"
+        let requestURL = "\(self.gatewayAddressString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(endNode.vendorThingID)"
 
         // generate header
         var requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -354,7 +357,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString!)/gateway-app/gateway/restore"
+        let requestURL = "\(self.gatewayAddressString)/gateway-app/gateway/restore"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -397,7 +400,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/THING_ID:\(endNodeThingID)"
+        let requestURL = "\(self.gatewayAddressString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/THING_ID:\(endNodeThingID)"
 
         // generate header
         var requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -446,7 +449,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString!)/gateway-info"
+        let requestURL = "\(self.gatewayAddressString)/gateway-info"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -67,7 +67,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString)/\(self.app.siteName)/token"
+        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/token"
 
         // generate header
         let credential = "\(self.app.appID):\(self.app.appKey)"
@@ -125,7 +125,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/onboarding"
+        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/onboarding"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -167,7 +167,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/id"
+        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/id"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -202,7 +202,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/onboarded"
+        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/onboarded"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -250,7 +250,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/pending"
+        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/pending"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -305,7 +305,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(endNode.vendorThingID)"
+        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(endNode.vendorThingID)"
 
         // generate header
         var requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -354,7 +354,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString)/gateway-app/gateway/restore"
+        let requestURL = "\(self.gatewayAddress.absoluteString!)/gateway-app/gateway/restore"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -397,7 +397,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/THING_ID:\(endNodeThingID)"
+        let requestURL = "\(self.gatewayAddress.absoluteString!)/\(self.app.siteName)/apps/\(self.app.appID)/gateway/end-nodes/THING_ID:\(endNodeThingID)"
 
         // generate header
         var requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()
@@ -446,7 +446,7 @@ public class GatewayAPI: NSObject, NSCoding {
             return;
         }
 
-        let requestURL = "\(self.gatewayAddress.absoluteString)/gateway-info"
+        let requestURL = "\(self.gatewayAddress.absoluteString!)/gateway-info"
 
         // generate header
         let requestHeaderDict:Dictionary<String, String> = generateAuthBearerHeader()

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
@@ -42,7 +42,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 204, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -107,7 +107,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -154,7 +154,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -201,7 +201,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIRestoreTests.swift
@@ -29,7 +29,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "POST")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/gateway-app/gateway/restore"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/gateway-app/gateway/restore"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -94,7 +94,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "POST")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/gateway-app/gateway/restore"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/gateway-app/gateway/restore"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -141,7 +141,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "POST")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/gateway-app/gateway/restore"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/gateway-app/gateway/restore"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -188,7 +188,7 @@ class GatewayAPIRestoreTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "POST")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/gateway-app/gateway/restore"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/gateway-app/gateway/restore"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
@@ -31,7 +31,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
             let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.HTTPMethod, "GET")
                 // verify path
-                let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
+                let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
                 XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
                 //verify header
                 let expectedHeader = [
@@ -103,7 +103,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -151,7 +151,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -199,7 +199,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -247,7 +247,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -295,7 +295,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/id"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayIDTests.swift
@@ -46,7 +46,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
             // mock response
             let dict = ["thingID": gatewayID]
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
-            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
@@ -116,7 +116,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -164,7 +164,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -212,7 +212,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -260,7 +260,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -308,7 +308,7 @@ class GetGatewayIDTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
@@ -46,7 +46,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
             // mock response
             let dict = ["vendorThingID": vendorThingID]
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
-            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
@@ -116,7 +116,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)

--- a/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetGatewayInformationTests.swift
@@ -31,7 +31,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
             let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.HTTPMethod, "GET")
                 // verify path
-                let expectedPath = "\(api.gatewayAddress.absoluteString)/gateway-info"
+                let expectedPath = "\(api.gatewayAddress.absoluteString!)/gateway-info"
                 XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
                 //verify header
                 let expectedHeader = [
@@ -103,7 +103,7 @@ class GetGatewayInformationTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/gateway-info"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/gateway-info"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [

--- a/ThingIFSDK/ThingIFSDKTests/IoTRequestTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTRequestTests.swift
@@ -37,6 +37,8 @@ class IoTRequestTests: XCTestCase {
         // generate header
         let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(accessToken)", "content-type": "application/json"]
 
+        iotSession = NSURLSession.self
+
         let request = buildDefaultRequest(HTTPMethod.PUT,urlString: requestURL, requestHeaderDict: requestHeaderDict, requestBodyData: nil, completionHandler: { (response, error) -> Void in
             if error == nil {
                 XCTFail("Should not be nil")

--- a/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
@@ -117,7 +117,7 @@ class ListCommandsTests: SmallTestBase {
                 // verify path
                 let expectedBasePath = "\(setting.app.baseURL)/thing-if/apps/\(setting.api.appID!)/targets/\(setting.target.typedID.toString())/commands"
                 let actualRequestPathString = request.URL!.absoluteString
-                XCTAssertTrue(actualRequestPathString.rangeOfString(expectedBasePath) != nil, tag)
+                XCTAssertTrue(actualRequestPathString!.rangeOfString(expectedBasePath) != nil, tag)
                 if testcase.paginationKey != nil || testcase.bestEffortLimit != nil {
                     let expectedURL = setting.app.baseURL + "/thing-if/apps/50a62843/targets/\(setting.target.typedID.toString())/commands"
                     var queryParams = ""

--- a/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
@@ -50,7 +50,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             // mock response
             let dict = [ "results": list ]
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
-            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
             
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
@@ -107,7 +107,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             // mock response
             let dict = [ "results": list ]
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
-            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
             
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
@@ -178,7 +178,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         }
         
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
         
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -226,7 +226,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         }
         
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
         
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -274,7 +274,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         }
         
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
         
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -322,7 +322,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         }
         
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
         
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -370,7 +370,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         }
         
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
         
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)

--- a/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
@@ -35,7 +35,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.HTTPMethod, "GET")
                 // verify path
-                let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
+                let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
                 XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
                 //verify header
                 let expectedHeader = [
@@ -92,7 +92,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.HTTPMethod, "GET")
                 // verify path
-                let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
+                let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
                 XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
                 //verify header
                 let expectedHeader = [
@@ -165,7 +165,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -213,7 +213,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -261,7 +261,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -309,7 +309,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -357,7 +357,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/onboarded"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [

--- a/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
@@ -51,7 +51,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             // mock response
             let dict = [ "results": list ]
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
-            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
@@ -108,7 +108,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             // mock response
             let dict = [ "results": list ]
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
-            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
@@ -179,7 +179,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -227,7 +227,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -275,7 +275,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -323,7 +323,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -371,7 +371,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)

--- a/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
@@ -36,7 +36,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.HTTPMethod, "GET")
                 // verify path
-                let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
+                let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
                 XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
                 //verify header
                 let expectedHeader = [
@@ -93,7 +93,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.HTTPMethod, "GET")
                 // verify path
-                let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
+                let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
                 XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
                 //verify header
                 let expectedHeader = [
@@ -166,7 +166,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -214,7 +214,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -262,7 +262,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -310,7 +310,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -358,7 +358,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "GET")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/pending"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [

--- a/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
@@ -49,7 +49,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 204, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -174,7 +174,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -228,7 +228,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -282,7 +282,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -336,7 +336,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -390,7 +390,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)

--- a/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/NotifyOnboardingCompletionTests.swift
@@ -32,7 +32,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -157,7 +157,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -211,7 +211,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -265,7 +265,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -319,7 +319,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -373,7 +373,7 @@ class NotifyOnboardingCompletionTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/VENDOR_THING_ID:\(vendorThingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [

--- a/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
@@ -32,7 +32,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
             let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.HTTPMethod, "POST")
                 // verify path
-                let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
+                let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
                 XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
                 //verify header
                 let expectedHeader = [
@@ -105,7 +105,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "POST")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -153,7 +153,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "POST")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -201,7 +201,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "POST")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -249,7 +249,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "POST")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/onboarding"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [

--- a/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardGatewayTests.swift
@@ -47,7 +47,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
             // mock response
             let dict = ["thingID": thingID, "vendorThingID": vendorThingID]
             let jsonData = try NSJSONSerialization.dataWithJSONObject(dict, options: .PrettyPrinted)
-            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+            let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
                 statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
@@ -118,7 +118,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -166,7 +166,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -214,7 +214,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -262,7 +262,7 @@ class OnboardGatewayTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)

--- a/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
@@ -31,7 +31,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -168,7 +168,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -225,7 +225,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -282,7 +282,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -339,7 +339,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [
@@ -396,7 +396,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         let requestVerifier: ((NSURLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.HTTPMethod, "PUT")
             // verify path
-            let expectedPath = "\(api.gatewayAddress.absoluteString)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
+            let expectedPath = "\(api.gatewayAddress.absoluteString!)/\(api.app.siteName)/apps/\(api.app.appID)/gateway/end-nodes/THING_ID:\(thingID)"
             XCTAssertEqual(request.URL!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [

--- a/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ReplaceEndNodeTests.swift
@@ -48,7 +48,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 204, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -185,7 +185,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 400, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -242,7 +242,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 401, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -299,7 +299,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 404, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -356,7 +356,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 409, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)
@@ -413,7 +413,7 @@ class ReplaceEndNodeTests: GatewayAPITestBase {
         }
 
         // mock response
-        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString)!,
+        let urlResponse = NSHTTPURLResponse(URL: NSURL(string:api.gatewayAddress.absoluteString!)!,
             statusCode: 503, HTTPVersion: nil, headerFields: nil)
 
         sharedMockSession.mockResponse = (nil, urlResponse: urlResponse, error: nil)

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "7.2"
+    version: "8.0"
   environment:
     default_destination: platform=iOS Simulator,name=iPhone 6,OS=latest
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,13 @@ dependencies:
     - sudo update_rubygems
 test:
   pre:
+    # This is workaround.
+    # xcinvoke-0.2.1 is not adapt Xcode 8.
+    # xcinvoke-0.2.1 is used from jazzy-0.7.2.
+    # So we need to fix to generate document with this workaround.
+    # ref: https://github.com/segiddins/xcinvoke/issues/6
+    - sed "s/cmd = \[@xcrun_path\] + cmd/cmd = \['xcrun'\] + cmd/g" /usr/local/lib/ruby/gems/2.3.0/gems/xcinvoke-0.2.1/lib/xcinvoke/xcode.rb > xcode.rb
+    - sudo mv xcode.rb /usr/local/lib/ruby/gems/2.3.0/gems/xcinvoke-0.2.1/lib/xcinvoke
     # Build sdk
     - cd ThingIFSDK; make all
     # Copy docs to artifacts


### PR DESCRIPTION
XCode8へ移行した結果、thing-if-iOSSDKがビルドできなくなりました。ビルドを成功させるために、幾つかの修正を行いました。

このブランチは、ビルドを成功させるまでのトピックブランチとなっています。
このPRに含まれる修正は全て別のPRでレビュー済みです。

Circle CI上でのビルドが成功するようになりましたので、マージをお願いします。
