### PR TITLE
patchTrigger for command

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		A56B0A471C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B0A461C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift */; };
 		A56B0A491C62143000E653EF /* PatchServerCodeTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B0A481C62143000E653EF /* PatchServerCodeTriggerTests.swift */; };
 		B60BBBD21DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */; };
+		B6323D291DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */; };
 		B63FC8AE1CEEDBFF0042C747 /* ThingIFSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DD44DE91BD4B7CD00AE0249 /* ThingIFSDK.framework */; };
 		B63FC8B51CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63FC8B41CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift */; };
 		B6651A221CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6651A211CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift */; };
@@ -259,6 +260,7 @@
 		A56B0A461C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewServerCodeTriggerTests.swift; sourceTree = "<group>"; };
 		A56B0A481C62143000E653EF /* PatchServerCodeTriggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchServerCodeTriggerTests.swift; sourceTree = "<group>"; };
 		B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
+		B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
 		B63FC8A91CEEDBFF0042C747 /* ThingIFSDKLargeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ThingIFSDKLargeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B63FC8AD1CEEDBFF0042C747 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B63FC8B41CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewTriggerForSchedulePredicateTests.swift; sourceTree = "<group>"; };
@@ -487,6 +489,7 @@
 				B66EA4511DA4B61000B6AB75 /* TriggeredCommandFormTests.swift */,
 				B66EA4531DA4BC1400B6AB75 /* TriggerOptionsTests.swift */,
 				B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */,
+				B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */,
 			);
 			path = ThingIFSDKTests;
 			sourceTree = "<group>";
@@ -768,6 +771,7 @@
 				2255434D1CEC34A900C73418 /* GatewayAPIStoredInstanceTests.swift in Sources */,
 				A54EFC2E1C7D9EF500BCF4D2 /* SmallTestBase.swift in Sources */,
 				7D36B6A21BD4D0CC00D9B821 /* EnableTriggerTests.swift in Sources */,
+				B6323D291DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift in Sources */,
 				B6651A221CBBA6CE00221AAE /* PostNewCommandWithCommandFormTests.swift in Sources */,
 				B68227F41C85823A00AB85D0 /* CommandSerializationTest.swift in Sources */,
 				7D36B6AE1BD4D0CC00D9B821 /* PostNewTriggerTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -496,7 +496,12 @@ public class ThingIFAPI: NSObject, NSCoding {
         options:TriggerOptions? = nil,
         completionHandler: (Trigger?, ThingIFError?) -> Void)
     {
-        // TODO: implement me.
+        _patchTrigger(
+            triggerID,
+            triggeredCommandForm: triggeredCommandForm,
+            predicate: predicate,
+            options: options,
+            completionHandler: completionHandler)
     }
 
     /** Apply patch to a registered Trigger
@@ -509,8 +514,6 @@ public class ThingIFAPI: NSObject, NSCoding {
     Trigger is defined.
     - Parameter schemaVersion: Version of the Schema of which the Command
     specified in Trigger is defined.
-    - Parameter commandTarget: new target for Command in Trigger. Every kind of target can be set.
-    But the owner has to be identical in Command and ThingIFAPI. This is optional.
     - Parameter actions: Modified Actions to be applied as patch.
     - Parameter predicate: Modified Predicate to be applied as patch.
     - Parameter completionHandler: A closure to be executed once finished. The closure takes 2 arguments: 1st one is the modified Trigger instance, 2nd one is an ThingIFError instance when failed.
@@ -519,13 +522,25 @@ public class ThingIFAPI: NSObject, NSCoding {
         triggerID:String,
         schemaName:String?,
         schemaVersion:Int?,
-        commandTarget:Target? = nil,
         actions:[Dictionary<String, AnyObject>]?,
         predicate:Predicate?,
         completionHandler: (Trigger?, ThingIFError?)-> Void
         )
     {
-        _patchTrigger(triggerID, schemaName: schemaName, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: actions, predicate: predicate, completionHandler: completionHandler)
+        let triggeredCommandForm: TriggeredCommandForm?
+        if (schemaName != nil && schemaVersion != nil && actions != nil) {
+            triggeredCommandForm = TriggeredCommandForm(
+                schemaName: schemaName!,
+                schemaVersion: schemaVersion!,
+                actions: actions!)
+        } else {
+            triggeredCommandForm = nil
+        }
+        _patchTrigger(
+            triggerID,
+            triggeredCommandForm: triggeredCommandForm,
+            predicate: predicate,
+            completionHandler: completionHandler)
     }
     
     /** Apply patch to a registered Trigger

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -49,6 +49,7 @@ class PatchTriggerTests: SmallTestBase {
             if actions != nil {
                 commandDict["actions"] = actions!
             }
+            commandDict["target"] = target.typedID.toString()
             return commandDict
         }
 
@@ -120,9 +121,14 @@ class PatchTriggerTests: SmallTestBase {
             }
             //verify body
             do {
-                let expectedBodyData = try NSJSONSerialization.dataWithJSONObject(expectedBodyDict, options: NSJSONWritingOptions(rawValue: 0))
-                let actualBodyData = request.HTTPBody
-                XCTAssertTrue(expectedBodyData.length == actualBodyData!.length, tag)
+                XCTAssertEqual(expectedBodyDict,
+                               NSDictionary(
+                                 dictionary: try! NSJSONSerialization.JSONObjectWithData(
+                                   request.HTTPBody!,
+                                   options: .MutableContainers)
+                                   as! Dictionary<String, AnyObject>),
+                               tag)
+
             }catch(_){
                 XCTFail(tag)
             }

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -26,7 +26,6 @@ class PatchTriggerTests: SmallTestBase {
 
         let schemaName: String?
         let schemaVersion: Int?
-        let commandTarget: Target?
         let actions: [Dictionary<String, AnyObject>]?
 
         let predicate: Predicate?
@@ -46,9 +45,6 @@ class PatchTriggerTests: SmallTestBase {
             }
             if schemaVersion != nil {
                 commandDict["schemaVersion"] = schemaVersion!
-            }
-            if commandTarget != nil {
-                commandDict["target"] = commandTarget!.typedID.toString()
             }
             if actions != nil {
                 commandDict["actions"] = actions!
@@ -83,46 +79,16 @@ class PatchTriggerTests: SmallTestBase {
 
         let testsCases: [TestCase] = [
             //
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: NotEqualsClause(field: "power", boolValue: true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "not", "clause": ["type":"eq","field":"power", "value": true]], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: nil, commandTarget: nil, actions: nil, predicate: StatePredicate(condition: Condition(clause: RangeClause(field: "color", upperLimitInt: 255, upperIncluded:true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "range", "field": "color", "upperLimit": 255, "upperIncluded": true], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: ScheduleOncePredicate(scheduleAt: NSDate(timeIntervalSinceNow: 1000)), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: schemaVersion, commandTarget: nil, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: nil, commandTarget: nil, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: nil, actions: nil, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: NotEqualsClause(field: "power", boolValue: true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "not", "clause": ["type":"eq","field":"power", "value": true]], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: nil, actions: nil, predicate: StatePredicate(condition: Condition(clause: RangeClause(field: "color", upperLimitInt: 255, upperIncluded:true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "range", "field": "color", "upperLimit": 255, "upperIncluded": true], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: expectedActions, predicate: ScheduleOncePredicate(scheduleAt: NSDate(timeIntervalSinceNow: 1000)), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: schemaVersion, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: nil, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
+            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, actions: nil, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
             
         ]
-        for (index,testCase) in testsCases.enumerate() {
-            patchTrigger("testPatchTrigger_\(index)", testcase: testCase)
-        }
-    }
-
-    func testPatchTriggerWithCommandTarget() {
-
-        let expectedActions: [Dictionary<String, AnyObject>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
-        let setting = TestSetting()
-        let api = setting.api
-        let target = setting.target
-        let owner = setting.owner
-        let schema = setting.schema
-        let schemaVersion = setting.schemaVersion
-        let commandTarget = StandaloneThing(thingID: "commandThingID", vendorThingID: "commandVendorThingID")
-
-        // perform onboarding
-        api._target = setting.target
-
-        let testsCases: [TestCase] = [
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: StatePredicate(condition: Condition(clause: NotEqualsClause(field: "power", boolValue: true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "not", "clause": ["type":"eq","field":"power", "value": true]], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: nil, commandTarget: commandTarget, actions: nil, predicate: StatePredicate(condition: Condition(clause: RangeClause(field: "color", upperLimitInt: 255, upperIncluded:true)), triggersWhen: TriggersWhen.CONDITION_FALSE_TO_TRUE), expectedStatementDict: ["type": "range", "field": "color", "upperLimit": 255, "upperIncluded": true], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: ScheduleOncePredicate(scheduleAt: NSDate(timeIntervalSinceNow: 1000)), expectedStatementDict: ["type":"eq","field":"color", "value": 0], expectedTriggersWhenString: "CONDITION_FALSE_TO_TRUE", success: true),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: nil, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: nil, commandTarget: commandTarget, actions: expectedActions, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-            TestCase(target: target, issuerID: owner.typedID, schemaName: schema, schemaVersion: schemaVersion, commandTarget: commandTarget, actions: nil, predicate: nil, expectedStatementDict: nil, expectedTriggersWhenString: nil, success: false),
-
-            ]
         for (index,testCase) in testsCases.enumerate() {
             patchTrigger("testPatchTrigger_\(index)", testcase: testCase)
         }
@@ -201,7 +167,7 @@ class PatchTriggerTests: SmallTestBase {
 
 
         api._target = setting.target
-        api.patchTrigger(expectedTriggerID, schemaName: testcase.schemaName, schemaVersion: testcase.schemaVersion, commandTarget: testcase.commandTarget, actions: testcase.actions, predicate: testcase.predicate, completionHandler: { (trigger, error) -> Void in
+        api.patchTrigger(expectedTriggerID, schemaName: testcase.schemaName, schemaVersion: testcase.schemaVersion, actions: testcase.actions, predicate: testcase.predicate, completionHandler: { (trigger, error) -> Void in
             if testcase.success {
                 if error == nil{
                     XCTAssertEqual(trigger!.triggerID, expectedTriggerID, tag)

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggeredCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggeredCommandFormTests.swift
@@ -1,0 +1,287 @@
+//
+//  PatchTriggerWithTriggeredCommandFormTest.swift
+//  ThingIFSDK
+//
+//  Created on 2016/10/06.
+//  Copyright (c) 2016 Kii. All rights reserved.
+//
+
+import XCTest
+@testable import ThingIFSDK
+
+class PatchTriggerWithTriggeredCommandFormTest: SmallTestBase {
+
+    func testSuccess() {
+        let actions: [Dictionary<String, AnyObject>] =
+            [["actions-key" : "actions-value"]]
+        let command_metadata: Dictionary<String, AnyObject> =
+            ["command_metadata-key" : "command_metadata-value"]
+        let targetID = TypedID(type: "THING", id: "thing-id")
+        let forms: [TriggeredCommandForm?] = [
+            nil,
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 targetID: targetID),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 title: "command title"),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 commandDescription: "command description"),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 metadata: command_metadata),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 targetID: targetID,
+                                 title: "command title"),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 targetID: targetID,
+                                 commandDescription: "command description"),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 targetID: targetID,
+                                 metadata: command_metadata),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 targetID: targetID,
+                                 title: "command title",
+                                 commandDescription: "command description"),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 targetID: targetID,
+                                 title: "command title",
+                                 metadata: command_metadata),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 targetID: targetID,
+                                 title: "command title",
+                                 commandDescription: "command description",
+                                 metadata: command_metadata),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 title: "command title",
+                                 commandDescription: "command description"),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 title: "command title",
+                                 metadata: command_metadata),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 title: "command title",
+                                 commandDescription: "command description",
+                                 metadata: command_metadata),
+            TriggeredCommandForm(schemaName: "name",
+                                 schemaVersion: 1,
+                                 actions: actions,
+                                 commandDescription: "command description",
+                                 metadata: command_metadata)
+        ]
+        let trigger_metadata: Dictionary<String, AnyObject> =
+            ["trigger_metadata-key" : "trigger_metadata-value"]
+        let optionsArray: [TriggerOptions?] = [
+            nil,
+            TriggerOptions(title: "trigger title"),
+            TriggerOptions(triggerDescription: "trigger description"),
+            TriggerOptions(metadata: trigger_metadata),
+            TriggerOptions(
+                title: "trigger title",
+                triggerDescription: "trigger description"),
+            TriggerOptions(
+                title: "trigger title",
+                metadata: trigger_metadata),
+            TriggerOptions(
+                title: "trigger title",
+                triggerDescription: "trigger description",
+                metadata: trigger_metadata),
+            TriggerOptions(
+                triggerDescription: "trigger description",
+                metadata: trigger_metadata),
+        ]
+        let triggerID = "triggerID"
+        let predicate = SchedulePredicate(schedule: "1 * * * *")
+
+        let setting = TestSetting()
+        setting.api._target = setting.target
+
+        let responseTrigger = [
+            "triggerID" : "triggerID",
+            "command" :
+              [
+                "schema" : "name",
+                "schemaVersion" : 1,
+                "actions" : actions,
+                "target" : "THING:target",
+                "issuer" : setting.owner.typedID.toString(),
+                "title" : "command title",
+                "description" : "command description",
+                "metadata" : command_metadata
+              ],
+            "predicate" :
+              [
+                "eventSource" : "SCHEDULE",
+                "schedule" : "1 * * * *"
+              ],
+            "title" : "trigger title",
+            "description" : "trigger description",
+            "metadata" : trigger_metadata,
+            "disabled": false
+        ]
+
+        for form_index in 0..<forms.count {
+            let form: TriggeredCommandForm? = forms[form_index]
+            for options_index in 0..<optionsArray.count {
+                let options: TriggerOptions? = optionsArray[options_index]
+
+                let error_message =
+                  "form: \(form_index), options: \(options_index)"
+                weak var expectation : XCTestExpectation!
+                defer {
+                    expectation = nil
+                }
+                expectation = self.expectationWithDescription(error_message)
+
+                sharedMockMultipleSession.responsePairs =
+                    [
+                      (
+                        (
+                          data: nil,
+                          urlResponse: NSHTTPURLResponse(
+                            URL: NSURL(string:setting.app.baseURL)!,
+                            statusCode: 204,
+                            HTTPVersion: nil,
+                            headerFields: nil),
+                          error: nil
+                        ),
+                        {(request) in
+                            XCTAssertEqual(request.HTTPMethod, "PATCH")
+
+                            var requestHeaders = request.allHTTPHeaderFields!;
+                            // X-Kii-SDK header is not required to check because
+                            // this is SDK version dependent.
+                            requestHeaders["X-Kii-SDK"] = nil
+                            // verify request header.
+                            XCTAssertEqual(
+                              requestHeaders,
+                              [
+                                "Authorization": "Bearer \(setting.owner.accessToken)",
+                                "Content-Type": "application/json"
+                              ],
+                              error_message);
+                            XCTAssertEqual(
+                              request.URL?.absoluteString,
+                              setting.app.baseURL + "/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers/triggerID",
+                              error_message)
+                        }
+                      ),
+                      (
+                        (
+                          data: try! NSJSONSerialization.dataWithJSONObject(
+                            responseTrigger,
+                            options: .PrettyPrinted),
+                          urlResponse: NSHTTPURLResponse(
+                            URL: NSURL(string: setting.app.baseURL)!,
+                            statusCode: 201,
+                            HTTPVersion: nil,
+                            headerFields: nil),
+                          error: nil
+                        ),
+                        {(request) in
+                        }
+                      )
+                    ]
+                iotSession = MockMultipleSession.self
+
+                setting.api.patchTrigger(
+                    triggerID,
+                    triggeredCommandForm: form,
+                    predicate: predicate,
+                    options: options,
+                    completionHandler: {
+                        (trigger, error) -> Void in
+                        if let tgr = trigger {
+                            XCTAssertEqual(
+                              tgr.triggerID, "triggerID", error_message)
+                            XCTAssertEqual(
+                              tgr.targetID.toString(),
+                              setting.api.target?.typedID.toString(),
+                              error_message)
+                            XCTAssertTrue(tgr.enabled, error_message)
+                            XCTAssertEqual(tgr.predicate.toNSDictionary(),
+                                           NSDictionary(
+                                             dictionary:
+                                               [
+                                                 "eventSource" : "SCHEDULE",
+                                                 "schedule" : "1 * * * *"
+                             ]))
+                            XCTAssertEqual(tgr.title, "trigger title",
+                                           error_message)
+                            XCTAssertEqual(tgr.triggerDescription,
+                                           "trigger description", error_message)
+                            XCTAssertEqual(
+                                NSDictionary(dictionary: tgr.metadata!),
+                                NSDictionary(dictionary: trigger_metadata),
+                                error_message)
+                            if let command = tgr.command {
+                                XCTAssertEqual(command.targetID.toString(),
+                                               "thing:target", error_message)
+                                XCTAssertEqual(command.issuerID.toString(),
+                                               setting.owner.typedID.toString(),
+                                               error_message)
+                                XCTAssertEqual(command.schemaName, "name",
+                                               error_message)
+                                XCTAssertEqual(command.schemaVersion, 1,
+                                               error_message)
+                                for i in 0..<command.actions.count {
+                                    XCTAssertEqual(
+                                      NSDictionary(
+                                        dictionary: command.actions[i]),
+                                      NSDictionary(dictionary: actions[i]),
+                                      error_message)
+                                }
+                                XCTAssertEqual(command.title!, "command title",
+                                               error_message)
+                                XCTAssertEqual(command.commandDescription!,
+                                               "command description",
+                                               error_message)
+                                XCTAssertEqual(
+                                  NSDictionary(dictionary: command.metadata!),
+                                  NSDictionary(dictionary: command_metadata),
+                                  error_message)
+                            } else {
+                                XCTFail(error_message)
+                            }
+
+                        } else {
+                            XCTFail(error_message)
+                        }
+                        expectation.fulfill()
+                    })
+                self.waitForExpectationsWithTimeout(TEST_TIMEOUT)
+                    { (error) -> Void in
+                        if error != nil {
+                            XCTFail(error_message)
+                        }
+                    }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
`TriggeredCommandForm` を受け取るpostNewTriggerを実装しました。

実装の修正内容は以下の通りです。
- `patchTrigger(triggerID:triggeredCommandForm:predicate:options:completionHandler)`を実装
- `patchTrigger(triggerID:schemaName:schamaVersion:actions:predicate:completionHandler)`から引数commandTargetを削除

commandTargetの削除は、cross thing triggerはtriggeredCommandFormの方で実現できるため、古いAPIは元の形に戻しました。この修正については熊野さんと合意済みです。

テストの修正は以下の通りです。
- `patchTrigger(triggerID:triggeredCommandForm:predicate:options:completionHandler)`に対してPatchTriggerWithTriggeredCommandFormTestsを追加
- `patchTrigger(triggerID:schemaName:schamaVersion:actions:predicate:completionHandler)`から引数commandTargetを削除したため、PatchTriggerTestsを修正。

Related PR: #164 
