### PR TITLE
Workaround for generating API document is added.

### DIFF
--- a/ThingIFSDK/Documentation/jazzy-options.js
+++ b/ThingIFSDK/Documentation/jazzy-options.js
@@ -6,7 +6,7 @@
     "author_url": "http://kii.com",
     "github_url": "https://github.com/KiiPlatform/thing-if-iOSSDK",
     "output": "docs",
-    "swift-version": "2",
+    "swift-version": "3",
 
     "doc-archive-prefix": "ThingIFSDK-Documentation",
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,13 @@ dependencies:
     - sudo update_rubygems
 test:
   pre:
+    # This is workaround.
+    # xcinvoke-0.2.1 is not adapt Xcode 8.
+    # xcinvoke-0.2.1 is used from jazzy-0.7.2.
+    # So we need to fix to generate document with this workaround.
+    # ref: https://github.com/segiddins/xcinvoke/issues/6
+    - sed "s/cmd = \[@xcrun_path\] + cmd/cmd = \['xcrun'\] + cmd/g" /usr/local/lib/ruby/gems/2.3.0/gems/xcinvoke-0.2.1/lib/xcinvoke/xcode.rb > xcode.rb
+    - sudo mv xcode.rb /usr/local/lib/ruby/gems/2.3.0/gems/xcinvoke-0.2.1/lib/xcinvoke
     # Build sdk
     - cd ThingIFSDK; make all
     # Copy docs to artifacts


### PR DESCRIPTION
XCode8に変更したところ、APIドキュメントの作成に失敗するようになりました。APIドキュメント作成失敗のため、Circle CIのビルドが失敗しています。

このPRでは、APIドキュメントを作成するためのworkaroundを追加しています。

失敗している理由はxcinvokeというライブラリがxcode8へ対応していないことが原因です。
詳細については、[こちらのissue](https://github.com/segiddins/xcinvoke/issues/6)をご確認ください。

xcinvokeがxcode8への対応をするまでworkaroundで対応しようと考えております。

Related PR: #159
