### PR TITLE
AnyObject should be changed to Any

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Command.swift
+++ b/ThingIFSDK/ThingIFSDK/Command.swift
@@ -37,9 +37,9 @@ open class Command: NSObject, NSCoding {
         self.schemaName = aDecoder.decodeObject(forKey: "schemaName") as! String
         self.schemaVersion = aDecoder.decodeInteger(forKey: "schemaVersion")
         self.actions = aDecoder.decodeObject(forKey: "actions")
-                as! [Dictionary<String, AnyObject>];
+                as! [Dictionary<String, Any>];
         self.actionResults = aDecoder.decodeObject(forKey: "actionResults")
-                as! [Dictionary<String, AnyObject>];
+                as! [Dictionary<String, Any>];
         self.commandState =
             CommandState(rawValue: aDecoder.decodeInteger(forKey: "commandState"))!;
         self.firedByTriggerID = aDecoder.decodeObject(forKey: "firedByTriggerID") as? String
@@ -55,7 +55,7 @@ open class Command: NSObject, NSCoding {
         }
         self.title = aDecoder.decodeObject(forKey: "title") as? String
         self.commandDescription = aDecoder.decodeObject(forKey: "commandDescription") as? String
-        self.metadata = aDecoder.decodeObject(forKey: "metadata") as? Dictionary<String, AnyObject>
+        self.metadata = aDecoder.decodeObject(forKey: "metadata") as? Dictionary<String, Any>
     }
 
 
@@ -70,9 +70,9 @@ open class Command: NSObject, NSCoding {
     /** Version of the Schema of which this Command is defined. */
     open let schemaVersion: Int
     /** Actions to be executed. */
-    open let actions: [Dictionary<String, AnyObject>]
+    open let actions: [Dictionary<String, Any>]
     /** Results of the action. */
-    open let actionResults: [Dictionary<String, AnyObject>]
+    open let actionResults: [Dictionary<String, Any>]
     /** State of the Command. */
     open let commandState: CommandState
     /** ID of the trigger which fired this command */
@@ -86,7 +86,7 @@ open class Command: NSObject, NSCoding {
     /** Description of the Command */
     open let commandDescription: String?
     /** Metadata of the Command */
-    open let metadata: Dictionary<String, AnyObject>?
+    open let metadata: Dictionary<String, Any>?
 
     public override init() {
         // TODO: implement it with proper initilizer.
@@ -111,15 +111,15 @@ open class Command: NSObject, NSCoding {
          issuerID: TypedID,
          schemaName: String,
          schemaVersion: Int,
-         actions:[Dictionary<String, AnyObject>],
-         actionResults:[Dictionary<String, AnyObject>]?,
+         actions:[Dictionary<String, Any>],
+         actionResults:[Dictionary<String, Any>]?,
          commandState: CommandState?,
          firedByTriggerID: String? = nil,
          created: Date? = nil,
          modified: Date? = nil,
          title: String? = nil,
          commandDescription: String? = nil,
-         metadata: Dictionary<String, AnyObject>? = nil) {
+         metadata: Dictionary<String, Any>? = nil) {
         if commandID != nil {
             self.commandID = commandID!
         }else {
@@ -167,14 +167,14 @@ open class Command: NSObject, NSCoding {
         let commandID = nsDict["commandID"] as? String
         let schemaName = nsDict["schema"] as? String
         // actions array
-        var actionsArray = [Dictionary<String, AnyObject>]()
+        var actionsArray = [Dictionary<String, Any>]()
         if let actions = nsDict["actions"] as? [NSDictionary] {
-            actionsArray = actions as! [Dictionary<String, AnyObject>]
+            actionsArray = actions as! [Dictionary<String, Any>]
         }
         // actionResult array
-        var actionsResultArray = [Dictionary<String, AnyObject>]()
+        var actionsResultArray = [Dictionary<String, Any>]()
         if let actionResults = nsDict["actionResults"] as? [NSDictionary] {
-            actionsResultArray = actionResults as! [Dictionary<String, AnyObject>]
+            actionsResultArray = actionResults as! [Dictionary<String, Any>]
         }
         let schemaVersion = nsDict["schemaVersion"] as? Int
 
@@ -218,7 +218,7 @@ open class Command: NSObject, NSCoding {
         if let modifiedAt = nsDict["modifiedAt"] as? NSNumber {
             modified = Date(timeIntervalSince1970: (modifiedAt.doubleValue)/1000.0)
         }
-        return Command(commandID: commandID, targetID: targetID!, issuerID: issuerID!, schemaName: schemaName!, schemaVersion: schemaVersion!, actions: actionsArray, actionResults: actionsResultArray, commandState: commandState, firedByTriggerID: nsDict["firedByTriggerID"] as? String, created: created, modified: modified, title: nsDict["title"] as? String, commandDescription: nsDict["description"] as? String, metadata: nsDict["metadata"] as? Dictionary<String, AnyObject>)
+        return Command(commandID: commandID, targetID: targetID!, issuerID: issuerID!, schemaName: schemaName!, schemaVersion: schemaVersion!, actions: actionsArray, actionResults: actionsResultArray, commandState: commandState, firedByTriggerID: nsDict["firedByTriggerID"] as? String, created: created, modified: modified, title: nsDict["title"] as? String, commandDescription: nsDict["description"] as? String, metadata: nsDict["metadata"] as? Dictionary<String, Any>)
     }
 }
 

--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -37,7 +37,7 @@ open class CommandForm: NSObject, NSCoding {
     open let schemaVersion: Int
 
     /// List of actions.
-    open let actions: [Dictionary<String, AnyObject>]
+    open let actions: [Dictionary<String, Any>]
 
     /// Title of a command.
     open let title: String?
@@ -46,7 +46,7 @@ open class CommandForm: NSObject, NSCoding {
     open let commandDescription: String?
 
     /// Meta data of ad command.
-    open let metadata: Dictionary<String, AnyObject>?
+    open let metadata: Dictionary<String, Any>?
 
 
     // MARK: - Initializing CommandForm instance.
@@ -64,10 +64,10 @@ open class CommandForm: NSObject, NSCoding {
     */
     public init(schemaName: String,
                 schemaVersion: Int,
-                actions: [Dictionary<String, AnyObject>],
+                actions: [Dictionary<String, Any>],
                 title: String? = nil,
                 commandDescription: String? = nil,
-                metadata: Dictionary<String, AnyObject>? = nil)
+                metadata: Dictionary<String, Any>? = nil)
     {
         self.schemaName = schemaName
         self.schemaVersion = schemaVersion
@@ -91,11 +91,11 @@ open class CommandForm: NSObject, NSCoding {
         self.schemaName = aDecoder.decodeObject(forKey: "schemaName") as! String
         self.schemaVersion = aDecoder.decodeInteger(forKey: "schemaVersion")
         self.actions = aDecoder.decodeObject(forKey: "actions")
-                as! [Dictionary<String, AnyObject>];
+                as! [Dictionary<String, Any>];
         self.title = aDecoder.decodeObject(forKey: "title") as? String
         self.commandDescription =
             aDecoder.decodeObject(forKey: "commandDescription") as? String;
         self.metadata = aDecoder.decodeObject(forKey: "metadata")
-                as? Dictionary<String, AnyObject>;
+                as? Dictionary<String, Any>;
     }
 }

--- a/ThingIFSDK/ThingIFSDK/Gateway/PendingEndNode.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/PendingEndNode.swift
@@ -12,7 +12,7 @@ open class PendingEndNode: NSObject, NSCoding {
     let KEY_THINGPROPERTIES = "thingProperties"
 
     open let vendorThingID: String?
-    open let thingProperties: Dictionary<String, AnyObject>?
+    open let thingProperties: Dictionary<String, Any>?
 
     open var thingType: String? {
         return self.thingProperties?["_thingType"] as? String
@@ -28,12 +28,12 @@ open class PendingEndNode: NSObject, NSCoding {
     public required init(coder aDecoder: NSCoder)
     {
         self.vendorThingID = aDecoder.decodeObject(forKey: KEY_VENDORTHINGID) as? String
-        self.thingProperties = aDecoder.decodeObject(forKey: KEY_THINGPROPERTIES) as? Dictionary<String, AnyObject>
+        self.thingProperties = aDecoder.decodeObject(forKey: KEY_THINGPROPERTIES) as? Dictionary<String, Any>
     }
 
-    init(json: Dictionary<String, AnyObject>)
+    init(json: Dictionary<String, Any>)
     {
         self.vendorThingID = json[KEY_VENDORTHINGID] as? String
-        self.thingProperties = json[KEY_THINGPROPERTIES] as? Dictionary<String, AnyObject>
+        self.thingProperties = json[KEY_THINGPROPERTIES] as? Dictionary<String, Any>
     }
 }

--- a/ThingIFSDK/ThingIFSDK/OnboardWithVendorThingIDOptions.swift
+++ b/ThingIFSDK/ThingIFSDK/OnboardWithVendorThingIDOptions.swift
@@ -13,7 +13,7 @@ import Foundation
 open class OnboardWithVendorThingIDOptions {
     open let thingType: String?
     open let firmwareVersion: String?
-    open let thingProperties: Dictionary<String,AnyObject>?
+    open let thingProperties: Dictionary<String, Any>?
     open let layoutPosition: LayoutPosition?
     open let dataGroupingInterval: DataGroupingInterval?
 
@@ -33,7 +33,7 @@ open class OnboardWithVendorThingIDOptions {
     public init(
         thingType:String? = nil,
         firmwareVersion:String? = nil,
-        thingProperties:Dictionary<String,AnyObject>? = nil,
+        thingProperties:Dictionary<String, Any>? = nil,
         position: LayoutPosition? = nil,
         interval: DataGroupingInterval? = nil)
     {

--- a/ThingIFSDK/ThingIFSDK/ServerCode.swift
+++ b/ThingIFSDK/ThingIFSDK/ServerCode.swift
@@ -21,7 +21,7 @@ open class ServerCode : NSObject, NSCoding {
         self.endpoint = aDecoder.decodeObject(forKey: "endpoint") as! String
         self.executorAccessToken = aDecoder.decodeObject(forKey: "executorAccessToken") as? String
         self.targetAppID = aDecoder.decodeObject(forKey: "targetAppID") as? String
-        self.parameters = aDecoder.decodeObject(forKey: "parameters") as? Dictionary<String, AnyObject>
+        self.parameters = aDecoder.decodeObject(forKey: "parameters") as? Dictionary<String, Any>
     }
 
     /** Endpoint to call on servercode */
@@ -31,7 +31,7 @@ open class ServerCode : NSObject, NSCoding {
     /** If provided, servercode endpoint will be called for this appid. Otherwise same appID of trigger is used */
     open let targetAppID: String?
     /** Parameters to pass to the servercode function */
-    open let parameters: Dictionary<String, AnyObject>?
+    open let parameters: Dictionary<String, Any>?
 
     /** Init TriggeredServerCodeResult with necessary attributes
 
@@ -40,7 +40,7 @@ open class ServerCode : NSObject, NSCoding {
      - Parameter targetAppID: If provided, servercode endpoint will be called for this appid. Otherwise same appID of trigger is used
      - Parameter parameters: Parameters to pass to the servercode function
      */
-    public init(endpoint: String, executorAccessToken: String?, targetAppID: String?, parameters: Dictionary<String, AnyObject>?) {
+    public init(endpoint: String, executorAccessToken: String?, targetAppID: String?, parameters: Dictionary<String, Any>?) {
         self.endpoint = endpoint
         self.executorAccessToken = executorAccessToken
         self.targetAppID = targetAppID
@@ -82,7 +82,7 @@ open class ServerCode : NSObject, NSCoding {
         let endpoint = nsDict["endpoint"] as? String
         let executorAccessToken = nsDict["executorAccessToken"] as? String
         let targetAppID = nsDict["targetAppID"] as? String
-        let parameters = nsDict["parameters"] as? Dictionary<String, AnyObject>
+        let parameters = nsDict["parameters"] as? Dictionary<String, Any>
         var serverCode: ServerCode?
         if (endpoint != nil) {
             serverCode = ServerCode(endpoint:endpoint!, executorAccessToken:executorAccessToken, targetAppID:targetAppID, parameters:parameters)

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Command.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Command.swift
@@ -13,17 +13,17 @@ extension ThingIFAPI {
     func _postNewCommand(
         _ schemaName:String,
         schemaVersion:Int,
-        actions:[Dictionary<String,AnyObject>],
+        actions:[Dictionary<String, Any>],
         title:String? = nil,
         description:String? = nil,
-        metadata:Dictionary<String, AnyObject>? = nil,
+        metadata:Dictionary<String, Any>? = nil,
         completionHandler: @escaping (Command?, ThingIFError?)-> Void
         ) -> Void
     {
         guard let target = self.target else {
             completionHandler(nil, ThingIFError.target_NOT_AVAILABLE)
             return
-        }
+        }   
 
         let requestURL = "\(baseURL)/thing-if/apps/\(appID)/targets/\(target.typedID.toString())/commands"
         
@@ -31,11 +31,15 @@ extension ThingIFAPI {
         let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(owner.accessToken)", "content-type": "application/json"]
         
         // generate body
-        let requestBodyDict = NSMutableDictionary(dictionary: ["schema": schemaName, "schemaVersion": schemaVersion])
-        requestBodyDict.setObject(actions, forKey: "actions" as NSCopying)
+        var requestBodyDict: Dictionary<String, Any> =
+          [
+            "schema": schemaName,
+            "schemaVersion": schemaVersion,
+            "actions": actions
+          ]
 
         let issuerID = owner.typedID
-        requestBodyDict.setObject(issuerID.toString(), forKey: "issuer" as NSCopying)
+        requestBodyDict["issuer"] = issuerID.toString()
         requestBodyDict["title"] = title;
         requestBodyDict["description"] = description;
         requestBodyDict["metadata"] = metadata;

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+GetState.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+GetState.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension ThingIFAPI {
     func _getState(
-        _ completionHandler: @escaping (Dictionary<String, AnyObject>?,  ThingIFError?)-> Void
+        _ completionHandler: @escaping (Dictionary<String, Any>?,  ThingIFError?)-> Void
         ){
             guard let target = self.target else {
                 completionHandler(nil, ThingIFError.target_NOT_AVAILABLE)
@@ -23,12 +23,12 @@ extension ThingIFAPI {
             let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(owner.accessToken)", "content-type": "application/json"]
             
             let request = buildDefaultRequest(HTTPMethod.GET,urlString: requestURL, requestHeaderDict: requestHeaderDict, requestBodyData: nil, completionHandler: { (response, error) -> Void in
-                var states : Dictionary<String, AnyObject>?
+                var states : Dictionary<String, Any>?
                 if response != nil {
-                    states = Dictionary<String, AnyObject>()
+                    states = Dictionary<String, Any>()
                     response!.enumerateKeysAndObjects(
                       { (key, obj, stop) -> Void in
-                          states![key as! String] = obj as AnyObject
+                          states![key as! String] = obj
                       }
                     )
                 }

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+OnBoard.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+OnBoard.swift
@@ -15,7 +15,7 @@ extension ThingIFAPI {
         thingPassword:String,
         thingType:String? = nil,
         firmwareVersion:String? = nil,
-        thingProperties:Dictionary<String,AnyObject>? = nil,
+        thingProperties:Dictionary<String, Any>? = nil,
         layoutPosition:LayoutPosition? = nil,
         dataGroupingInterval:DataGroupingInterval? = nil,
         completionHandler: @escaping (Target?, ThingIFError?)-> Void
@@ -29,16 +29,20 @@ extension ThingIFAPI {
             let requestURL = "\(baseURL)/thing-if/apps/\(appID)/onboardings"
             
             // genrate body
-            let requestBodyDict = NSMutableDictionary(dictionary: ["thingPassword": thingPassword, "owner": owner.typedID.toString()])
+            var requestBodyDict: Dictionary<String, Any> =
+              [
+                "thingPassword": thingPassword,
+                "owner": owner.typedID.toString()
+              ]
             
             // generate header
             var requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(owner.accessToken)"]
             
             if byVendorThingID {
-                requestBodyDict.setObject(IDString, forKey: "vendorThingID" as NSCopying)
+                requestBodyDict["vendorThingID"] = IDString
                 requestHeaderDict["Content-type"] = "application/vnd.kii.OnboardingWithVendorThingIDByOwner+json"
-            }else {
-                requestBodyDict.setObject(IDString, forKey: "thingID" as NSCopying)
+            } else {
+                requestBodyDict["thingID"] = IDString
                 requestHeaderDict["Content-type"] = "application/vnd.kii.OnboardingWithThingIDByOwner+json"
             }
 

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -29,19 +29,19 @@ extension ThingIFAPI {
         // generate command
         let targetID = triggeredCommandForm.targetID ?? target.typedID
         var commandDict = triggeredCommandForm.toDictionary()
-        commandDict["issuer"] = owner.typedID.toString() as AnyObject?
+        commandDict["issuer"] = owner.typedID.toString()
         if commandDict["target"] == nil {
-            commandDict["target"] = targetID.toString() as AnyObject?
+            commandDict["target"] = targetID.toString()
         }
 
         // generate body
-        var requestBodyDict: Dictionary<String, AnyObject> = [
+        var requestBodyDict: Dictionary<String, Any> = [
           "predicate": predicate.toNSDictionary(),
-          "command": commandDict as AnyObject,
-          "triggersWhat": TriggersWhat.COMMAND.rawValue as AnyObject]
-        requestBodyDict["title"] = options?.title as AnyObject?
-        requestBodyDict["description"] = options?.triggerDescription as AnyObject?
-        requestBodyDict["metadata"] = options?.metadata as AnyObject?
+          "command": commandDict,
+          "triggersWhat": TriggersWhat.COMMAND.rawValue]
+        requestBodyDict["title"] = options?.title
+        requestBodyDict["description"] = options?.triggerDescription
+        requestBodyDict["metadata"] = options?.metadata
 
         do{
             let requestBodyData = try JSONSerialization.data(withJSONObject: requestBodyDict, options: JSONSerialization.WritingOptions(rawValue: 0))
@@ -102,13 +102,13 @@ extension ThingIFAPI {
         let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(owner.accessToken)", "content-type": "application/json"]
         
         // generate body
-        var requestBodyDict: Dictionary<String, AnyObject> = [
+        var requestBodyDict: Dictionary<String, Any> = [
           "predicate": predicate.toNSDictionary(),
           "serverCode": serverCode.toNSDictionary(),
-          "triggersWhat": TriggersWhat.SERVER_CODE.rawValue as AnyObject]
-        requestBodyDict["title"] = options?.title as AnyObject?
-        requestBodyDict["description"] = options?.triggerDescription as AnyObject?
-        requestBodyDict["metadata"] = options?.metadata as AnyObject?
+          "triggersWhat": TriggersWhat.SERVER_CODE.rawValue]
+        requestBodyDict["title"] = options?.title
+        requestBodyDict["description"] = options?.triggerDescription
+        requestBodyDict["metadata"] = options?.metadata
         do{
             let requestBodyData =
               try JSONSerialization.data(
@@ -164,12 +164,12 @@ extension ThingIFAPI {
         let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(owner.accessToken)", "content-type": "application/json"]
 
         // generate body
-        var requestBodyDict: Dictionary<String, AnyObject> = [
-          "triggersWhat": TriggersWhat.COMMAND.rawValue as AnyObject
+        var requestBodyDict: Dictionary<String, Any> = [
+          "triggersWhat": TriggersWhat.COMMAND.rawValue
         ];
-        requestBodyDict["title"] = options?.title as AnyObject?
-        requestBodyDict["description"] = options?.triggerDescription as AnyObject?
-        requestBodyDict["metadata"] = options?.metadata as AnyObject?
+        requestBodyDict["title"] = options?.title
+        requestBodyDict["description"] = options?.triggerDescription
+        requestBodyDict["metadata"] = options?.metadata
 
         // generate predicate
         if predicate != nil {
@@ -179,11 +179,11 @@ extension ThingIFAPI {
         // generate command
         if let form = triggeredCommandForm {
             var command = form.toDictionary()
-            command["issuer"] = owner.typedID.toString() as AnyObject?
+            command["issuer"] = owner.typedID.toString()
             if command["target"] == nil {
-                command["target"] = target.typedID.toString() as AnyObject?
+                command["target"] = target.typedID.toString()
             }
-            requestBodyDict["command"] = command as AnyObject?
+            requestBodyDict["command"] = command
         }
         do{
             let requestBodyData = try JSONSerialization.data(withJSONObject: requestBodyDict, options: JSONSerialization.WritingOptions(rawValue: 0))
@@ -233,14 +233,14 @@ extension ThingIFAPI {
         let requestHeaderDict:Dictionary<String, String> = ["authorization": "Bearer \(owner.accessToken)", "content-type": "application/json"]
         
         // generate body
-        var requestBodyDict: Dictionary<String, AnyObject> = [
-          "triggersWhat" : TriggersWhat.SERVER_CODE.rawValue as AnyObject
+        var requestBodyDict: Dictionary<String, Any> = [
+          "triggersWhat" : TriggersWhat.SERVER_CODE.rawValue
         ]
         requestBodyDict["predicate"] = predicate?.toNSDictionary()
         requestBodyDict["serverCode"] = serverCode?.toNSDictionary()
-        requestBodyDict["title"] = options?.title as AnyObject?;
-        requestBodyDict["description"] = options?.triggerDescription as AnyObject?;
-        requestBodyDict["metadata"] = options?.metadata as AnyObject?;
+        requestBodyDict["title"] = options?.title
+        requestBodyDict["description"] = options?.triggerDescription
+        requestBodyDict["metadata"] = options?.metadata
         do{
             let requestBodyData = try JSONSerialization.data(withJSONObject: requestBodyDict, options: JSONSerialization.WritingOptions(rawValue: 0))
             // do request

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -108,7 +108,7 @@ open class ThingIFAPI: NSObject, NSCoding {
         _ vendorThingID:String,
         thingPassword:String,
         thingType:String?,
-        thingProperties:Dictionary<String,AnyObject>?,
+        thingProperties:Dictionary<String, Any>?,
         completionHandler: @escaping (Target?, ThingIFError?)-> Void
         ) ->Void
     {
@@ -292,7 +292,7 @@ open class ThingIFAPI: NSObject, NSCoding {
     open func postNewCommand(
         _ schemaName:String,
         schemaVersion:Int,
-        actions:[Dictionary<String,AnyObject>],
+        actions:[Dictionary<String, Any>],
         completionHandler: @escaping (Command?, ThingIFError?)-> Void
         ) -> Void
     {
@@ -417,7 +417,7 @@ open class ThingIFAPI: NSObject, NSCoding {
     open func postNewTrigger(
         _ schemaName:String,
         schemaVersion:Int,
-        actions:[Dictionary<String, AnyObject>],
+        actions:[Dictionary<String, Any>],
         predicate:Predicate,
         completionHandler: @escaping (Trigger?, ThingIFError?)-> Void
         )
@@ -528,7 +528,7 @@ open class ThingIFAPI: NSObject, NSCoding {
         _ triggerID:String,
         schemaName:String?,
         schemaVersion:Int?,
-        actions:[Dictionary<String, AnyObject>]?,
+        actions:[Dictionary<String, Any>]?,
         predicate:Predicate?,
         completionHandler: @escaping (Trigger?, ThingIFError?)-> Void
         )
@@ -666,7 +666,7 @@ open class ThingIFAPI: NSObject, NSCoding {
     - Parameter completionHandler: A closure to be executed once get state has finished. The closure takes 2 arguments: 1st one is Dictionary that represent Target State and 2nd one is an instance of ThingIFError when failed.
     */
     open func getState(
-        _ completionHandler: @escaping (Dictionary<String, AnyObject>?,  ThingIFError?)-> Void
+        _ completionHandler: @escaping (Dictionary<String, Any>?,  ThingIFError?)-> Void
         )
     {
         _getState(completionHandler)

--- a/ThingIFSDK/ThingIFSDK/Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/Trigger.swift
@@ -32,7 +32,7 @@ open class Trigger: NSObject, NSCoding {
         self.serverCode = aDecoder.decodeObject(forKey: "serverCode") as? ServerCode
         self.title = aDecoder.decodeObject(forKey: "title") as? String
         self.triggerDescription = aDecoder.decodeObject(forKey: "triggerDescription") as? String
-        self.metadata = aDecoder.decodeObject(forKey: "metadata") as? Dictionary<String, AnyObject>
+        self.metadata = aDecoder.decodeObject(forKey: "metadata") as? Dictionary<String, Any>
         // TODO: add aditional decoder
     }
     
@@ -85,7 +85,7 @@ open class Trigger: NSObject, NSCoding {
 
         let title = triggerDict["title"] as? String
         let triggerDescription = triggerDict["description"] as? String
-        let metadata = triggerDict["metadata"] as? Dictionary<String, AnyObject>
+        let metadata = triggerDict["metadata"] as? Dictionary<String, Any>
 
         if triggerID != nil && predicate != nil && command != nil && disabled != nil{
             trigger = Trigger(triggerID: triggerID!, targetID: targetID, enabled: !(disabled!), predicate: predicate!, command: command!, title: title, triggerDescription: triggerDescription, metadata: metadata)
@@ -114,7 +114,7 @@ open class Trigger: NSObject, NSCoding {
     /** Description of the Trigger */
     open let triggerDescription: String?
     /** Metadata of the Trigger */
-    open let metadata: Dictionary<String, AnyObject>?
+    open let metadata: Dictionary<String, Any>?
 
     /** Init Trigger with Command
 
@@ -124,7 +124,7 @@ open class Trigger: NSObject, NSCoding {
     - Parameter predicate: Predicate instance
     - Parameter command: Command instance
     */
-    public init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, command: Command, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, AnyObject>? = nil) {
+    public init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, command: Command, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, Any>? = nil) {
         self.triggerID = triggerID
         self.targetID = targetID
         self.enabled = enabled
@@ -143,7 +143,7 @@ open class Trigger: NSObject, NSCoding {
      - Parameter predicate: Predicate instance
      - Parameter serverCode: ServerCode instance
      */
-    public init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, serverCode: ServerCode, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, AnyObject>? = nil) {
+    public init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, serverCode: ServerCode, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, Any>? = nil) {
         self.triggerID = triggerID
         self.targetID = targetID
         self.enabled = enabled

--- a/ThingIFSDK/ThingIFSDK/TriggerOptions.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggerOptions.swift
@@ -26,7 +26,7 @@ open class TriggerOptions: NSObject, NSCoding {
     open let triggerDescription: String?
 
     /// Meta data of a trigger.
-    open let metadata: Dictionary<String, AnyObject>?
+    open let metadata: Dictionary<String, Any>?
 
     // MARK: - Initializing TriggerOptions instance.
     /**
@@ -40,7 +40,7 @@ open class TriggerOptions: NSObject, NSCoding {
     */
     public init(title: String? = nil,
                 triggerDescription: String? = nil,
-                metadata: Dictionary<String, AnyObject>? = nil)
+                metadata: Dictionary<String, Any>? = nil)
     {
         self.title = title
         self.triggerDescription = triggerDescription;
@@ -59,6 +59,6 @@ open class TriggerOptions: NSObject, NSCoding {
         self.triggerDescription =
             aDecoder.decodeObject(forKey: "triggerDescription") as? String
         self.metadata = aDecoder.decodeObject(forKey: "metadata")
-                as? Dictionary<String, AnyObject>
+                as? Dictionary<String, Any>
     }
 }

--- a/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
@@ -41,7 +41,7 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     open let schemaVersion: Int
 
     /// List of actions.
-    open let actions: [Dictionary<String, AnyObject>]
+    open let actions: [Dictionary<String, Any>]
 
     /// Target thing ID.
     open let targetID: TypedID?
@@ -53,7 +53,7 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     open let commandDescription: String?
 
     /// Meta data of ad command.
-    open let metadata: Dictionary<String, AnyObject>?
+    open let metadata: Dictionary<String, Any>?
 
 
     // MARK: - Initializing TriggeredCommandForm instance.
@@ -72,11 +72,11 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     */
     public init(schemaName: String,
                 schemaVersion: Int,
-                actions: [Dictionary<String, AnyObject>],
+                actions: [Dictionary<String, Any>],
                 targetID: TypedID? = nil,
                 title: String? = nil,
                 commandDescription: String? = nil,
-                metadata: Dictionary<String, AnyObject>? = nil)
+                metadata: Dictionary<String, Any>? = nil)
     {
         self.schemaName = schemaName
         self.schemaVersion = schemaVersion
@@ -117,11 +117,11 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     public init(command: Command,
                 schemaName: String? = nil,
                 schemaVersion: Int? = nil,
-                actions: [Dictionary<String, AnyObject>]? = nil,
+                actions: [Dictionary<String, Any>]? = nil,
                 targetID: TypedID? = nil,
                 title: String? = nil,
                 commandDescription: String? = nil,
-                metadata: Dictionary<String, AnyObject>? = nil)
+                metadata: Dictionary<String, Any>? = nil)
     {
         self.schemaName = schemaName != nil ? schemaName! : command.schemaName
         self.schemaVersion =
@@ -150,28 +150,28 @@ open class TriggeredCommandForm: NSObject, NSCoding {
         self.schemaName = aDecoder.decodeObject(forKey: "schemaName") as! String
         self.schemaVersion = aDecoder.decodeInteger(forKey: "schemaVersion")
         self.actions = aDecoder.decodeObject(forKey: "actions")
-                as! [Dictionary<String, AnyObject>];
+                as! [Dictionary<String, Any>];
         self.targetID = aDecoder.decodeObject(forKey: "targetID") as? TypedID
         self.title = aDecoder.decodeObject(forKey: "title") as? String
         self.commandDescription =
             aDecoder.decodeObject(forKey: "commandDescription") as? String;
         self.metadata = aDecoder.decodeObject(forKey: "metadata")
-                as? Dictionary<String, AnyObject>;
+                as? Dictionary<String, Any>;
     }
 
-    func toDictionary() -> Dictionary<String, AnyObject> {
-        var retval: Dictionary<String, AnyObject> =
+    func toDictionary() -> Dictionary<String, Any> {
+        var retval: Dictionary<String, Any> =
             [
-                "schema": self.schemaName as AnyObject,
-                "schemaVersion": self.schemaVersion as AnyObject,
-                "actions": self.actions as AnyObject
+                "schema": self.schemaName,
+                "schemaVersion": self.schemaVersion,
+                "actions": self.actions
             ]
         if let targetID = self.targetID {
-            retval["target"] = targetID.toString() as AnyObject?
+            retval["target"] = targetID.toString()
         }
-        retval["title"] = self.title as AnyObject?
-        retval["description"] = self.commandDescription as AnyObject?;
-        retval["metadata"] = self.metadata as AnyObject?;
+        retval["title"] = self.title
+        retval["description"] = self.commandDescription
+        retval["metadata"] = self.metadata
         return retval;
     }
 }

--- a/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
@@ -15,7 +15,7 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
     // MARK: - Implements NSCoding protocol
     public required init(coder aDecoder: NSCoder) {
         self.succeeded = aDecoder.decodeBool(forKey: "succeeded")
-        self.returnedValue = aDecoder.decodeObject(forKey: "returnedValue") as AnyObject?
+        self.returnedValue = aDecoder.decodeObject(forKey: "returnedValue")
         self.executedAt = Date(timeIntervalSince1970: aDecoder.decodeDouble(forKey: "executedAt"))
         self.endpoint = aDecoder.decodeObject(forKey: "endpoint") as! String
         self.error = aDecoder.decodeObject(forKey: "error") as? ServerError
@@ -25,7 +25,7 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
     /** Whether the invocation succeeded */
     open let succeeded: Bool
     /** Returned value from server code (JsonObject, JsonArray, String, Number, Boolean or null) */
-    open let returnedValue: AnyObject?
+    open let returnedValue: Any?
     /** Date of the execution */
     open let executedAt: Date
     /** The endpoint used in the server code invocation */
@@ -42,7 +42,7 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
      - Parameter endpoint: The endpoint used in the server code invocation
      - Parameter error: Error object of the invocation if any
      */
-    public init(succeeded: Bool, returnedValue: AnyObject?, executedAt: Date, endpoint: String, error: ServerError?) {
+    public init(succeeded: Bool, returnedValue: Any?, executedAt: Date, endpoint: String, error: ServerError?) {
         self.succeeded = succeeded
         self.returnedValue = returnedValue
         self.executedAt = executedAt
@@ -50,7 +50,7 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
         self.error = error
     }
     
-    open func getReturnedValue() -> AnyObject? {
+    open func getReturnedValue() -> Any? {
         return self.returnedValue
     }
     open func getReturnedValueAsString() -> String? {
@@ -68,11 +68,11 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
     open func getReturnedValueAsNSNumber() -> NSNumber? {
         return self.returnedValue as? NSNumber
     }
-    open func getReturnedValueAsDictionary() -> Dictionary<String, AnyObject>? {
-        return self.returnedValue as? Dictionary<String, AnyObject>
+    open func getReturnedValueAsDictionary() -> Dictionary<String, Any>? {
+        return self.returnedValue as? Dictionary<String, Any>
     }
-    open func getReturnedValueAsArray() -> [AnyObject]? {
-        return self.returnedValue as? [AnyObject]
+    open func getReturnedValueAsArray() -> [Any]? {
+        return self.returnedValue as? [Any]
     }
 
     open override func isEqual(_ object: Any?) -> Bool {
@@ -84,12 +84,12 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
                 return false
             }
         } else {
-            if self.returnedValue! is Dictionary<String, AnyObject> {
+            if self.returnedValue! is Dictionary<String, Any> {
                 if !NSDictionary(dictionary: self.returnedValue as! [AnyHashable: Any]).isEqual(to: aResult.returnedValue as! [AnyHashable: Any]) {
                     return false
                 }
-            } else if self.returnedValue! is [AnyObject] {
-                if !isEqualArray(self.returnedValue as! [AnyObject], arr2: aResult.returnedValue as! [AnyObject]) {
+            } else if self.returnedValue! is [Any] {
+                if !isEqualArray(self.returnedValue as! [Any], arr2: aResult.returnedValue as! [Any]) {
                     return false
                 }
             } else if self.returnedValue! is String {
@@ -115,19 +115,19 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
         }
         return self.succeeded == aResult.succeeded && self.executedAt == aResult.executedAt && self.endpoint == aResult.endpoint
     }
-    fileprivate func isEqualArray(_ arr1:[AnyObject], arr2:[AnyObject]) -> Bool {
+    fileprivate func isEqualArray(_ arr1:[Any], arr2:[Any]) -> Bool {
         if arr1.count != arr2.count {
             return false
         }
         for i in 0 ..< arr1.count {
             let e1 = arr1[i]
             let e2 = arr2[i]
-            if e1 is Dictionary<String, AnyObject> {
+            if e1 is Dictionary<String, Any> {
                 if !NSDictionary(dictionary: e1 as! [AnyHashable: Any]).isEqual(to: e2 as! [AnyHashable: Any]) {
                     return false
                 }
-            } else if e1 is [AnyObject] {
-                if !isEqualArray(e1 as! [AnyObject], arr2: e2 as! [AnyObject]) {
+            } else if e1 is [Any] {
+                if !isEqualArray(e1 as! [Any], arr2: e2 as! [Any]) {
                     return false
                 }
             } else if e1 is String {
@@ -156,9 +156,9 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
         guard let executedAtStamp = resultDict["executedAt"] as? NSNumber else{
             return nil
         }
-        let returnedValue = resultDict["returnedValue"] as AnyObject?
+        let returnedValue = resultDict["returnedValue"]
         
-        let error = resultDict["error"] as? Dictionary<String, AnyObject>
+        let error = resultDict["error"] as? Dictionary<String, Any>
         var serverError: ServerError? = nil
         if error != nil {
             serverError = ServerError.errorWithNSDict(error! as NSDictionary)


### PR DESCRIPTION
### 問題点

Swift 3.0から`AnyObject`の代わりに`Any`を使うことになりました。

詳細は[Import Objective-C id as Swift Any type](https://github.com/apple/swift-evolution/blob/master/proposals/0116-id-as-any.md)に記載されています。

Cocoaライブラリのメソッドの引数や戻り値が、NSArrayやNSDictionaryなものは、以前はその中身はAnyObjectだったのが、Anyに変わるというものです。
### 必要な修正

この結果、以下の2点の修正が必要になると考えています。
1. SDK内部としては、Cocoaライブラリへの受渡しのためにAnyObjectからAnyへの変更が必要
2. APIとしては、リテラルの記述を容易にするために、AnyObjectからAnyへの変更が必要

2つ目について、説明します。

AnyObjectから、Anyに変更されたことで、`AnyObject`で行われていた暗黙的な変換が行われなくなります。結果、`Dictionary`や`Array`のリテラルを記述する際に冗長なコードを記載しなければいけなくなりました。

thing-if iOSSDKでは、actionやmetadataなどを`Dictionary<String, AnyObject>`で受けています。このままですと、以下のような冗長なコードを記述することをアプリケーションに要求することになります。

``` swift
let dict: Dictionary<String, AnyObject> =
    [
        "key": "value" as AnyObject
    ]
```

以前は `as AnyObject`は不要でした。Anyの場合、この`as AnyObject`は不要になります。

``` swift
let dict: Dictionary<String, Any> =
    [
        "key": "value"
    ]
```

このためAPIを含め、AnyObjectをAnyに変更しようと考えています。

Related PR: #188
Realted issue: No. 989
Release version: 1.0.0
