### PR TITLE
MockSession should not be used in IoTRequestTests.

### DIFF
--- a/ThingIFSDK/ThingIFSDKTests/IoTRequestTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTRequestTests.swift
@@ -37,6 +37,8 @@ class IoTRequestTests: XCTestCase {
         // generate header
         let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(accessToken)", "content-type": "application/json"]
 
+        iotSession = NSURLSession.self
+
         let request = buildDefaultRequest(HTTPMethod.PUT,urlString: requestURL, requestHeaderDict: requestHeaderDict, requestBodyData: nil, completionHandler: { (response, error) -> Void in
             if error == nil {
                 XCTFail("Should not be nil")


### PR DESCRIPTION
IoTRequestTestの中で実際のNSURLSessionを使うべき部分があります。しかし、外部変数のiotSessionが他のテストでsharedMockSessionに変わってしまっているため、MockSessionが利用されていました。

MockSessionが使われているために、テストが失敗しているのを修正しました。

Related PR: #159 
