### PR TITLE
TriggerOptions argument is added to postNewTrigger and patchTrigger for server code.

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		A56B0A491C62143000E653EF /* PatchServerCodeTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B0A481C62143000E653EF /* PatchServerCodeTriggerTests.swift */; };
 		B60BBBD21DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */; };
 		B6323D291DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */; };
+		B6323D2B1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */; };
 		B63FC8AE1CEEDBFF0042C747 /* ThingIFSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DD44DE91BD4B7CD00AE0249 /* ThingIFSDK.framework */; };
 		B63FC8B51CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63FC8B41CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift */; };
 		B6651A221CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6651A211CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift */; };
@@ -261,6 +262,7 @@
 		A56B0A481C62143000E653EF /* PatchServerCodeTriggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchServerCodeTriggerTests.swift; sourceTree = "<group>"; };
 		B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
 		B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
+		B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewServerCodeTriggerWithTriggerOptionsTests.swift; sourceTree = "<group>"; };
 		B63FC8A91CEEDBFF0042C747 /* ThingIFSDKLargeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ThingIFSDKLargeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B63FC8AD1CEEDBFF0042C747 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B63FC8B41CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewTriggerForSchedulePredicateTests.swift; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 				7D36B69E1BD4D0CC00D9B821 /* TestHelpers.swift */,
 				7D36B69F1BD4D0CC00D9B821 /* XCTest+Utils.swift */,
 				A56B0A461C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift */,
+				B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */,
 				A56B0A481C62143000E653EF /* PatchServerCodeTriggerTests.swift */,
 				A54C7C1C1C631B7300A38940 /* ListTriggeredServerCodeResultsTests.swift */,
 				743800F71C29303A005D8458 /* TestSetting.swift */,
@@ -776,6 +779,7 @@
 				B68227F41C85823A00AB85D0 /* CommandSerializationTest.swift in Sources */,
 				7D36B6AE1BD4D0CC00D9B821 /* PostNewTriggerTests.swift in Sources */,
 				226C79871D4F19B700E8C440 /* OnboardTests.swift in Sources */,
+				B6323D2B1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift in Sources */,
 				22ADEC071C89899B00F487D9 /* PredicateNSCodingTests.swift in Sources */,
 				22F2E7801C8D60BD0011F85C /* TriggerNSCodingTests.swift in Sources */,
 				7D36B6A11BD4D0CC00D9B821 /* DeleteTriggerTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		B60BBBD21DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */; };
 		B6323D291DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */; };
 		B6323D2B1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */; };
+		B6323D2D1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D2C1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift */; };
 		B63FC8AE1CEEDBFF0042C747 /* ThingIFSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DD44DE91BD4B7CD00AE0249 /* ThingIFSDK.framework */; };
 		B63FC8B51CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63FC8B41CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift */; };
 		B6651A221CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6651A211CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift */; };
@@ -263,6 +264,7 @@
 		B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
 		B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
 		B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewServerCodeTriggerWithTriggerOptionsTests.swift; sourceTree = "<group>"; };
+		B6323D2C1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchServerCodeTriggerWIthTriggerOptionsTests.swift; sourceTree = "<group>"; };
 		B63FC8A91CEEDBFF0042C747 /* ThingIFSDKLargeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ThingIFSDKLargeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B63FC8AD1CEEDBFF0042C747 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B63FC8B41CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewTriggerForSchedulePredicateTests.swift; sourceTree = "<group>"; };
@@ -493,6 +495,7 @@
 				B66EA4531DA4BC1400B6AB75 /* TriggerOptionsTests.swift */,
 				B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */,
 				B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */,
+				B6323D2C1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift */,
 			);
 			path = ThingIFSDKTests;
 			sourceTree = "<group>";
@@ -766,6 +769,7 @@
 				2254F2171CE99C5C00703185 /* ListPendingEndNodesTests.swift in Sources */,
 				2254F21B1CE9DFE000703185 /* NotifyOnboardingCompletionTests.swift in Sources */,
 				7D36B6AD1BD4D0CC00D9B821 /* PostNewCommandTests.swift in Sources */,
+				B6323D2D1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift in Sources */,
 				2242770C1CEB17BD004369EE /* GatewayAPINSCodingTests.swift in Sources */,
 				7D36B6B11BD4D0CC00D9B821 /* TestHelpers.swift in Sources */,
 				225A591E1C8ED8440042B007 /* ClauseNSCodingTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -20,7 +20,6 @@ extension ThingIFAPI {
             completionHandler(nil, ThingIFError.TARGET_NOT_AVAILABLE)
             return
         }
-        let triggerOptions = options ?? TriggerOptions()
 
         let requestURL = "\(baseURL)/thing-if/apps/\(appID)/targets/\(target.typedID.toString())/triggers"
 
@@ -36,16 +35,13 @@ extension ThingIFAPI {
         }
 
         // generate body
-        let requestBodyDict = NSMutableDictionary(dictionary: ["predicate": predicate.toNSDictionary(), "command": NSDictionary(dictionary: commandDict), "triggersWhat": TriggersWhat.COMMAND.rawValue])
-        if let title = triggerOptions.title {
-            requestBodyDict.setObject(title, forKey: "title")
-        }
-        if let description = triggerOptions.triggerDescription {
-            requestBodyDict.setObject(description, forKey: "description")
-        }
-        if let metadata = triggerOptions.metadata {
-            requestBodyDict.setObject(metadata, forKey: "metadata")
-        }
+        var requestBodyDict: Dictionary<String, AnyObject> = [
+          "predicate": predicate.toNSDictionary(),
+          "command": commandDict,
+          "triggersWhat": TriggersWhat.COMMAND.rawValue]
+        requestBodyDict["title"] = options?.title
+        requestBodyDict["description"] = options?.triggerDescription
+        requestBodyDict["metadata"] = options?.metadata
 
         do{
             let requestBodyData = try NSJSONSerialization.dataWithJSONObject(requestBodyDict, options: NSJSONWritingOptions(rawValue: 0))
@@ -71,9 +67,9 @@ extension ThingIFAPI {
                       enabled: true,
                       predicate: predicate,
                       command: command,
-                      title: triggerOptions.title,
-                      triggerDescription: triggerOptions.triggerDescription,
-                      metadata: triggerOptions.metadata
+                      title: options?.title,
+                      triggerDescription: options?.triggerDescription,
+                      metadata: options?.metadata
                     )
                 }
 

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -207,8 +207,9 @@ extension ThingIFAPI {
 
     func _patchTrigger(
         triggerID:String,
-        serverCode:ServerCode,
+        serverCode:ServerCode?,
         predicate:Predicate?,
+        options:TriggerOptions?,
         completionHandler: (Trigger?, ThingIFError?) -> Void
         )
     {
@@ -223,14 +224,14 @@ extension ThingIFAPI {
         let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(owner.accessToken)", "content-type": "application/json"]
         
         // generate body
-        let requestBodyDict = NSMutableDictionary()
-        requestBodyDict["triggersWhat"] = TriggersWhat.SERVER_CODE.rawValue
-        
-        // generate predicate
-        if predicate != nil {
-            requestBodyDict["predicate"] = predicate!.toNSDictionary()
-        }
-        requestBodyDict["serverCode"] = serverCode.toNSDictionary()
+        var requestBodyDict: Dictionary<String, AnyObject> = [
+          "triggersWhat" : TriggersWhat.SERVER_CODE.rawValue
+        ]
+        requestBodyDict["predicate"] = predicate?.toNSDictionary()
+        requestBodyDict["serverCode"] = serverCode?.toNSDictionary()
+        requestBodyDict["title"] = options?.title;
+        requestBodyDict["description"] = options?.triggerDescription;
+        requestBodyDict["metadata"] = options?.metadata;
         do{
             let requestBodyData = try NSJSONSerialization.dataWithJSONObject(requestBodyDict, options: NSJSONWritingOptions(rawValue: 0))
             // do request

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -99,6 +99,7 @@ extension ThingIFAPI {
             completionHandler(nil, ThingIFError.TARGET_NOT_AVAILABLE)
             return
         }
+        let triggerOptions = options ?? TriggerOptions()
         
         let requestURL = "\(baseURL)/thing-if/apps/\(appID)/targets/\(target.typedID.toString())/triggers"
         
@@ -107,16 +108,14 @@ extension ThingIFAPI {
         
         // generate body
         let requestBodyDict = NSMutableDictionary(dictionary: ["predicate": predicate.toNSDictionary(), "serverCode": serverCode.toNSDictionary(), "triggersWhat": TriggersWhat.SERVER_CODE.rawValue])
-        if let triggerOptions = options {
-            if let title = triggerOptions.title {
-                requestBodyDict["title"] = title
-            }
-            if let description = triggerOptions.triggerDescription {
-                requestBodyDict["description"] = description
-            }
-            if let metadata = triggerOptions.metadata {
-                requestBodyDict["metadata"] = metadata
-            }
+        if let title = triggerOptions.title {
+            requestBodyDict["title"] = title
+        }
+        if let description = triggerOptions.triggerDescription {
+            requestBodyDict["description"] = description
+        }
+        if let metadata = triggerOptions.metadata {
+            requestBodyDict["metadata"] = metadata
         }
         do{
             let requestBodyData = try NSJSONSerialization.dataWithJSONObject(requestBodyDict, options: NSJSONWritingOptions(rawValue: 0))
@@ -124,7 +123,15 @@ extension ThingIFAPI {
             let request = buildDefaultRequest(.POST,urlString: requestURL, requestHeaderDict: requestHeaderDict, requestBodyData: requestBodyData, completionHandler: { (response, error) -> Void in
                 var trigger: Trigger?
                 if let triggerID = response?["triggerID"] as? String{
-                    trigger = Trigger(triggerID: triggerID, targetID: target.typedID, enabled: true, predicate: predicate, serverCode: serverCode)
+                    trigger = Trigger(
+                      triggerID: triggerID,
+                      targetID: target.typedID,
+                      enabled: true,
+                      predicate: predicate,
+                      serverCode: serverCode,
+                      title: triggerOptions.title,
+                      triggerDescription: triggerOptions.triggerDescription,
+                      metadata: triggerOptions.metadata)
                 }
                 
                 dispatch_async(dispatch_get_main_queue()) {

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -217,7 +217,12 @@ extension ThingIFAPI {
             completionHandler(nil, ThingIFError.TARGET_NOT_AVAILABLE)
             return
         }
-        
+
+        if serverCode == nil && predicate == nil && options == nil {
+            completionHandler(nil, ThingIFError.UNSUPPORTED_ERROR)
+            return
+        }
+
         let requestURL = "\(baseURL)/thing-if/apps/\(appID)/targets/\(target.typedID.toString())/triggers/\(triggerID)"
         
         // generate header

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -91,6 +91,7 @@ extension ThingIFAPI {
     func _postNewTrigger(
         serverCode:ServerCode,
         predicate:Predicate,
+        options:TriggerOptions? = nil,
         completionHandler: (Trigger?, ThingIFError?)-> Void
         )
     {
@@ -106,6 +107,17 @@ extension ThingIFAPI {
         
         // generate body
         let requestBodyDict = NSMutableDictionary(dictionary: ["predicate": predicate.toNSDictionary(), "serverCode": serverCode.toNSDictionary(), "triggersWhat": TriggersWhat.SERVER_CODE.rawValue])
+        if let triggerOptions = options {
+            if let title = triggerOptions.title {
+                requestBodyDict["title"] = title
+            }
+            if let description = triggerOptions.triggerDescription {
+                requestBodyDict["description"] = description
+            }
+            if let metadata = triggerOptions.metadata {
+                requestBodyDict["metadata"] = metadata
+            }
+        }
         do{
             let requestBodyData = try NSJSONSerialization.dataWithJSONObject(requestBodyDict, options: NSJSONWritingOptions(rawValue: 0))
             // do request

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -99,7 +99,6 @@ extension ThingIFAPI {
             completionHandler(nil, ThingIFError.TARGET_NOT_AVAILABLE)
             return
         }
-        let triggerOptions = options ?? TriggerOptions()
         
         let requestURL = "\(baseURL)/thing-if/apps/\(appID)/targets/\(target.typedID.toString())/triggers"
         
@@ -107,18 +106,18 @@ extension ThingIFAPI {
         let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(owner.accessToken)", "content-type": "application/json"]
         
         // generate body
-        let requestBodyDict = NSMutableDictionary(dictionary: ["predicate": predicate.toNSDictionary(), "serverCode": serverCode.toNSDictionary(), "triggersWhat": TriggersWhat.SERVER_CODE.rawValue])
-        if let title = triggerOptions.title {
-            requestBodyDict["title"] = title
-        }
-        if let description = triggerOptions.triggerDescription {
-            requestBodyDict["description"] = description
-        }
-        if let metadata = triggerOptions.metadata {
-            requestBodyDict["metadata"] = metadata
-        }
+        var requestBodyDict: Dictionary<String, AnyObject> = [
+          "predicate": predicate.toNSDictionary(),
+          "serverCode": serverCode.toNSDictionary(),
+          "triggersWhat": TriggersWhat.SERVER_CODE.rawValue]
+        requestBodyDict["title"] = options?.title
+        requestBodyDict["description"] = options?.triggerDescription
+        requestBodyDict["metadata"] = options?.metadata
         do{
-            let requestBodyData = try NSJSONSerialization.dataWithJSONObject(requestBodyDict, options: NSJSONWritingOptions(rawValue: 0))
+            let requestBodyData =
+              try NSJSONSerialization.dataWithJSONObject(
+                requestBodyDict,
+                options: NSJSONWritingOptions(rawValue: 0))
             // do request
             let request = buildDefaultRequest(.POST,urlString: requestURL, requestHeaderDict: requestHeaderDict, requestBodyData: requestBodyData, completionHandler: { (response, error) -> Void in
                 var trigger: Trigger?
@@ -129,9 +128,9 @@ extension ThingIFAPI {
                       enabled: true,
                       predicate: predicate,
                       serverCode: serverCode,
-                      title: triggerOptions.title,
-                      triggerDescription: triggerOptions.triggerDescription,
-                      metadata: triggerOptions.metadata)
+                      title: options?.title,
+                      triggerDescription: options?.triggerDescription,
+                      metadata: options?.metadata)
                 }
                 
                 dispatch_async(dispatch_get_main_queue()) {

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -568,7 +568,11 @@ public class ThingIFAPI: NSObject, NSCoding {
         completionHandler: (Trigger?, ThingIFError?)-> Void
         )
     {
-        _patchTrigger(triggerID, serverCode: serverCode!, predicate: predicate, completionHandler: completionHandler)
+        _patchTrigger(triggerID,
+                      serverCode: serverCode,
+                      predicate: predicate,
+                      options: options,
+                      completionHandler: completionHandler)
     }
 
     /** Enable/Disable a registered Trigger

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -558,8 +558,8 @@ public class ThingIFAPI: NSObject, NSCoding {
      */
     public func patchTrigger(
         triggerID:String,
-        serverCode:ServerCode,
-        predicate:Predicate?,
+        serverCode:ServerCode? = nil,
+        predicate:Predicate? = nil,
         options:TriggerOptions? = nil,
         completionHandler: (Trigger?, ThingIFError?)-> Void
         )

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -441,11 +441,13 @@ public class ThingIFAPI: NSObject, NSCoding {
      specified in Trigger is defined.
      - Parameter serverCode: Server code to be executed by the Trigger.
      - Parameter predicate: Predicate of the Command.
+     - Parameter options: Optional data for this trigger.
      - Parameter completionHandler: A closure to be executed once finished. The closure takes 2 arguments: 1st one is an created Trigger instance, 2nd one is an ThingIFError instance when failed.
      */
     public func postNewTrigger(
         serverCode:ServerCode,
         predicate:Predicate,
+        options:TriggerOptions? = nil,
         completionHandler: (Trigger?, ThingIFError?)-> Void
         )
     {
@@ -551,12 +553,14 @@ public class ThingIFAPI: NSObject, NSCoding {
      - Parameter triggerID: ID of the Trigger to which the patch is applied.
      - Parameter serverCode: Modified ServerCode to be applied as patch.
      - Parameter predicate: Modified Predicate to be applied as patch.
+     - Parameter options: Optional data for this trigger.
      - Parameter completionHandler: A closure to be executed once finished. The closure takes 2 arguments: 1st one is the modified Trigger instance, 2nd one is an ThingIFError instance when failed.
      */
     public func patchTrigger(
         triggerID:String,
         serverCode:ServerCode,
         predicate:Predicate?,
+        options:TriggerOptions? = nil,
         completionHandler: (Trigger?, ThingIFError?)-> Void
         )
     {

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -451,7 +451,11 @@ public class ThingIFAPI: NSObject, NSCoding {
         completionHandler: (Trigger?, ThingIFError?)-> Void
         )
     {
-        _postNewTrigger(serverCode, predicate: predicate, completionHandler: completionHandler)
+        _postNewTrigger(
+          serverCode,
+          predicate: predicate,
+          options: options,
+          completionHandler: completionHandler)
     }
 
 

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -564,7 +564,7 @@ public class ThingIFAPI: NSObject, NSCoding {
         completionHandler: (Trigger?, ThingIFError?)-> Void
         )
     {
-        _patchTrigger(triggerID, serverCode: serverCode, predicate: predicate, completionHandler: completionHandler)
+        _patchTrigger(triggerID, serverCode: serverCode!, predicate: predicate, completionHandler: completionHandler)
     }
 
     /** Enable/Disable a registered Trigger

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerWIthTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerWIthTriggerOptionsTests.swift
@@ -1,0 +1,216 @@
+//
+//  PatchServerCodeTriggeWIthTriggerOptions.swift
+//  ThingIFSDK
+//
+//  Created on 2016/10/07.
+//  Copyright (c) 2016 Kii. All rights reserved.
+//
+
+import XCTest
+@testable import ThingIFSDK
+
+class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
+
+    private func getResonseData(
+      triggerID: String,
+      serverCode: ServerCode,
+      predicate: Predicate,
+      options: TriggerOptions?) -> Dictionary<String, AnyObject>
+    {
+        var retval: Dictionary<String, AnyObject> = [
+          "triggerID" : triggerID,
+          "triggersWhat" : "SERVER_CODE",
+          "serverCode" : serverCode.toNSDictionary(),
+          "predicate" : predicate.toNSDictionary(),
+          "disabled" : false
+        ]
+        retval["title"] = options?.title
+        retval["description"] = options?.triggerDescription
+        retval["metadata"] = options?.metadata
+        return retval;
+    }
+
+    private func expectedRequestBody(
+      serverCode: ServerCode?,
+      predicate: Predicate?,
+      options: TriggerOptions?) -> Dictionary<String, AnyObject>
+    {
+        var retval: Dictionary<String, AnyObject> = [
+          "triggersWhat" : "SERVER_CODE"
+        ]
+        retval["serverCode"] = serverCode?.toNSDictionary()
+        retval["predicate"] = predicate?.toNSDictionary()
+        retval["title"] = options?.title
+        retval["description"] = options?.triggerDescription
+        retval["metadata"] = options?.metadata
+        return retval;
+    }
+
+    func testSuccess() {
+        let metadata: Dictionary<String, AnyObject> = [
+          "key" : "value"
+        ]
+        let optionsArray: [TriggerOptions?] = [
+          nil,
+          TriggerOptions(),
+          TriggerOptions(title: "title"),
+          TriggerOptions(triggerDescription: "trigger description"),
+          TriggerOptions(metadata: metadata),
+          TriggerOptions(
+            title: "title",
+            triggerDescription: "trigger description"),
+          TriggerOptions(
+            title: "title",
+            metadata: metadata),
+          TriggerOptions(
+            title: "title",
+            triggerDescription: "trigger description",
+            metadata: metadata),
+          TriggerOptions(
+            triggerDescription: "trigger description",
+            metadata: metadata)
+        ]
+
+        let setting = TestSetting()
+        setting.api._target = setting.target
+        let serverCode =  ServerCode(endpoint: "my_function",
+                                     executorAccessToken: "executorAccessToken",
+                                     targetAppID: "targetAppID",
+                                     parameters: [
+                                       "param key" : "param value"
+                                     ])
+        let predicate = SchedulePredicate(schedule: "1 * * * *")
+
+        for options_index in 0..<optionsArray.count {
+            let options: TriggerOptions? = optionsArray[options_index]
+            let error_message = "options: \(options_index)"
+
+            weak var expectation : XCTestExpectation!
+            defer {
+                expectation = nil
+            }
+            expectation = self.expectationWithDescription(error_message)
+
+            sharedMockMultipleSession.responsePairs = [
+              (
+                (data: try! NSJSONSerialization.dataWithJSONObject(
+                   ["triggerID", "triggerID"],
+                   options: .PrettyPrinted),
+                 urlResponse: NSHTTPURLResponse(
+                   URL: NSURL(string:setting.app.baseURL)!,
+                   statusCode: 200,
+                   HTTPVersion: nil,
+                   headerFields: nil)!,
+                 error: nil),
+                { (request) in
+                    XCTAssertEqual(request.HTTPMethod, "PATCH")
+
+                    var requestHeaders = request.allHTTPHeaderFields!;
+                    // X-Kii-SDK header is not required to check because
+                    // this is SDK version dependent.
+                    requestHeaders["X-Kii-SDK"] = nil
+                    // verify request header.
+                    XCTAssertEqual(
+                      requestHeaders,
+                      [
+                        "Authorization": "Bearer \(setting.owner.accessToken)",
+                        "Content-Type": "application/json"
+                      ],
+                      error_message);
+                    XCTAssertEqual(
+                      request.URL?.absoluteString,
+                      setting.app.baseURL + "/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers/triggerID",
+                      error_message)
+                    XCTAssertEqual(
+                      NSDictionary(
+                        dictionary: try! NSJSONSerialization.JSONObjectWithData(
+                         request.HTTPBody!,
+                         options: .MutableContainers)
+                          as! Dictionary<String, AnyObject>),
+                      NSDictionary(dictionary: self.expectedRequestBody(
+                                     serverCode,
+                                     predicate: predicate,
+                                     options: options)),
+                      error_message)
+                }
+              ),
+              (
+                (data: try! NSJSONSerialization.dataWithJSONObject(
+                   NSDictionary(dictionary: self.getResonseData(
+                                  "triggerID",
+                                  serverCode: serverCode,
+                                  predicate: predicate,
+                                  options: options)),
+                   options: .PrettyPrinted),
+                 urlResponse: NSHTTPURLResponse(
+                   URL: NSURL(string:setting.app.baseURL)!,
+                   statusCode: 200,
+                   HTTPVersion: nil,
+                   headerFields: nil)!,
+                 error: nil),
+                { (request) in
+                    XCTAssertEqual(request.HTTPMethod, "GET")
+
+                    var requestHeaders = request.allHTTPHeaderFields!;
+                    // X-Kii-SDK header is not required to check because
+                    // this is SDK version dependent.
+                    requestHeaders["X-Kii-SDK"] = nil
+                    // verify request header.
+                    XCTAssertEqual(
+                      requestHeaders,
+                      [
+                        "Authorization": "Bearer \(setting.owner.accessToken)",
+                        "Content-Type": "application/json"
+                      ],
+                      error_message);
+                    XCTAssertEqual(
+                      request.URL?.absoluteString,
+                      setting.app.baseURL + "/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers/triggerID",
+                      error_message)
+                }
+              )
+            ]
+            iotSession = MockMultipleSession.self
+            setting.api.patchTrigger(
+              "triggerID",
+              serverCode: serverCode,
+              predicate: predicate,
+              options: options,
+              completionHandler: {
+                  (trigger, error) -> Void in
+
+                  XCTAssertEqual(trigger?.triggerID, "triggerID", error_message)
+                  XCTAssertEqual(trigger?.targetID.toString(),
+                                 setting.target.typedID.toString(),
+                                 error_message)
+                  XCTAssertEqual(trigger?.enabled, Bool(true), error_message)
+                  XCTAssertEqual(trigger?.predicate.toNSDictionary(),
+                                 predicate.toNSDictionary(),
+                                 error_message)
+                  XCTAssertNil(trigger?.command, error_message)
+                  XCTAssertEqual(trigger?.serverCode!.toNSDictionary(),
+                                 serverCode.toNSDictionary(),
+                                 error_message)
+                  XCTAssertEqual(trigger?.title, options?.title, error_message)
+                  XCTAssertEqual(trigger?.triggerDescription,
+                                 options?.triggerDescription,
+                                 error_message)
+                  if let expectedMetadata = options?.metadata {
+                      XCTAssertEqual(
+                        NSDictionary(dictionary: (trigger?.metadata!)!),
+                        NSDictionary(dictionary: expectedMetadata),
+                        error_message)
+                  } else {
+                      XCTAssertNil(trigger?.metadata)
+                  }
+                  expectation.fulfill()
+              })
+            self.waitForExpectationsWithTimeout(TEST_TIMEOUT)
+            { (error) -> Void in
+                if error != nil {
+                    XCTFail("execution timeout for \(error_message)")
+                }
+            }
+        }
+    }
+}

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerWithTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerWithTriggerOptionsTests.swift
@@ -1,0 +1,178 @@
+//
+//  PostNewServerCodeTriggerWithTriggerOptionsTests.swift
+//  ThingIFSDK
+//
+//  Created on 2016/10/07.
+//  Copyright (c) 2016 Kii. All rights reserved.
+//
+
+import XCTest
+@testable import ThingIFSDK
+
+class PostNewServerCodeTriggerWithTriggerOptionsTests: SmallTestBase {
+
+    private func createSuccessRequestBody(
+      serverCode: ServerCode,
+      predicate: Predicate,
+      options: TriggerOptions?) -> Dictionary<String, AnyObject>
+    {
+        var retval: Dictionary<String, AnyObject> =
+          [
+            "serverCode" : serverCode.toNSDictionary(),
+            "predicate" : predicate.toNSDictionary(),
+            "triggersWhat": TriggersWhat.SERVER_CODE.rawValue
+          ]
+        if let triggerOptions = options {
+            if let title = triggerOptions.title {
+                retval["title"] = title
+            }
+            if let description = triggerOptions.triggerDescription {
+                retval["description"] = description
+            }
+            if let metadata = triggerOptions.metadata {
+                retval["metadata"] = metadata
+            }
+        }
+        return retval;
+    }
+
+    func testSuccess() {
+        let metadata: Dictionary<String, AnyObject> = [
+          "key" : "value"
+        ]
+        let optionsArray: [TriggerOptions?] = [
+          nil,
+          TriggerOptions(),
+          TriggerOptions(title: "title"),
+          TriggerOptions(triggerDescription: "trigger description"),
+          TriggerOptions(metadata: metadata),
+          TriggerOptions(
+            title: "title",
+            triggerDescription: "trigger description"),
+          TriggerOptions(
+            title: "title",
+            metadata: metadata),
+          TriggerOptions(
+            title: "title",
+            triggerDescription: "trigger description",
+            metadata: metadata),
+          TriggerOptions(
+            triggerDescription: "trigger description",
+            metadata: metadata)
+        ]
+
+        let setting = TestSetting()
+        setting.api._target = setting.target
+        let serverCode =  ServerCode(endpoint: "my_function",
+                                     executorAccessToken: "executorAccessToken",
+                                     targetAppID: "targetAppID",
+                                     parameters: [
+                                       "param key" : "param value"
+                                     ])
+        let predicate = SchedulePredicate(schedule: "1 * * * *")
+
+        for options_index in 0..<optionsArray.count {
+            let options: TriggerOptions? = optionsArray[options_index]
+            let error_message = "options: \(options_index)"
+
+            weak var expectation : XCTestExpectation!
+            defer {
+                expectation = nil
+            }
+            expectation = self.expectationWithDescription(error_message)
+
+            sharedMockSession.mockResponse = MockResponse(
+              try! NSJSONSerialization.dataWithJSONObject(
+                ["triggerID": "triggerID"],
+                options: .PrettyPrinted),
+              urlResponse: NSHTTPURLResponse(
+                URL: NSURL(string:setting.app.baseURL)!,
+                statusCode: 201,
+                HTTPVersion: nil,
+                headerFields: nil)!,
+              error: nil)
+            sharedMockSession.requestVerifier = {(request) in
+                XCTAssertEqual(request.HTTPMethod, "POST", error_message)
+                XCTAssertEqual(request.URL!.absoluteString,
+                               "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers",
+                               error_message)
+                var requestHeaders = request.allHTTPHeaderFields!;
+                // X-Kii-SDK header is not required to check because
+                // this is SDK version dependent.
+                requestHeaders["X-Kii-SDK"] = nil
+                // verify request header.
+                XCTAssertEqual(
+                  requestHeaders,
+                  [
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": "application/json"
+                  ],
+                  error_message);
+
+                // verify body.
+                XCTAssertEqual(
+                  NSDictionary(
+                    dictionary: try! NSJSONSerialization.JSONObjectWithData(
+                      request.HTTPBody!,
+                      options: .MutableContainers)
+                      as! Dictionary<String, AnyObject>),
+                  NSDictionary(
+                    dictionary: self.createSuccessRequestBody(
+                      serverCode,
+                      predicate: predicate,
+                      options: options)),
+                  error_message)
+            }
+            iotSession = MockSession.self
+
+            setting.api.postNewTrigger(
+                serverCode,
+                predicate: predicate,
+                options: options,
+              completionHandler: {
+                  (trigger, error) -> Void in
+                  if let actual = trigger {
+                      XCTAssertEqual(actual.triggerID, "triggerID",
+                                     error_message)
+                      XCTAssertEqual(actual.targetID.toString(),
+                                     setting.target.typedID.toString(),
+                                     error_message)
+                      XCTAssertEqual(actual.enabled, Bool(true), error_message)
+                      XCTAssertEqual(actual.predicate.toNSDictionary(),
+                                     predicate.toNSDictionary(),
+                                     error_message)
+                      XCTAssertNil(actual.command, error_message)
+                      XCTAssertEqual(actual.serverCode!.toNSDictionary(),
+                                     serverCode.toNSDictionary(),
+                                     error_message)
+                      if let expectedOptions = options {
+                          XCTAssertEqual(actual.title, expectedOptions.title,
+                                         error_message)
+                          XCTAssertEqual(actual.triggerDescription,
+                                         expectedOptions.triggerDescription,
+                                         error_message)
+                          if let expectedMetadata = expectedOptions.metadata {
+                              XCTAssertEqual(
+                                NSDictionary(dictionary: actual.metadata!),
+                                NSDictionary(dictionary: expectedMetadata),
+                                error_message)
+                          } else {
+                              XCTAssertNil(actual.metadata)
+                          }
+                      } else {
+                          XCTAssertNil(actual.title)
+                          XCTAssertNil(actual.triggerDescription)
+                          XCTAssertNil(actual.metadata)
+                      }
+                  }
+                  expectation.fulfill()
+              })
+            self.waitForExpectationsWithTimeout(TEST_TIMEOUT)
+            { (error) -> Void in
+                if error != nil {
+                    XCTFail("execution timeout for \(error_message)")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
TriggerOptions argument is added to postNewTrigger and patchTrigger.
### Issue

Current postNewTrigger and patchTrigger for server code can not send title, description and metadata fields

In this PR, New postNewTrigger and patchTrigger for server code is designed. The methods can send title, description and metadata.
### Modified  APIs
- `ThingIFAPI#postNewTrigger(serverCode:predicate:complitionHandler:)` -> `ThingIFAPI#postNewTrigger(serverCode:predicate:options:complitionHandler:)`
  - Modified Point
    - An argument `options` is added. This argument is optional type.
- `ThingIFAPI#patchTrigger(triggerID:serverCode:predicate:complitionHandler:)` -> `ThingIFAPI#postNewTrigger(triggerID:serverCode:predicate:options:complitionHandler:)`
  - Modified Point
    - An argument `options` is added. This argument is optional type.
    - serverCode arugment becomes optional type
    - predicate arugment becomes optional type
### Tests
- PatchServerCodeTriggerWIthTriggerOptionsTests.swift
- PostNewServerCodeTriggerWithTriggerOptionsTests.swift
### Reference

Related issue: No. 973
Release version: 0.13.0
