### PR TITLE
Links to methods in API document are fixed.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -12,7 +12,7 @@ import Foundation
 Form of a command.
 
 This class contains data in order to create `Command` with
-`ThingIFAPI.postNewCommand(_:completionHandler:)`.
+`ThingIFAPI.postNewCommand(commandForm:completionHandler:)`.
 
 Mandatory data are followings:
 

--- a/ThingIFSDK/ThingIFSDK/OnboardEndnodeWithGatewayOptions.swift
+++ b/ThingIFSDK/ThingIFSDK/OnboardEndnodeWithGatewayOptions.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-/** Optional parameters of `ThingIFAPI.onboardEndnodeWithGateway(_:endnodePassword:options:completionHandler:)`.
- */
+/** Optional parameters of
+`ThingIFAPI.onboardEndnodeWithGateway(pendingEndnode:endnodePassword:options:completionHandler:)`.
+*/
 public class OnboardEndnodeWithGatewayOptions {
     public let dataGroupingInterval: DataGroupingInterval?
 

--- a/ThingIFSDK/ThingIFSDK/OnboardWithThingIDOptions.swift
+++ b/ThingIFSDK/ThingIFSDK/OnboardWithThingIDOptions.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-/** Optional parameters of `ThingIFAPI.onboardWithThingID(_:thingPassword:options:completionHandler:)`.
+/** Optional parameters of
+`ThingIFAPI.onboardWithThingID(thingID:thingPassword:options:completionHandler:)`.
 */
 public class OnboardWithThingIDOptions {
     public let layoutPosition: LayoutPosition?

--- a/ThingIFSDK/ThingIFSDK/OnboardWithVendorThingIDOptions.swift
+++ b/ThingIFSDK/ThingIFSDK/OnboardWithVendorThingIDOptions.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-/** Optional parameters of `ThingIFAPI.onboardWithVendorThingID(_:thingPassword:options:completionHandler:)`.
- */
+/** Optional parameters of
+`ThingIFAPI.onboardWithVendorThingID(vendorThingID:thingPassword:options:completionHandler:)`.
+*/
 public class OnboardWithVendorThingIDOptions {
     public let thingType: String?
     public let firmwareVersion: String?


### PR DESCRIPTION
From v0.13.0, We adapt swift 2.3. As as result, notation of links to other methods in API document is changed.

In old style, first argument of a method is "_".
In new style, first argument is label of the first argument of the method.

Related issue: No. 988
