### PR TITLE
Implicitly unwrapping is removed

### DIFF
--- a/ThingIFSDK/ThingIFSDKTests/TestSetting.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TestSetting.swift
@@ -10,18 +10,18 @@ import UIKit
 
 open class TestSetting: NSObject {
 
-    let app:App!
+    let app:App
 
-    let owner:Owner!
-    let ownerID:String!
-    let ownerToken:String!
+    let owner:Owner
+    let ownerID:String
+    let ownerToken:String
 
-    let target:Target!
-    let thingID:String!
+    let target:Target
+    let thingID:String
 
-    let appID:String!
-    let appKey:String!
-    let hostName:String!
+    let appID:String
+    let appKey:String
+    let hostName:String
 
     let api:ThingIFAPI
 


### PR DESCRIPTION
This PR is not testable and buildable. This PR is a part of migration of swift 3.0

Implicitly unwrapping optional type is used at unnecessary place.

This cause error requiring unwrapping.

Related PR: #188 
