### PR TITLE
Error fix

### DIFF
--- a/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
@@ -118,7 +118,7 @@ class GetStateTests: SmallTestBase {
 
             for (k,v) in dict! {
                 let val : Any = result![k]!
-                XCTAssertTrue(v === val)
+                XCTAssertTrue(v as AnyObject ===  val as AnyObject)
             }
 
             expectation.fulfill()
@@ -295,8 +295,8 @@ class GetStateTests: SmallTestBase {
             }
             
             for (k,v) in dict! {
-                let val : AnyObject = result![k]!
-                XCTAssertTrue(v === val)
+                let val : Any = result![k]!
+                XCTAssertTrue(v as AnyObject === val as AnyObject)
             }
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
@@ -118,7 +118,7 @@ class GetStateTests: SmallTestBase {
 
             for (k,v) in dict! {
                 let val : Any = result![k]!
-                XCTAssertTrue(v as AnyObject ===  val as AnyObject)
+                XCTAssertTrue((v as AnyObject).isEqual(val))
             }
 
             expectation.fulfill()
@@ -296,7 +296,7 @@ class GetStateTests: SmallTestBase {
             
             for (k,v) in dict! {
                 let val : Any = result![k]!
-                XCTAssertTrue(v as AnyObject === val as AnyObject)
+                XCTAssertTrue((v as AnyObject).isEqual(val))
             }
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
@@ -72,8 +72,8 @@ class OnboardingTests: SmallTestBase {
                         XCTFail("should not be connection error")
                     case .error_RESPONSE(let actualErrorResponse):
                         XCTAssertEqual(400, actualErrorResponse.httpStatusCode)
-                        XCTAssertEqual(dict["errorCode"]!, actualErrorResponse.errorCode)
-                        XCTAssertEqual(dict["message"]!, actualErrorResponse.errorMessage)
+                        XCTAssertEqual(dict["errorCode"] as! String, actualErrorResponse.errorCode)
+                        XCTAssertEqual(dict["message"] as! String, actualErrorResponse.errorMessage)
                     default:
                         break
                     }

--- a/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
@@ -122,8 +122,8 @@ class OnboardingTests: SmallTestBase {
                 }
                 
                 //verify body
-                let expectedBody = ["vendorThingID": vendorThingID, "thingPassword": thingPassword, "owner": owner.typedID.toString(), "thingType":thingType, "thingProperties":["key1":"value1", "key2":"value2"]]
-                self.verifyDict(expectedBody as! Dictionary<String, Any>, actualData: request.httpBody!)
+                let expectedBody: [String : Any] = ["vendorThingID": vendorThingID, "thingPassword": thingPassword, "owner": owner.typedID.toString(), "thingType":thingType, "thingProperties":["key1":"value1", "key2":"value2"]]
+                self.verifyDict(expectedBody, actualData: request.httpBody!)
                 XCTAssertEqual(request.url?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/onboardings")
             }
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
@@ -210,8 +210,8 @@ class OnboardingTests: SmallTestBase {
                 }
 
                 //verify body
-                let expectedBody = ["vendorThingID": vendorThingID, "thingPassword": thingPassword, "owner": owner.typedID.toString(), "thingType":thingType, "thingProperties":["key1":"value1", "key2":"value2"]]
-                self.verifyDict(expectedBody as! Dictionary<String, Any>, actualData: request.httpBody!)
+                let expectedBody: [String : Any] = ["vendorThingID": vendorThingID, "thingPassword": thingPassword, "owner": owner.typedID.toString(), "thingType":thingType, "thingProperties":["key1":"value1", "key2":"value2"]]
+                self.verifyDict(expectedBody, actualData: request.httpBody!)
                 XCTAssertEqual(request.url?.absoluteString, setting.app.baseURL + "/thing-if/apps/50a62843/onboardings")
             }
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -93,7 +93,7 @@ class PostNewCommandTests: SmallTestBase {
                     XCTAssertNotNil(command, tag)
                     XCTAssertEqual(command!.commandID, expectedCommandID, tag)
                     XCTAssertEqual(command!.targetID.toString(), testcase.target.typedID.toString(), tag)
-                    XCTAssertEqual(command!.actions, testcase.actions, tag)
+                    self.verifyArray(command!.actions, actual: testcase.actions, message: tag)
                 }else {
                     XCTFail("should success for \(tag)")
                 }

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
@@ -187,7 +187,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
                     XCTAssertNotNil(command, tag)
                     XCTAssertEqual(command!.commandID, expectedCommandID, tag)
                     XCTAssertEqual(command!.targetID.toString(), testcase.target.typedID.toString(), tag)
-                    XCTAssertEqual(command!.actions, testcase.actions, tag)
+                    self.verifyArray(command!.actions, actual: testcase.actions, message: tag)
                 }else {
                     XCTFail("should success for \(tag)")
                 }

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -12,15 +12,27 @@ import XCTest
 
 extension XCTestCase {
 
-    func verifyArray(_ expected: [Any], actual: [Any]?) {
-        guard let actual2 = actual else {
-            XCTFail("actual must not be nil")
+    func verifyArray(_ expected: [Any]?,
+                     actual: [Any]?,
+                     message: String? = nil)
+    {
+        if expected == nil && actual == nil {
+            return
+        }
+        guard let expected2 = expected, let actual2 = actual else {
+            XCTFail("one of expected or actual is nil")
             return
         }
 
-        let error_message = "expected=" + expected.description +
-          "actual=" + actual2.description
-        XCTAssertEqual(NSArray(array: expected), NSArray(array: actual2),
+        let error_message: String
+        if let message2 = message {
+            error_message = message2 + ", expected=" + expected2.description +
+              "actual=" + actual2.description
+        } else {
+            error_message = "expected=" + expected2.description +
+              "actual=" + actual2.description
+        }
+        XCTAssertEqual(NSArray(array: expected2), NSArray(array: actual2),
                       error_message)
     }
     


### PR DESCRIPTION
This PR is a part of migration of swift 3.0

Some errors are fixed.

  * Any is casted to AnyObject to use === operator. (b8ffaa3)
  * XCTAssertEqual is not applied to [Any]. (217dd80)
  * Heterogenous collection literal could only be inferred to '[String : Any]' (7852fa2)


Related PR: #188