### PR TITLE
Check sdk version for stored objects

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -500,6 +500,16 @@ open class GatewayAPI: NSObject, NSCoding {
 
     /** Try to load the instance of GatewayAPI using stored serialized instance.
 
+     Instance is automatically saved when login method is called and successfully completed.
+
+     If the GatewayAPI instance is build without the tag, all instance is saved in same place
+     and overwritten when the instance is saved.
+
+     If the GatewayAPI instance is build with the tag(optional), tag is used as key to distinguish
+     the storage area to save the instance. This would be useful to saving multiple instance.
+
+     When you catch exceptions, please call login for saving or updating serialized instance.
+
      - Parameter tag: tag of the GatewayAPI instance
      - Returns: GatewayIFAPI instance.
      */

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -514,9 +514,9 @@ open class GatewayAPI: NSObject, NSCoding {
         if let dict = UserDefaults.standard.object(forKey: baseKey) as? NSDictionary {
             if dict.object(forKey: key) != nil {
 
-                let sdkVersion = dict.object(forKey: versionKey) as? String
-                if isLoadable(sdkVersion) == false {
-                    throw ThingIFError.apiUnloadable
+                let storedSDKVersion = dict.object(forKey: versionKey) as? String
+                if isLoadable(storedSDKVersion) == false {
+                    throw ThingIFError.apiUnloadable(tag: tag, storedVersion: storedSDKVersion, minimumVersion: MINIMUM_LOADABLE_SDK_VERSION)
                 }
 
                 if let data = dict[key] as? Data {
@@ -529,10 +529,10 @@ open class GatewayAPI: NSObject, NSCoding {
                     throw ThingIFError.invalidStoredApi
                 }
             } else {
-                throw ThingIFError.apiNotStored
+                throw ThingIFError.apiNotStored(tag: tag)
             }
         } else {
-            throw ThingIFError.apiNotStored
+            throw ThingIFError.apiNotStored(tag: tag)
         }
     }
 

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -13,11 +13,11 @@ open class GatewayAPI: NSObject, NSCoding {
     private static func getStoredInstanceKey(_ tag : String?) -> String{
         return SHARED_NSUSERDEFAULT_KEY_INSTANCE + (tag == nil ? "" : "_\(tag)")
     }
-    fileprivate static let SHARED_NSUSERDEFAULT_SDK_VERSION_KEY = "GatewayAPI_VERSION"
-    fileprivate static func getStoredSDKVersionKey(_ tag : String?) -> String{
+    private static let SHARED_NSUSERDEFAULT_SDK_VERSION_KEY = "GatewayAPI_VERSION"
+    private static func getStoredSDKVersionKey(_ tag : String?) -> String{
         return SHARED_NSUSERDEFAULT_SDK_VERSION_KEY + (tag == nil ? "" : "_\(tag)")
     }
-    fileprivate static let MINIMUM_LOADABLE_SDK_VERSION = "0.13.0"
+    private static let MINIMUM_LOADABLE_SDK_VERSION = "0.13.0"
 
     open let tag: String?
     open let app: App

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -798,6 +798,19 @@ open class ThingIFAPI: NSObject, NSCoding {
 
     /** Try to load the instance of ThingIFAPI using stored serialized instance.
 
+    Instance is automatically saved when following methods are called.
+    onboard, onboardWithVendorThingID, copyWithTarget and installPush
+    has been successfully completed.
+    (When copyWithTarget is called, only the copied instance is saved.)
+
+    If the ThingIFAPI instance is build without the tag, all instance is saved in same place
+    and overwritten when the instance is saved.
+
+    If the ThingIFAPI instance is build with the tag(optional), tag is used as key to distinguish
+    the storage area to save the instance. This would be useful to saving multiple instance.
+
+    When you catch exceptions, please call onload for saving or updating serialized instance.
+
     - Parameter tag: tag of the ThingIFAPI instance
     - Returns: ThingIFAPI instance.
     */

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -12,11 +12,11 @@ open class ThingIFAPI: NSObject, NSCoding {
     private static func getStoredInstanceKey(_ tag : String?) -> String{
         return SHARED_NSUSERDEFAULT_KEY_INSTANCE + (tag == nil ? "" : "_\(tag!)")
     }
-    fileprivate static let SHARED_NSUSERDEFAULT_SDK_VERSION_KEY = "ThingIFAPI_VERSION"
-    fileprivate static func getStoredSDKVersionKey(_ tag : String?) -> String{
+    private static let SHARED_NSUSERDEFAULT_SDK_VERSION_KEY = "ThingIFAPI_VERSION"
+    private static func getStoredSDKVersionKey(_ tag : String?) -> String{
         return SHARED_NSUSERDEFAULT_SDK_VERSION_KEY + (tag == nil ? "" : "_\(tag!)")
     }
-    fileprivate static let MINIMUM_LOADABLE_SDK_VERSION = "0.13.0"
+    private static let MINIMUM_LOADABLE_SDK_VERSION = "0.13.0"
 
     /** Tag of the ThingIFAPI instance */
     open let tag : String?

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -10,11 +10,11 @@ open class ThingIFAPI: NSObject, NSCoding {
 
     private static let SHARED_NSUSERDEFAULT_KEY_INSTANCE = "ThingIFAPI_INSTANCE"
     private static func getStoredInstanceKey(_ tag : String?) -> String{
-        return SHARED_NSUSERDEFAULT_KEY_INSTANCE + (tag == nil ? "" : "_\(tag)")
+        return SHARED_NSUSERDEFAULT_KEY_INSTANCE + (tag == nil ? "" : "_\(tag!)")
     }
     fileprivate static let SHARED_NSUSERDEFAULT_SDK_VERSION_KEY = "ThingIFAPI_VERSION"
     fileprivate static func getStoredSDKVersionKey(_ tag : String?) -> String{
-        return SHARED_NSUSERDEFAULT_SDK_VERSION_KEY + (tag == nil ? "" : "_\(tag)")
+        return SHARED_NSUSERDEFAULT_SDK_VERSION_KEY + (tag == nil ? "" : "_\(tag!)")
     }
     fileprivate static let MINIMUM_LOADABLE_SDK_VERSION = "0.13.0"
 
@@ -812,9 +812,9 @@ open class ThingIFAPI: NSObject, NSCoding {
         {
             if dict.object(forKey: key) != nil {
 
-                let sdkVersion = dict.object(forKey: versionKey) as? String
-                if isLoadable(sdkVersion) == false {
-                    throw ThingIFError.apiUnloadable
+                let storedSDKVersion = dict.object(forKey: versionKey) as? String
+                if isLoadable(storedSDKVersion) == false {
+                    throw ThingIFError.apiUnloadable(tag: tag, storedVersion: storedSDKVersion, minimumVersion: MINIMUM_LOADABLE_SDK_VERSION)
                 }
 
                 if let data = dict[key] as? Data {
@@ -827,10 +827,10 @@ open class ThingIFAPI: NSObject, NSCoding {
                     throw ThingIFError.invalidStoredApi
                 }
             } else {
-                throw ThingIFError.apiNotStored
+                throw ThingIFError.apiNotStored(tag: tag)
             }
         }else{
-            throw ThingIFError.apiNotStored
+            throw ThingIFError.apiNotStored(tag: tag)
         }
     }
     /** Save this instance

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -9,11 +9,11 @@ import Foundation
 open class ThingIFAPI: NSObject, NSCoding {
 
     private static let SHARED_NSUSERDEFAULT_KEY_INSTANCE = "ThingIFAPI_INSTANCE"
-    private static func getSharedNSDefaultKey(_ tag : String?) -> String{
+    private static func getStoredInstanceKey(_ tag : String?) -> String{
         return SHARED_NSUSERDEFAULT_KEY_INSTANCE + (tag == nil ? "" : "_\(tag)")
     }
     fileprivate static let SHARED_NSUSERDEFAULT_SDK_VERSION_KEY = "ThingIFAPI_VERSION"
-    fileprivate static func getSharedSDKVersionKey(_ tag : String?) -> String{
+    fileprivate static func getStoredSDKVersionKey(_ tag : String?) -> String{
         return SHARED_NSUSERDEFAULT_SDK_VERSION_KEY + (tag == nil ? "" : "_\(tag)")
     }
     fileprivate static let MINIMUM_LOADABLE_SDK_VERSION = "0.13.0"
@@ -803,19 +803,20 @@ open class ThingIFAPI: NSObject, NSCoding {
     */
     open static func loadWithStoredInstance(_ tag : String? = nil) throws -> ThingIFAPI?{
         let baseKey = ThingIFAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE
-        let versionKey = ThingIFAPI.getSharedSDKVersionKey(tag)
-        let key = ThingIFAPI.getSharedNSDefaultKey(tag)
+        let versionKey = ThingIFAPI.getStoredSDKVersionKey(tag)
+        let key = ThingIFAPI.getStoredInstanceKey(tag)
 
         // try to get iotAPI from NSUserDefaults
 
         if let dict = UserDefaults.standard.object(forKey: baseKey) as? NSDictionary
         {
-            let sdkVersion = dict.object(forKey: versionKey) as? String
-            if isLoadable(sdkVersion) == false {
-                throw ThingIFError.api_NOT_STORED
-            }
-
             if dict.object(forKey: key) != nil {
+
+                let sdkVersion = dict.object(forKey: versionKey) as? String
+                if isLoadable(sdkVersion) == false {
+                    throw ThingIFError.apiUnloadable
+                }
+
                 if let data = dict[key] as? Data {
                     if let savedIoTAPI = NSKeyedUnarchiver.unarchiveObject(with: data) as? ThingIFAPI {
                         return savedIoTAPI
@@ -851,8 +852,8 @@ open class ThingIFAPI: NSObject, NSCoding {
     */
     open static func removeStoredInstances(_ tag : String?=nil){
         let baseKey = ThingIFAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE
-        let versionKey = ThingIFAPI.getSharedSDKVersionKey(tag)
-        let key = ThingIFAPI.getSharedNSDefaultKey(tag)
+        let versionKey = ThingIFAPI.getStoredSDKVersionKey(tag)
+        let key = ThingIFAPI.getStoredInstanceKey(tag)
         if let tempdict = UserDefaults.standard.object(forKey: baseKey) as? NSDictionary {
             let dict  = tempdict.mutableCopy() as! NSMutableDictionary
             dict.removeObject(forKey: versionKey)
@@ -866,8 +867,8 @@ open class ThingIFAPI: NSObject, NSCoding {
 
         let baseKey = ThingIFAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE
 
-        let versionKey = ThingIFAPI.getSharedSDKVersionKey(self.tag)
-        let key = ThingIFAPI.getSharedNSDefaultKey(self.tag)
+        let versionKey = ThingIFAPI.getStoredSDKVersionKey(self.tag)
+        let key = ThingIFAPI.getStoredInstanceKey(self.tag)
         let data = NSKeyedArchiver.archivedData(withRootObject: self)
 
         if let tempdict = UserDefaults.standard.object(forKey: baseKey) as? NSDictionary {
@@ -881,20 +882,20 @@ open class ThingIFAPI: NSObject, NSCoding {
         UserDefaults.standard.synchronize()
     }
 
-    static func isLoadable(_ sdkVersion: String?) -> Bool {
-        if sdkVersion == nil {
+    static func isLoadable(_ storedSDKVersion: String?) -> Bool {
+        if storedSDKVersion == nil {
             return false
         }
 
-        let actualVersions = sdkVersion!.components(separatedBy: ".")
+        let actualVersions = storedSDKVersion!.components(separatedBy: ".")
         if actualVersions.count != 3 {
             return false
         }
 
-        let expectVersions = MINIMUM_LOADABLE_SDK_VERSION.components(separatedBy: ".")
+        let minimumLoadableVersions = MINIMUM_LOADABLE_SDK_VERSION.components(separatedBy: ".")
         for i in 0..<3 {
             let actual = Int(actualVersions[i])!
-            let expect = Int(expectVersions[i])!
+            let expect = Int(minimumLoadableVersions[i])!
             if actual < expect {
                 return false
             } else if actual > expect {

--- a/ThingIFSDK/ThingIFSDK/ThingIFError.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFError.swift
@@ -29,9 +29,9 @@ public enum ThingIFError : Error {
     /** where target not found */
     case targetNotAvailable
     /** when trying to load API from persistance but not avaialble*/
-    case apiNotStored
+    case apiNotStored(tag: String?)
     /** when trying to load API from persistance but unloadable by version*/
-    case apiUnloadable
+    case apiUnloadable(tag: String?, storedVersion: String?, minimumVersion: String)
     /** when trying to load API from persistance but it does not have correct instance*/
     case invalidStoredApi
     /** when trying to access Gateway but user is not logged in*/

--- a/ThingIFSDK/ThingIFSDK/ThingIFError.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFError.swift
@@ -30,6 +30,8 @@ public enum ThingIFError : Error {
     case targetNotAvailable
     /** when trying to load API from persistance but not avaialble*/
     case apiNotStored
+    /** when trying to load API from persistance but unloadable by version*/
+    case apiUnloadable
     /** when trying to load API from persistance but it does not have correct instance*/
     case invalidStoredApi
     /** when trying to access Gateway but user is not logged in*/

--- a/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
+++ b/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
@@ -10,13 +10,15 @@ import UIKit
 open class SDKVersion: NSObject {
     open static let sharedInstance = SDKVersion()
     /** Version of the Thing-IF SDK */
-    open let versionString:String?
-    internal var kiiSDKHeader:String?
+    open let versionString:String
+    internal var kiiSDKHeader:String
     private override init() {
         let b:Bundle? = Bundle.allFrameworks.filter{$0.bundleIdentifier == "Kii-Corporation.ThingIFSDK"}.first
-        versionString = b?.infoDictionary?["CFBundleShortVersionString"] as! String?
-        if let v = versionString {
-            kiiSDKHeader = "sn=it;sv=\(v);pv=\(UIDevice.current.systemVersion)"
+        if let v = b?.infoDictionary?["CFBundleShortVersionString"] as? String {
+            versionString = v
+        } else {
+            versionString = "0.0.0"
         }
+        kiiSDKHeader = "sn=it;sv=\(versionString);pv=\(UIDevice.current.systemVersion)"
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
@@ -108,4 +108,157 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
             XCTFail("should not throw error")
         }
     }
+
+    func testLoadFromStoredInstanceNoSDKVersion()
+    {
+        let expectation = self.expectation(description: "testLoadFromStoredInstanceNoSDKVersion")
+        let setting = TestSetting()
+
+        do {
+            let dict = ["accessToken": ACCESSTOKEN]
+            let jsonData = try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+            let urlResponse = HTTPURLResponse(url: URL(string:setting.app.baseURL)!,
+                                              statusCode: 200, httpVersion: nil, headerFields: nil)
+
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            iotSession = MockSession.self
+        } catch(_) {
+            XCTFail("should not throw error")
+        }
+
+        let api = GatewayAPI(app: setting.app, gatewayAddress: URL(string: setting.app.baseURL)!, tag: nil)
+        api.login("dummy", password: "dummy", completionHandler: { (error:ThingIFError?) -> Void in
+            XCTAssertNil(error)
+            expectation.fulfill()
+        })
+        XCTAssertNil(api.tag)
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            if error != nil {
+                XCTFail("execution timeout")
+            }
+        }
+
+        let baseKey = "GatewayAPI_INSTANCE"
+        let versionKey = "GatewayAPI_VERSION"
+        if let tempdict = UserDefaults.standard.object(forKey: baseKey) as? NSDictionary {
+            let dict  = tempdict.mutableCopy() as! NSMutableDictionary
+            dict.removeObject(forKey: versionKey)
+            UserDefaults.standard.set(dict, forKey: baseKey)
+            UserDefaults.standard.synchronize()
+        }
+
+        do {
+            let restoreApi = try GatewayAPI.loadWithStoredInstance()
+
+            XCTAssertNotNil(restoreApi, "should not be restored.")
+        } catch ThingIFError.api_NOT_STORED {
+            // Succeed.
+        } catch {
+            XCTAssertFalse(false, "Unexpected exception throwed.")
+        }
+    }
+
+    func testLoadFromStoredInstanceLowerSDKVersion()
+    {
+        let expectation = self.expectation(description: "testLoadFromStoredInstanceLowerSDKVersion")
+        let setting = TestSetting()
+
+        do {
+            let dict = ["accessToken": ACCESSTOKEN]
+            let jsonData = try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+            let urlResponse = HTTPURLResponse(url: URL(string:setting.app.baseURL)!,
+                                              statusCode: 200, httpVersion: nil, headerFields: nil)
+
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            iotSession = MockSession.self
+        } catch(_) {
+            XCTFail("should not throw error")
+        }
+
+        let api = GatewayAPI(app: setting.app, gatewayAddress: URL(string: setting.app.baseURL)!, tag: nil)
+        api.login("dummy", password: "dummy", completionHandler: { (error:ThingIFError?) -> Void in
+            XCTAssertNil(error)
+            expectation.fulfill()
+        })
+        XCTAssertNil(api.tag)
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            if error != nil {
+                XCTFail("execution timeout")
+            }
+        }
+
+        let baseKey = "GatewayAPI_INSTANCE"
+        let versionKey = "GatewayAPI_VERSION"
+        if let tempdict = UserDefaults.standard.object(forKey: baseKey) as? NSDictionary {
+            let dict  = tempdict.mutableCopy() as! NSMutableDictionary
+            dict[versionKey] = "0.0.0"
+            UserDefaults.standard.set(dict, forKey: baseKey)
+            UserDefaults.standard.synchronize()
+        }
+
+        do {
+            let restoreApi = try GatewayAPI.loadWithStoredInstance()
+
+            XCTAssertNotNil(restoreApi, "should not be restored.")
+        } catch ThingIFError.api_NOT_STORED {
+            // Succeed.
+        } catch {
+            XCTAssertFalse(false, "Unexpected exception throwed.")
+        }
+    }
+
+    func testLoadFromStoredInstanceUpperSDKVersion()
+    {
+        let expectation = self.expectation(description: "testLoadFromStoredInstanceUpperSDKVersion")
+        let setting = TestSetting()
+
+        do {
+            let dict = ["accessToken": ACCESSTOKEN]
+            let jsonData = try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+            let urlResponse = HTTPURLResponse(url: URL(string:setting.app.baseURL)!,
+                                              statusCode: 200, httpVersion: nil, headerFields: nil)
+
+            sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
+            iotSession = MockSession.self
+        } catch(_) {
+            XCTFail("should not throw error")
+        }
+
+        let api = GatewayAPI(app: setting.app, gatewayAddress: URL(string: setting.app.baseURL)!, tag: nil)
+        api.login("dummy", password: "dummy", completionHandler: { (error:ThingIFError?) -> Void in
+            XCTAssertNil(error)
+            expectation.fulfill()
+        })
+        XCTAssertNil(api.tag)
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            if error != nil {
+                XCTFail("execution timeout")
+            }
+        }
+
+        let baseKey = "GatewayAPI_INSTANCE"
+        let versionKey = "GatewayAPI_VERSION"
+        if let tempdict = UserDefaults.standard.object(forKey: baseKey) as? NSDictionary {
+            let dict  = tempdict.mutableCopy() as! NSMutableDictionary
+            dict[versionKey] = "1000.0.0"
+            UserDefaults.standard.set(dict, forKey: baseKey)
+            UserDefaults.standard.synchronize()
+        }
+
+        do {
+            let restoreApi = try GatewayAPI.loadWithStoredInstance()
+
+            XCTAssertNotNil(restoreApi)
+            XCTAssertNil(restoreApi!.tag)
+            XCTAssertEqual(api.app.appID, restoreApi!.app.appID)
+            XCTAssertEqual(api.app.appKey, restoreApi!.app.appKey)
+            XCTAssertEqual(api.gatewayAddress, restoreApi!.gatewayAddress)
+            XCTAssertEqual(api.getAccessToken(), restoreApi!.getAccessToken())
+        } catch (_) {
+            XCTFail("should not throw error")
+        }
+    }
 }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
@@ -148,14 +148,14 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
             UserDefaults.standard.synchronize()
         }
 
-        do {
-            let restoreApi = try GatewayAPI.loadWithStoredInstance()
-
-            XCTAssertNotNil(restoreApi, "should not be restored.")
-        } catch ThingIFError.api_NOT_STORED {
-            // Succeed.
-        } catch {
-            XCTAssertFalse(false, "Unexpected exception throwed.")
+        XCTAssertThrowsError(try GatewayAPI.loadWithStoredInstance()) { error in
+            switch error {
+            case ThingIFError.apiUnloadable:
+                // Succeed.
+                break
+            default:
+                XCTFail("Unexpected exception throwed.")
+            }
         }
     }
 
@@ -198,14 +198,14 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
             UserDefaults.standard.synchronize()
         }
 
-        do {
-            let restoreApi = try GatewayAPI.loadWithStoredInstance()
-
-            XCTAssertNotNil(restoreApi, "should not be restored.")
-        } catch ThingIFError.api_NOT_STORED {
-            // Succeed.
-        } catch {
-            XCTAssertFalse(false, "Unexpected exception throwed.")
+        XCTAssertThrowsError(try GatewayAPI.loadWithStoredInstance()) { error in
+            switch error {
+            case ThingIFError.apiUnloadable:
+                // Succeed.
+                break
+            default:
+                XCTFail("Unexpected exception throwed.")
+            }
         }
     }
 

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -485,7 +485,7 @@ class ThingIFSDKTests: SmallTestBase {
         let persistance = UserDefaults.standard
         let baseKey = "ThingIFAPI_INSTANCE"
         let versionKey = "ThingIFAPI_VERSION"
-        let sdkVersion = SDKVersion.sharedInstance.versionString
+        let sdkVersion = SDKVersion.sharedInstance.versionString!
         //clear
         persistance.removeObject(forKey: baseKey)
         persistance.synchronize()

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -485,7 +485,7 @@ class ThingIFSDKTests: SmallTestBase {
         let persistance = UserDefaults.standard
         let baseKey = "ThingIFAPI_INSTANCE"
         let versionKey = "ThingIFAPI_VERSION"
-        let sdkVersion = SDKVersion.sharedInstance.versionString!
+        let sdkVersion = SDKVersion.sharedInstance.versionString
         //clear
         persistance.removeObject(forKey: baseKey)
         persistance.synchronize()

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -668,7 +668,7 @@ class ThingIFSDKTests: SmallTestBase {
         let versionKey = "ThingIFAPI_VERSION"
         if let tempdict = UserDefaults.standard.object(forKey: baseKey) as? NSDictionary {
             let dict  = tempdict.mutableCopy() as! NSMutableDictionary
-            dict[versionKey] = "0.0.0"
+            dict[versionKey] = "1000.0.0"
             UserDefaults.standard.set(dict, forKey: baseKey)
             UserDefaults.standard.synchronize()
         }

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -589,13 +589,14 @@ class ThingIFSDKTests: SmallTestBase {
             UserDefaults.standard.synchronize()
         }
 
-        do {
-            try ThingIFAPI.loadWithStoredInstance()
-            XCTFail("Should raise exception")
-        } catch ThingIFError.api_NOT_STORED {
-            // Succeed.
-        } catch {
-            XCTAssertFalse(false, "Unexpected exception throwed.")
+        XCTAssertThrowsError(try ThingIFAPI.loadWithStoredInstance()) { error in
+            switch error {
+            case ThingIFError.apiUnloadable:
+                // Succeed.
+                break
+            default:
+                XCTFail("Unexpected exception throwed.")
+            }
         }
     }
 
@@ -630,13 +631,14 @@ class ThingIFSDKTests: SmallTestBase {
             UserDefaults.standard.synchronize()
         }
 
-        do {
-            try ThingIFAPI.loadWithStoredInstance()
-            XCTFail("Should raise exception")
-        } catch ThingIFError.api_NOT_STORED {
-            // Succeed.
-        } catch {
-            XCTAssertFalse(false, "Unexpected exception throwed.")
+        XCTAssertThrowsError(try ThingIFAPI.loadWithStoredInstance()) { error in
+            switch error {
+            case ThingIFError.apiUnloadable:
+                // Succeed.
+                break
+            default:
+                XCTFail("Unexpected exception throwed.")
+            }
         }
     }
 
@@ -675,7 +677,7 @@ class ThingIFSDKTests: SmallTestBase {
             let temp = try ThingIFAPI.loadWithStoredInstance()
             XCTAssertEqual(api, temp , "should be equal")
         } catch {
-            XCTAssertFalse(false, "Unexpected exception throwed.")
+            XCTFail("Unexpected exception throwed.")
         }
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerWIthTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerWIthTriggerOptionsTests.swift
@@ -112,7 +112,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
                       [
                         "Authorization": "Bearer \(setting.owner.accessToken)",
                         "Content-Type": "application/json",
-                        "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                        "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                       ],
                       error_message);
                     XCTAssertEqual(
@@ -156,7 +156,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
                       [
                         "Authorization": "Bearer \(setting.owner.accessToken)",
                         "Content-Type": "application/json",
-                        "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                        "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                       ],
                       error_message);
                     XCTAssertEqual(
@@ -255,7 +255,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
                   [
                     "Authorization": "Bearer \(setting.owner.accessToken)",
                     "Content-Type": "application/json",
-                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                   ]);
                 XCTAssertEqual(
                   request.url?.absoluteString,
@@ -295,7 +295,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
                   [
                     "Authorization": "Bearer \(setting.owner.accessToken)",
                     "Content-Type": "application/json",
-                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                   ]);
                 XCTAssertEqual(
                   request.url?.absoluteString,
@@ -383,7 +383,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
                   [
                     "Authorization": "Bearer \(setting.owner.accessToken)",
                     "Content-Type": "application/json",
-                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                   ]);
                 XCTAssertEqual(
                   request.url?.absoluteString,
@@ -423,7 +423,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
                   [
                     "Authorization": "Bearer \(setting.owner.accessToken)",
                     "Content-Type": "application/json",
-                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                   ]);
                 XCTAssertEqual(
                   request.url?.absoluteString,

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggerOptionsTests.swift
@@ -95,7 +95,7 @@ class PatchTriggerWithTriggerOptionsTests: SmallTestBase {
                           [
                             "Authorization": "Bearer \(setting.owner.accessToken)",
                             "Content-Type": "application/json",
-                            "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                            "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                           ],
                           error_message);
                         XCTAssertEqual(

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggeredCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggeredCommandFormTests.swift
@@ -157,7 +157,7 @@ class PatchTriggerWithTriggeredCommandFormTest: SmallTestBase {
                           [
                             "Authorization": "Bearer \(setting.owner.accessToken)",
                             "Content-Type": "application/json",
-                            "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                            "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                           ],
                           error_message);
                         XCTAssertEqual(

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerWithTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerWithTriggerOptionsTests.swift
@@ -103,7 +103,7 @@ class PostNewServerCodeTriggerWithTriggerOptionsTests: SmallTestBase {
                   [
                     "Authorization": "Bearer \(setting.owner.accessToken)",
                     "Content-Type": "application/json",
-                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                   ],
                   error_message);
 

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerForScheduleTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerForScheduleTests.swift
@@ -203,7 +203,7 @@ class PostNewTriggerForScheduleTests: SmallTestBase {
                                                expectedHeader: [
                                                      "Authorization": "Bearer \(setting.owner.accessToken)",
                                                      "Content-Type": "application/json",
-                                                     "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                                                     "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                                                  ],
                                                expectedBody: [
                                                    "predicate": predicate.toNSDictionary() as Dictionary,

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggerOptionsTests.swift
@@ -95,7 +95,7 @@ class PostNewTriggerWithTriggerOptionsTests: SmallTestBase {
                   [
                     "Authorization": "Bearer \(setting.owner.accessToken)",
                     "Content-Type": "application/json",
-                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                   ],
                   error_message);
 

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggeredCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggeredCommandFormTests.swift
@@ -157,7 +157,7 @@ class PostNewTriggerWithTriggeredCommandFormTests: SmallTestBase {
                   [
                     "Authorization": "Bearer \(setting.owner.accessToken)",
                     "Content-Type": "application/json",
-                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader!
+                    "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader
                  ],
                   error_message);
 


### PR DESCRIPTION
ThingIFAPIとGatewayAPIで保存済みインスタンスの読み込み時に対応するSDKのバージョンを扱うように修正しました。
テストの追加の際に、既存のテストにも影響が出ていたので既存のテストも修正しています。
レビューをお願いします。

追記: API関連の修正
 * ThingIFErrorにapi_UNLOADABLEを追加

No.770
Related PR: #188

## Android
KiiPlatform/thing-if-AndroidSDK#147
