### PR TITLE
Undo list change

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -203,7 +203,7 @@ open class GatewayAPI: NSObject, NSCoding {
 
      - Parameter completionHandler: A closure to be executed once get id has finished. The closure takes 2 arguments: 1st one is list of end nodes and 2nd one is an instance of ThingIFError when failed.
      */
-    open func list(
+    open func listOnboardedEndNodes(
         _ completionHandler: @escaping ([EndNode]?, ThingIFError?)-> Void
         )
     {
@@ -251,7 +251,7 @@ open class GatewayAPI: NSObject, NSCoding {
 
      - Parameter completionHandler: A closure to be executed once get id has finished. The closure takes 2 arguments: 1st one is list of end nodes connected to the gateway but waiting for onboarding and 2nd one is an instance of ThingIFError when failed.
      */
-    open func list(
+    open func listPendingEndNodes(
         _ completionHandler: @escaping ([PendingEndNode]?, ThingIFError?)-> Void
         )
     {

--- a/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListOnboardedEndNodesTests.swift
@@ -57,7 +57,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
-            api.list( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
+            api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
                 XCTAssertNil(error)
                 XCTAssertNotNil(nodes)
                 XCTAssertEqual(3, nodes!.count)
@@ -113,7 +113,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
-            api.list( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
+            api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
                 XCTAssertNil(error)
                 XCTAssertNotNil(nodes)
                 XCTAssertEqual(0, nodes!.count)
@@ -136,7 +136,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: URL(string: setting.app.baseURL)!)
         let expectation = self.expectation(description: "testNoLoggedInError")
         
-        api.list( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
+        api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -184,7 +184,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
-        api.list( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
+        api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -232,7 +232,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
-        api.list( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
+        api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -280,7 +280,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
-        api.list( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
+        api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -328,7 +328,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
-        api.list( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
+        api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -376,7 +376,7 @@ class ListOnboardedEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
         
-        api.list( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
+        api.listOnboardedEndNodes( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {

--- a/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListPendingEndNodesTests.swift
@@ -58,7 +58,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
-            api.list( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
+            api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
                 XCTAssertNil(error)
                 XCTAssertNotNil(nodes)
                 XCTAssertEqual(3, nodes!.count)
@@ -114,7 +114,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
-            api.list( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
+            api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
                 XCTAssertNil(error)
                 XCTAssertNotNil(nodes)
                 XCTAssertEqual(0, nodes!.count)
@@ -137,7 +137,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         let api:GatewayAPI = GatewayAPI(app: setting.app, gatewayAddress: URL(string: setting.app.baseURL)!)
         let expectation = self.expectation(description: "testNoLoggedInError")
 
-        api.list( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
+        api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -185,7 +185,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
-        api.list( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
+        api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -233,7 +233,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
-        api.list( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
+        api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -281,7 +281,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
-        api.list( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
+        api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -329,7 +329,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
-        api.list( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
+        api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {
@@ -377,7 +377,7 @@ class ListPendingEndNodesTests: GatewayAPITestBase {
         sharedMockSession.requestVerifier = requestVerifier
         iotSession = MockSession.self
 
-        api.list( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
+        api.listPendingEndNodes( { (nodes:[PendingEndNode]?, error:ThingIFError?) -> Void in
             XCTAssertNil(nodes)
             XCTAssertNotNil(error)
             switch error! {


### PR DESCRIPTION
#217 でlist系のAPIを修正した結果、型推論失敗のためにビルドエラーが発生する可能性が出るようになったため、修正をrollbackしました。

#217 で、`GatewayAPI.listOnboardedEndNodes()`と`GatewayAPI.listPendedEndNodes()`を両方共、`GatewayAPI.list()`というメソッド名に変更しました。
これは、引数の`completionHandler`コールバックが取得するデータの型を指定するため、メソッド名に型情報を乗せる必要はないという判断に基づき、修正されました。

しかし、コールバックの引数の型はメソッドの利用時に省略可能でした。以下のように

```swift
api.list( { (nodes:[EndNode]?, error:ThingIFError?) -> Void in
   // do somthing
})
```

と書けば型が指定されているので型推論は成功しますが、

```swift
api.list( { (nodes, error) -> Void in
   // do somthing
})
```

と書かれると、型が指定されていないため、型推論が失敗します。結果、OnboardedEndNodesの取得を意図しているのか、PendingEndnodesの取得を意図しているのかわからなくなります。

型推論が失敗しないよう、メソッド名に取得する内容を追加した方が良いと考えます。

これは[swift API design guidelineのGeneral Conventions](https://swift.org/documentation/api-design-guidelines/#general-conventions)の中にある、`Methods can share a base name`という項目の最後の項目、

```
Lastly, avoid “overloading on return type” because it causes ambiguities in the presence of type inference.
```

に対応した形の修正と考えております。戻り値のみが違う場合、型推論のためにメソッドオーバーライドは使わないというものです。

Related issue: #205
Related PR: #188