### PR TITLE
Remove implicitly unwrap

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -18,15 +18,15 @@ open class ThingIFAPI: NSObject, NSCoding {
 
     let operationQueue = OperationQueue()
     /** URL of KiiApps Server */
-    open let baseURL: String!
+    open let baseURL: String
     /** The application ID found in your Kii developer console */
-    open let appID: String!
+    open let appID: String
     /** The application key found in your Kii developer console */
-    open let appKey: String!
+    open let appKey: String
     /** Kii Cloud Application */
-    open let app: App!
+    open let app: App
     /** owner of target */
-    open let owner: Owner!
+    open let owner: Owner
 
     var _installationID:String?
     var _target: Target?

--- a/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
@@ -82,7 +82,7 @@ class GetCommandTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "GET")
 
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID!)/targets/\(testcase.targetIDString)/commands/\(commandID)"
+                let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(testcase.targetIDString)/commands/\(commandID)"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal for \(tag)")
 
                 //verify header
@@ -157,7 +157,7 @@ class GetCommandTests: SmallTestBase {
             let requestVerifier: ((URLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.httpMethod, "GET")
                 // verify path
-                let expectedPath = "\(api.baseURL!)/thing-if/apps/\(api.appID!)/targets/\(setting.target.typedID.type):\(setting.target.typedID.id)/commands/\(commandID)"
+                let expectedPath = "\(api.baseURL)/thing-if/apps/\(api.appID)/targets/\(setting.target.typedID.type):\(setting.target.typedID.id)/commands/\(commandID)"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
                 //verify header

--- a/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
@@ -79,7 +79,7 @@ class GetStateTests: SmallTestBase {
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.httpMethod, "GET")
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID!)/targets/\(setting.target.typedID.toString())/states"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/states"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = ["authorization": "Bearer \(setting.owner.accessToken)", "content-type": "application/json"]
@@ -136,7 +136,7 @@ class GetStateTests: SmallTestBase {
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.httpMethod, "GET")
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID!)/targets/\(setting.target.typedID.toString())/states"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/states"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = ["authorization": "Bearer \(setting.owner.accessToken)", "content-type": "application/json"]
@@ -194,7 +194,7 @@ class GetStateTests: SmallTestBase {
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.httpMethod, "GET")
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID!)/targets/\(setting.target.typedID.toString())/states"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/states"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = ["authorization": "Bearer \(setting.owner.accessToken)", "content-type": "application/json"]
@@ -253,7 +253,7 @@ class GetStateTests: SmallTestBase {
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.httpMethod, "GET")
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID!)/targets/\(setting.target.typedID.toString())/states"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/states"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = ["authorization": "Bearer \(setting.owner.accessToken)", "content-type": "application/json"]

--- a/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
@@ -35,7 +35,7 @@ class GetVendorThingIDTests: SmallTestBase {
             let requestVerifier: ((URLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.httpMethod, "GET")
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/api/apps/\(setting.appID)/things/\(setting.target.typedID.id)/vendor-thing-id"
+                let expectedPath = "\(setting.api.baseURL)/api/apps/\(setting.appID)/things/\(setting.target.typedID.id)/vendor-thing-id"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
                 //verify header
                 let expectedHeader = [
@@ -91,7 +91,7 @@ class GetVendorThingIDTests: SmallTestBase {
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.httpMethod, "GET")
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/api/apps/\(setting.appID)/things/\(setting.target.typedID.id)/vendor-thing-id"
+            let expectedPath = "\(setting.api.baseURL)/api/apps/\(setting.appID)/things/\(setting.target.typedID.id)/vendor-thing-id"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = [

--- a/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
@@ -115,7 +115,7 @@ class ListCommandsTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "GET")
 
                 // verify path
-                let expectedBasePath = "\(setting.app.baseURL)/thing-if/apps/\(setting.api.appID!)/targets/\(setting.target.typedID.toString())/commands"
+                let expectedBasePath = "\(setting.app.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/commands"
                 let actualRequestPathString = request.url!.absoluteString
                 XCTAssertTrue(actualRequestPathString.range(of: expectedBasePath) != nil, tag)
                 if testcase.paginationKey != nil || testcase.bestEffortLimit != nil {
@@ -210,7 +210,7 @@ class ListCommandsTests: SmallTestBase {
             let requestVerifier: ((URLRequest) -> Void) = {(request) in
                 XCTAssertEqual(request.httpMethod, "GET")
                 // verify path
-                let expectedPath = "\(api.baseURL!)/thing-if/apps/\(api.appID!)/targets/\(setting.target.typedID.type):\(setting.target.typedID.id)/commands"
+                let expectedPath = "\(api.baseURL)/thing-if/apps/\(api.appID)/targets/\(setting.target.typedID.type):\(setting.target.typedID.id)/commands"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
                 //verify header

--- a/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
@@ -41,7 +41,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "POST")
 
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+                let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
                 //verify header
@@ -135,7 +135,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -225,7 +225,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -315,7 +315,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -570,7 +570,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "POST")
 
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+                let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
                 //verify header
@@ -667,7 +667,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -760,7 +760,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -853,7 +853,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header

--- a/ThingIFSDK/ThingIFSDKTests/OnboardTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardTests.swift
@@ -43,7 +43,7 @@ class OnboardTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "POST")
 
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+                let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
                 //verify header
@@ -132,7 +132,7 @@ class OnboardTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -217,7 +217,7 @@ class OnboardTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -302,7 +302,7 @@ class OnboardTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -447,7 +447,7 @@ class OnboardTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "POST")
 
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+                let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
                 //verify header
@@ -528,7 +528,7 @@ class OnboardTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -606,7 +606,7 @@ class OnboardTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -684,7 +684,7 @@ class OnboardTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "POST")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.appID)/onboardings"
+            let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.appID)/onboardings"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -65,7 +65,7 @@ class PostNewCommandTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "POST")
 
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID!)/targets/\(testcase.target.typedID.toString())/commands"
+                let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(testcase.target.typedID.toString())/commands"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal for \(tag)")
 
                 //verify header
@@ -132,7 +132,7 @@ class PostNewCommandTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "POST")
 
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID!)/targets/\(target.typedID.toString())/commands"
+                let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(target.typedID.toString())/commands"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
                 //verify header

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
@@ -151,7 +151,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "POST")
 
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID!)/targets/\(testcase.target.typedID.toString())/commands"
+                let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(testcase.target.typedID.toString())/commands"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal for \(tag)")
 
                 //verify header
@@ -226,7 +226,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
                 XCTAssertEqual(request.httpMethod, "POST")
 
                 // verify path
-                let expectedPath = "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID!)/targets/\(target.typedID.toString())/commands"
+                let expectedPath = "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(target.typedID.toString())/commands"
                 XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
                 //verify header

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerWithTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerWithTriggerOptionsTests.swift
@@ -94,7 +94,7 @@ class PostNewServerCodeTriggerWithTriggerOptionsTests: SmallTestBase {
             sharedMockSession.requestVerifier = {(request) in
                 XCTAssertEqual(request.httpMethod, "POST", error_message)
                 XCTAssertEqual(request.url!.absoluteString,
-                               "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers",
+                               "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers",
                                error_message)
                 let requestHeaders = request.allHTTPHeaderFields!;
                 // verify request header.

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggerOptionsTests.swift
@@ -86,7 +86,7 @@ class PostNewTriggerWithTriggerOptionsTests: SmallTestBase {
             sharedMockSession.requestVerifier = {(request) in
                 XCTAssertEqual(request.httpMethod, "POST", error_message)
                 XCTAssertEqual(request.url!.absoluteString,
-                               "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers",
+                               "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers",
                                error_message)
                 let requestHeaders = request.allHTTPHeaderFields!;
                 // verify request header.

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggeredCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggeredCommandFormTests.swift
@@ -148,7 +148,7 @@ class PostNewTriggerWithTriggeredCommandFormTests: SmallTestBase {
             sharedMockSession.requestVerifier = {(request) in
                 XCTAssertEqual(request.httpMethod, "POST", error_message)
                 XCTAssertEqual(request.url!.absoluteString,
-                               "\(setting.api.baseURL!)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers",
+                               "\(setting.api.baseURL)/thing-if/apps/\(setting.api.appID)/targets/\(setting.target.typedID.toString())/triggers",
                                error_message)
                 let requestHeaders = request.allHTTPHeaderFields!;
                 // verify request header.

--- a/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
@@ -89,7 +89,7 @@ class PushUninstallationTests: SmallTestBase {
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.httpMethod, "DELETE")
-            let expectedPath = "\(setting.api.baseURL!)/api/apps/\(setting.api.appID!)/installations/\(installID)"
+            let expectedPath = "\(setting.api.baseURL)/api/apps/\(setting.api.appID)/installations/\(installID)"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = ["authorization": "Bearer \(setting.owner.accessToken)"]
@@ -124,7 +124,7 @@ class PushUninstallationTests: SmallTestBase {
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.httpMethod, "DELETE")
-            let expectedPath = "\(setting.api.baseURL!)/api/apps/\(setting.api.appID!)/installations/\(installID)"
+            let expectedPath = "\(setting.api.baseURL)/api/apps/\(setting.api.appID)/installations/\(installID)"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = ["authorization": "Bearer \(setting.owner.accessToken)"]
@@ -182,7 +182,7 @@ class PushUninstallationTests: SmallTestBase {
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
             XCTAssertEqual(request.httpMethod, "DELETE")
-            let expectedPath = "\(setting.api.baseURL!)/api/apps/\(setting.api.appID!)/installations/\(installID)"
+            let expectedPath = "\(setting.api.baseURL)/api/apps/\(setting.api.appID)/installations/\(installID)"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
             //verify header
             let expectedHeader = ["authorization": "Bearer \(setting.owner.accessToken)"]

--- a/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
@@ -37,7 +37,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "PUT")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/api/apps/\(setting.appID)/things/\(target.typedID.id)/vendor-thing-id"
+            let expectedPath = "\(setting.api.baseURL)/api/apps/\(setting.appID)/things/\(target.typedID.id)/vendor-thing-id"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -108,7 +108,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "PUT")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/api/apps/\(setting.appID)/things/\(target.typedID.id)/vendor-thing-id"
+            let expectedPath = "\(setting.api.baseURL)/api/apps/\(setting.appID)/things/\(target.typedID.id)/vendor-thing-id"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header
@@ -185,7 +185,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
             XCTAssertEqual(request.httpMethod, "PUT")
 
             // verify path
-            let expectedPath = "\(setting.api.baseURL!)/api/apps/\(setting.appID)/things/\(target.typedID.id)/vendor-thing-id"
+            let expectedPath = "\(setting.api.baseURL)/api/apps/\(setting.appID)/things/\(target.typedID.id)/vendor-thing-id"
             XCTAssertEqual(request.url!.absoluteString, expectedPath, "Should be equal")
 
             //verify header


### PR DESCRIPTION
ThingIFAPIの以下のプロパティが暗黙的なオプショナルとして宣言されていました。

  * baseURL
  * appID
  * appKey
  * app
  * owner

これらのプロパティはinitializerで値が設定されるもので、オプショナルである必要性がありません。

これらがオプショナルである結果、REST APIのURL作成が失敗するようになっています。`ThingIFAPI#deleteTrigger()`で作成されるURLの文字列が以下のようになっていました。


```
Optional(\"https://api-development-jp.internal.kii.com\")/thing-if/apps/Optional(\"50a62843\")/targets/thing:th.0267251d9d60-1858-5e11-3dc3-00f3f0b5/triggers/triggerID
```

不要な `Optional`という文字列がURLの中に入ってしまい、URLクラスのインスタンスを作成する際にURL文字列のパースに失敗するという状況です。

この修正方法は2つ考えられます。

  1. 不要な暗黙的なオプショナル宣言を消す
  1. それらのプロパティを利用している部分で、 "!" を使いアンラップする

本PRでは、1の方法を採用しました。

APIの変更になりますが、API設計上のバグと思われるものを残すより、メジャーバージョンアップに併せて修正した方が良いと判断したためです。
後方互換性はくずれますが、アンラップしている部分を削除してもらえば済むのでそれほど大きなインパクトにはならないのではと推測しています。

検討、よろしくお願いします。

Related PR: #188