### PR TITLE
Builders APIs are fixed according to API design guideline

### DIFF
--- a/ThingIFSDK/ThingIFSDK/App.swift
+++ b/ThingIFSDK/ThingIFSDK/App.swift
@@ -79,69 +79,42 @@ open class AppBuilder: NSObject {
     private let appID:String
     private let appKey:String
     private let hostName:String
-    private var urlSchema:String
-    private var siteName:String
-    private var port:Int32
+    private let urlSchema:String
+    private let siteName:String
+    private let port:Int32
 
     /** Init the Builder.
 
      - Parameter appID: ID of the app.
      - Parameter appKey: Key of the app.
-     - Parameter hostName: Host name to which the app connects
+     - Parameter hostNabuildme: Host name to which the app connects
+     - Parameter urlSchema: URL schema. By default, "https" is
+       used. You can override the URL schema with this parameter.
+     - Parameter siteName: Site name. By default site name is set to
+       "CUSTOM". This site name should match with your Gateway Agent
+       configuration if you interact Gateway Agent with this SDK.
     */
-    public init(appID:String, appKey:String, hostName:String) {
+    public init(
+      appID: String,
+      appKey: String,
+      hostName: String,
+      urlSchema: String = "https",
+      siteName: String = "CUSTOM",
+      port: Int32 = -1)
+    {
         self.appID = appID
         self.appKey = appKey
         self.hostName = hostName
-        self.urlSchema = "https"
-        self.siteName = "CUSTOM"
-        self.port = -1
-    }
-
-    /** Set port number.
-     This method call is optional.
-     By default no port number is used to connect to the cloud.
-
-     - Parameter port: port number. 0 or less than 0 would be ignored.
-     - Returns: AppBuilder instance.
-    */
-    open func setPort(_ port:Int32) -> AppBuilder {
-        self.port=port
-        return self
-    }
-
-    /** Set the API endpoint URL schema
-     This method call is optional.
-     By default "https" is used. You can override the URL schema with this
-     method.
-
-     - Parameter urlSchema: API endpoit URL schema
-     - Returns: AppBuilder instance.
-    */
-    open func setUrlSchema(_ urlSchema:String) -> AppBuilder {
         self.urlSchema = urlSchema
-        return self
-    }
-
-    /** Set site name.
-     This method call is optional.
-     By default site name is set to "CUSTOM".
-     This site name should match with your Gateway Agent configuration
-     if you interact Gateway Agent with this SDK.
-
-     - Parameter siteName: site name.
-     - Returns: AppBuilder instance.
-    */
-    open func setSiteName(_ siteName:String) -> AppBuilder {
         self.siteName = siteName
-        return self
+        self.port = port
     }
 
-    /** Build App instance
+    /** Make App instance
 
      - Returns: App instance
     */
-    open func build() -> App {
+    open func make() -> App {
         var baseURL:String = urlSchema + "://" + hostName
         if (self.port > 0) {
             baseURL = baseURL + ":" + String(port)

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPIBuilder.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPIBuilder.swift
@@ -9,33 +9,26 @@ import Foundation
 
 open class GatewayAPIBuilder {
 
-    private var tag: String?
+    private let tag: String?
     private let app: App
     private let gatewayAddress: URL
 
-    /** Set tag to this GatewayAPI instance.
-     tag is used to distinguish storage area of instance.
-     <br>
-     If the api instance is tagged with same string, It will be overwritten.
-     <br>
-     If the api instance is tagged with different string, Different key is used to store the instance.
-     <br>
-     <br>
-     Please refer to {@link GatewayAPI#loadFromStoredInstance(Context, String)} as well.
-
-     - Parameter tag: If null or empty String us passed, it will be ignored.
-     - Returns: builder instance for chaining call.
-     */
-    open func setTag(_ tag: String?) -> GatewayAPIBuilder
-    {
-        self.tag = tag
-        return self
-    }
-
     /** Initialize builder.
+
+     If you want to store GatewayAPI instance to storage, you need to
+     set tag.
+
+     tag is used to distinguish storage area of instance.  If the api
+     instance is tagged with same string, It will be overwritten.  If
+     the api instance is tagged with different string, Different key
+     is used to store the instance.
+
+     Please refer to [GatewayAPI.loadWithStoredInstance(_:)]
+
      - Parameter app: Kii Cloud Application.
      - Parameter gatewayAddress: address information for the gateway
-     - Parameter tag: tag of the GatewayAPI instance.
+     - Parameter tag: tag of the GatewayAPI instance. If null or empty
+       String is passed, it will be ignored.
      */
     public init(app:App, address:URL, tag:String?=nil)
     {
@@ -44,10 +37,10 @@ open class GatewayAPIBuilder {
         self.tag = tag
     }
 
-    /** Build GatewayAPI instance.
+    /** Make GatewayAPI instance.
     - Returns: GatewayAPI instance.
     */
-    open func build() -> GatewayAPI
+    open func make() -> GatewayAPI
     {
         let api = GatewayAPI(app: self.app, gatewayAddress: self.gatewayAddress, tag: self.tag)
         return api

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPIBuilder.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPIBuilder.swift
@@ -23,7 +23,7 @@ open class GatewayAPIBuilder {
      the api instance is tagged with different string, Different key
      is used to store the instance.
 
-     Please refer to [GatewayAPI.loadWithStoredInstance(_:)]
+     Please refer to `GatewayAPI.loadWithStoredInstance(_:)`
 
      - Parameter app: Kii Cloud Application.
      - Parameter gatewayAddress: address information for the gateway

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPIBuilder.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPIBuilder.swift
@@ -26,10 +26,10 @@ open class ThingIFAPIBuilder {
         self.tag = tag
     }
 
-    /** Build ThingIFAPI instance.
+    /** Make ThingIFAPI instance.
     - Returns: ThingIFAPI instance.
      */
-    open func build() -> ThingIFAPI {
+    open func make() -> ThingIFAPI {
         let thingIFAPI = ThingIFAPI(app: self.app, owner: self.owner, tag: self.tag)
         thingIFAPI._target = self.target
         return thingIFAPI

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -26,7 +26,7 @@ class ThingIFSDKTests: SmallTestBase {
         let owner = setting.owner
 
         // ThingIFAPI is not saved when ThingIFAPI is instantiation.
-        let api = ThingIFAPIBuilder(app:app, owner:owner).build()
+        let api = ThingIFAPIBuilder(app:app, owner:owner).make()
         XCTAssertThrowsError(try ThingIFAPI.loadWithStoredInstance())
         api.saveInstance()
         
@@ -44,9 +44,9 @@ class ThingIFSDKTests: SmallTestBase {
         let app = setting.app
         let owner = setting.owner
         
-        let api1 = ThingIFAPIBuilder(app:app, owner:owner).build()
-        let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
-        let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
+        let api1 = ThingIFAPIBuilder(app:app, owner:owner).make()
+        let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).make()
+        let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).make()
         
         var expectation = self.expectation(description: "testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
@@ -126,9 +126,9 @@ class ThingIFSDKTests: SmallTestBase {
         let app = setting.app
         let owner = setting.owner
         
-        let api1 = ThingIFAPIBuilder(app:app, owner:owner).build()
-        let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
-        let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
+        let api1 = ThingIFAPIBuilder(app:app, owner:owner).make()
+        let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).make()
+        let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).make()
         
         var expectation = self.expectation(description: "testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
@@ -222,7 +222,7 @@ class ThingIFSDKTests: SmallTestBase {
         let owner1 = Owner(typedID: TypedID(type: "user", id: "user001"), accessToken: "token001")
         let owner2 = Owner(typedID: TypedID(type: "user", id: "user002"), accessToken: "token002")
         
-        let api1 = ThingIFAPIBuilder(app:app1, owner:owner1, tag: tag).build()
+        let api1 = ThingIFAPIBuilder(app:app1, owner:owner1, tag: tag).make()
         
         var expectation = self.expectation(description: "testOverwriteSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
@@ -238,7 +238,7 @@ class ThingIFSDKTests: SmallTestBase {
             }
         }
         
-        let api2 = ThingIFAPIBuilder(app:app2, owner:owner2, tag: tag).build()
+        let api2 = ThingIFAPIBuilder(app:app2, owner:owner2, tag: tag).make()
 
         expectation = self.expectation(description: "testOverwriteSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
@@ -266,7 +266,7 @@ class ThingIFSDKTests: SmallTestBase {
     func testOverwriteSavedInstanceWithOnboard222(){
         let setting = TestSetting()
         
-        let api1 = ThingIFAPIBuilder(app:setting.app, owner:setting.owner, tag: "tag1").build()
+        let api1 = ThingIFAPIBuilder(app:setting.app, owner:setting.owner, tag: "tag1").make()
         
         let expectation = self.expectation(description: "testOverwriteSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
@@ -313,9 +313,9 @@ class ThingIFSDKTests: SmallTestBase {
         let app = setting.app
         let owner = setting.owner
         
-        let api1 = ThingIFAPIBuilder(app:app, owner:owner).build()
-        let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
-        let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
+        let api1 = ThingIFAPIBuilder(app:app, owner:owner).make()
+        let api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).make()
+        let api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).make()
         
         var expectation = self.expectation(description: "testSavedInstanceWithInstallPush")
         setMockResponse4InstallPush("installationID-0001", setting: setting);
@@ -423,9 +423,9 @@ class ThingIFSDKTests: SmallTestBase {
         let target2 = StandaloneThing(thingID: "user-00002", vendorThingID: "vendor-thing-id-002", accessToken: "token-00002")
         let target3 = StandaloneThing(thingID: "user-00003", vendorThingID: "vendor-thing-id-003", accessToken: "token-00003")
         
-        var api1 = ThingIFAPIBuilder(app:app, owner:owner).build()
-        var api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).build()
-        var api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).build()
+        var api1 = ThingIFAPIBuilder(app:app, owner:owner).make()
+        var api2 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[0]).make()
+        var api3 = ThingIFAPIBuilder(app:app, owner:owner, tag:tags[1]).make()
         
         api1 = api1.copyWithTarget(target1)
         api2 = api2.copyWithTarget(target2, tag: tags[0])

--- a/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
@@ -185,7 +185,7 @@ class OnboardingTests: SmallTestBase {
         let owner = setting.owner
         let app = setting.app
 
-        let api = ThingIFAPIBuilder(app:app, owner:owner, tag:"target1").build()
+        let api = ThingIFAPIBuilder(app:app, owner:owner, tag:"target1").make()
         do{
             let thingProperties:Dictionary<String, Any> = ["key1":"value1", "key2":"value2"]
             let thingType = "LED"

--- a/ThingIFSDK/ThingIFSDKTests/TestSetting.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TestSetting.swift
@@ -37,7 +37,7 @@ open class TestSetting: NSObject {
         self.appID = dict["appID"] as! String
         self.appKey = dict["appKey"] as! String
         self.hostName = dict["hostName"] as! String
-        self.app = AppBuilder(appID: appID, appKey: appKey, hostName: hostName).build()
+        self.app = AppBuilder(appID: appID, appKey: appKey, hostName: hostName).make()
 
         self.ownerID = dict["ownerID"] as! String
         self.ownerToken = dict["ownerToken"] as! String
@@ -47,7 +47,7 @@ open class TestSetting: NSObject {
         self.thingID = dict["thingID"] as! String
         self.target = StandaloneThing(thingID: thingID, vendorThingID: ownerID, accessToken: ownerToken)
 
-        self.api = ThingIFAPIBuilder(app: app, owner: owner).build()
+        self.api = ThingIFAPIBuilder(app: app, owner: owner).make()
 
         self.schema = dict["schema"] as! String
         self.schemaVersion = dict["schemaVersion"] as! Int


### PR DESCRIPTION
3 builder classes are fixed according to API design guideline:

  * AppBuilder (64dad77)
  * GatewayAPIBuilder (5575a93)
  * ThingIFAPIBuilder (4992355)

Tests are fixed at b3eab1d



Related issue: #205 
Related PR: #188