### PR TITLE
Get accessors are changed to read-only propeties

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -26,7 +26,8 @@ open class GatewayAPI: NSObject, NSCoding {
         return self.gatewayAddress.absoluteString
     }
 
-    private var accessToken: String?
+    /** Access token of this gate way */
+    open private(set) var accessToken: String?
 
     let operationQueue = OperationQueue()
 
@@ -489,15 +490,6 @@ open class GatewayAPI: NSObject, NSCoding {
     open func isLoggedIn() -> Bool
     {
         return !(self.accessToken?.isEmpty ?? true)
-    }
-
-    /** Get Access Token
-
-     - Returns: Access token
-     */
-    open func getAccessToken() -> String?
-    {
-        return self.accessToken
     }
 
     /** Try to load the instance of GatewayAPI using stored serialized instance.

--- a/ThingIFSDK/ThingIFSDK/Predicate.swift
+++ b/ThingIFSDK/ThingIFSDK/Predicate.swift
@@ -18,11 +18,11 @@ public protocol Predicate :  NSCoding {
      */
     func toNSDictionary() -> NSDictionary
 
-    /** Get EventSource enum
+    /** Event source of this predicate.
 
-     - Returns: an enumeration instance of the event source.
+     See `EventSource`
      */
-    func getEventSource() -> EventSource
+    var eventSource: EventSource { get }
 }
 
 

--- a/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
@@ -11,10 +11,8 @@ open class ScheduleOncePredicate: NSObject,Predicate {
     /** Specified schedule. */
     open let scheduleAt: Date
 
-    open func getEventSource() -> EventSource {
-        return EventSource.scheduleOnce
-    }
-    
+    open let eventSource: EventSource = EventSource.scheduleOnce
+
     /** Instantiate new ScheduleOncePredicate.
 
      -Parameter scheduleAt: Specify execution schedule. It must be future date.

--- a/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
@@ -13,9 +13,8 @@ open class SchedulePredicate: NSObject,Predicate {
     /** Specified schedule. (cron tab format) */
     open let schedule: String
 
-    open func getEventSource() -> EventSource {
-        return EventSource.schedule
-    }
+    open let eventSource: EventSource = EventSource.schedule
+
     /** Instantiate new SchedulePredicate.
 
      -Parameter schedule: Specify schedule. (cron tab format)

--- a/ThingIFSDK/ThingIFSDK/StatePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/StatePredicate.swift
@@ -13,9 +13,8 @@ open class StatePredicate: NSObject,Predicate {
     open let triggersWhen: TriggersWhen!
     open let condition: Condition!
 
-    open func getEventSource() -> EventSource {
-        return EventSource.states
-    }
+    open let eventSource: EventSource = EventSource.states
+
     /** Initialize StatePredicate with Condition and TriggersWhen
 
      - Parameter condition: Condition of the Trigger.

--- a/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
@@ -24,16 +24,56 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
     
     /** Whether the invocation succeeded */
     open let succeeded: Bool
-    /** Returned value from server code (JsonObject, JsonArray, String, Number, Boolean or null) */
-    open let returnedValue: Any?
     /** Date of the execution */
     open let executedAt: Date
     /** The endpoint used in the server code invocation */
     open let endpoint: String
     /** Error object of the invocation if any */
     open let error: ServerError?
-    
-    
+
+    /** Returned value from server code (JsonObject, JsonArray, String, Number, Boolean or null) */
+    open let returnedValue: Any?
+
+    /** Returned value from server code casted to String. */
+    open var returnedValueAsString: String? {
+        get {
+            if let str = self.returnedValue as? String {
+                return str
+            } else if let num = self.returnedValue as? NSNumber {
+                return String(describing: num)
+            }
+            return nil
+        }
+    }
+
+    /** Returned value from server code casted to Bool. */
+    open var returnedValueAsBool: Bool? {
+        get {
+            return self.returnedValue as? Bool
+        }
+    }
+
+    /** Returned value from server code casted to NSNumber. */
+    open var returnedValueAsNSNumber: NSNumber? {
+        get {
+            return self.returnedValue as? NSNumber
+        }
+    }
+
+    /** Returned value from server code casted to [String : Any]. */
+    open var returnedValueAsDictionary: Dictionary<String, Any>? {
+        get {
+            return self.returnedValue as? Dictionary<String, Any>
+        }
+    }
+
+    /** Returned value from server code casted to [Any]. */
+    open var returnedValueAsArray: [Any]? {
+        get {
+            return self.returnedValue as? [Any]
+        }
+    }
+
     /** Init TriggeredServerCodeResult with necessary attributes
      
      - Parameter succeeded: Whether the invocation succeeded
@@ -50,31 +90,6 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
         self.error = error
     }
     
-    open func getReturnedValue() -> Any? {
-        return self.returnedValue
-    }
-    open func getReturnedValueAsString() -> String? {
-        if let str = self.returnedValue as? String {
-            return str
-        }
-        if let num = self.returnedValue as? NSNumber {
-            return String(describing: num)
-        }
-        return nil
-    }
-    open func getReturnedValueAsBool() -> Bool? {
-        return self.returnedValue as? Bool
-    }
-    open func getReturnedValueAsNSNumber() -> NSNumber? {
-        return self.returnedValue as? NSNumber
-    }
-    open func getReturnedValueAsDictionary() -> Dictionary<String, Any>? {
-        return self.returnedValue as? Dictionary<String, Any>
-    }
-    open func getReturnedValueAsArray() -> [Any]? {
-        return self.returnedValue as? [Any]
-    }
-
     open override func isEqual(_ object: Any?) -> Bool {
         guard let aResult = object as? TriggeredServerCodeResult else{
             return false

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPINSCodingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPINSCodingTests.swift
@@ -60,6 +60,6 @@ class GatewayAPINSCodingTests: GatewayAPITestBase {
         XCTAssertEqual(gatewayAPI.app.siteName, decode.app.siteName);
         XCTAssertEqual(gatewayAPI.app.baseURL, decode.app.baseURL);
         XCTAssertEqual(gatewayAPI.gatewayAddress, decode.gatewayAddress);
-        XCTAssertEqual(gatewayAPI.getAccessToken(), decode.getAccessToken());
+        XCTAssertEqual(gatewayAPI.accessToken, decode.accessToken);
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIStoredInstanceTests.swift
@@ -58,7 +58,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
             XCTAssertEqual(api.app.appID, restoreApi!.app.appID)
             XCTAssertEqual(api.app.appKey, restoreApi!.app.appKey)
             XCTAssertEqual(api.gatewayAddress, restoreApi!.gatewayAddress)
-            XCTAssertEqual(api.getAccessToken(), restoreApi!.getAccessToken())
+            XCTAssertEqual(api.accessToken, restoreApi!.accessToken)
         } catch (_) {
             XCTFail("should not throw error")
         }
@@ -103,7 +103,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
             XCTAssertEqual(api.app.appID, restoreApi!.app.appID)
             XCTAssertEqual(api.app.appKey, restoreApi!.app.appKey)
             XCTAssertEqual(api.gatewayAddress, restoreApi!.gatewayAddress)
-            XCTAssertEqual(api.getAccessToken(), restoreApi!.getAccessToken())
+            XCTAssertEqual(api.accessToken, restoreApi!.accessToken)
         } catch (_) {
             XCTFail("should not throw error")
         }
@@ -256,7 +256,7 @@ class GatewayAPIStoredInstanceTests: GatewayAPITestBase {
             XCTAssertEqual(api.app.appID, restoreApi!.app.appID)
             XCTAssertEqual(api.app.appKey, restoreApi!.app.appKey)
             XCTAssertEqual(api.gatewayAddress, restoreApi!.gatewayAddress)
-            XCTAssertEqual(api.getAccessToken(), restoreApi!.getAccessToken())
+            XCTAssertEqual(api.accessToken, restoreApi!.accessToken)
         } catch (_) {
             XCTFail("should not throw error")
         }

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
@@ -25,7 +25,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_success"
-        let expectation : XCTestExpectation! = self.expectation(description: "testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectation(description: "testPostNewServerCodeTrigger_success_\(predicate.eventSource.rawValue)")
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
@@ -126,7 +126,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let api = setting.api
         let tag = "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_http_404"
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        let expectation : XCTestExpectation! = self.expectation(description: "testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectation(description: "testPostNewServerCodeTrigger_http_404_\(predicate.eventSource.rawValue)")
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
         let expectedTargetAppID = "app000001"
@@ -212,7 +212,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
-        let expectation : XCTestExpectation! = self.expectation(description: "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_target_not_available_error_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectation(description: "PatchServerCodeTriggerTests.testPatchServerCodeTrigger_target_not_available_error_\(predicate.eventSource.rawValue)")
         
         let serverCode:ServerCode = ServerCode(endpoint: "function_name", executorAccessToken: "abcd", targetAppID: "app001", parameters: nil)
         

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
@@ -26,7 +26,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PostNewServerCodeTriggerTests.testPostNewTrigger_success"
-        let expectation : XCTestExpectation! = self.expectation(description: "testPostNewServerCodeTrigger_success_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectation(description: "testPostNewServerCodeTrigger_success_\(predicate.eventSource.rawValue)")
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
@@ -113,7 +113,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         let tag = "PostNewServerCodeTriggerTests.testPostNewServerCodeTrigger_http_404"
-        let expectation : XCTestExpectation! = self.expectation(description: "testPostNewServerCodeTrigger_http_404_\(predicate.getEventSource().rawValue)")
+        let expectation : XCTestExpectation! = self.expectation(description: "testPostNewServerCodeTrigger_http_404_\(predicate.eventSource.rawValue)")
         let expectedEndpoint = "my_function"
         let expectedExecutorAccessToken = "abcdefgHIJKLMN1234567"
         let expectedTargetAppID = "app000001"

--- a/ThingIFSDK/ThingIFSDKTests/TriggeredServerCodeResultTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TriggeredServerCodeResultTest.swift
@@ -57,90 +57,90 @@ class TriggeredServerCodeResultTest: SmallTestBase {
         testData = "{\"succeeded\":true,\"executedAt\":1455531174923,\"endpoint\":\"func\"}"
         resultDict = try! JSONSerialization.jsonObject(with: testData.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
         result = TriggeredServerCodeResult.resultWithNSDict(resultDict!)!
-        XCTAssertNil(result!.getReturnedValue())
+        XCTAssertNil(result!.returnedValue)
         
         // null
         testData = "{\"succeeded\":true,\"executedAt\":1455531174923,\"endpoint\":\"func\",\"returnedValue\":null}"
         resultDict = try! JSONSerialization.jsonObject(with: testData.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
         result = TriggeredServerCodeResult.resultWithNSDict(resultDict!)!
-        XCTAssertTrue(NSNull().isEqual(result!.getReturnedValue()))
+        XCTAssertTrue(NSNull().isEqual(result!.returnedValue))
         
         // String
         testData = "{\"succeeded\":true,\"executedAt\":1455531174923,\"endpoint\":\"func\",\"returnedValue\":\"1234\"}"
         resultDict = try! JSONSerialization.jsonObject(with: testData.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
         result = TriggeredServerCodeResult.resultWithNSDict(resultDict!)!
-        XCTAssertEqual("1234", result?.getReturnedValueAsString())
-        XCTAssertNil(result?.getReturnedValueAsNSNumber())
-        XCTAssertNil(result?.getReturnedValueAsBool())
-        XCTAssertNil(result?.getReturnedValueAsArray())
-        XCTAssertNil(result?.getReturnedValueAsDictionary())
+        XCTAssertEqual("1234", result?.returnedValueAsString)
+        XCTAssertNil(result?.returnedValueAsNSNumber)
+        XCTAssertNil(result?.returnedValueAsBool)
+        XCTAssertNil(result?.returnedValueAsArray)
+        XCTAssertNil(result?.returnedValueAsDictionary)
         
         // Bool
         testData = "{\"succeeded\":true,\"executedAt\":1455531174923,\"endpoint\":\"func\",\"returnedValue\":true}"
         resultDict = try! JSONSerialization.jsonObject(with: testData.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
         result = TriggeredServerCodeResult.resultWithNSDict(resultDict!)!
-        XCTAssertTrue(result!.getReturnedValueAsBool()!)
-        XCTAssertEqual("1", result?.getReturnedValueAsString())
-        XCTAssertEqual(1, result?.getReturnedValueAsNSNumber())
-        XCTAssertNil(result?.getReturnedValueAsArray())
-        XCTAssertNil(result?.getReturnedValueAsDictionary())
+        XCTAssertTrue(result!.returnedValueAsBool!)
+        XCTAssertEqual("1", result?.returnedValueAsString)
+        XCTAssertEqual(1, result?.returnedValueAsNSNumber)
+        XCTAssertNil(result?.returnedValueAsArray)
+        XCTAssertNil(result?.returnedValueAsDictionary)
         
         // Number int
         testData = "{\"succeeded\":true,\"executedAt\":1455531174923,\"endpoint\":\"func\",\"returnedValue\":1234}"
         resultDict = try! JSONSerialization.jsonObject(with: testData.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
         result = TriggeredServerCodeResult.resultWithNSDict(resultDict!)!
-        XCTAssertEqual(1234, result!.getReturnedValueAsNSNumber()!)
-        XCTAssertEqual("1234", result?.getReturnedValueAsString())
-        XCTAssertTrue(result!.getReturnedValueAsBool()!)
-        XCTAssertNil(result?.getReturnedValueAsArray())
-        XCTAssertNil(result?.getReturnedValueAsDictionary())
+        XCTAssertEqual(1234, result!.returnedValueAsNSNumber!)
+        XCTAssertEqual("1234", result?.returnedValueAsString)
+        XCTAssertTrue(result!.returnedValueAsBool!)
+        XCTAssertNil(result?.returnedValueAsArray)
+        XCTAssertNil(result?.returnedValueAsDictionary)
         
         // Number long
         testData = "{\"succeeded\":true,\"executedAt\":1455531174923,\"endpoint\":\"func\",\"returnedValue\":145553117492300}"
         resultDict = try! JSONSerialization.jsonObject(with: testData.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
         result = TriggeredServerCodeResult.resultWithNSDict(resultDict!)!
-        XCTAssertEqual(145553117492300, result!.getReturnedValueAsNSNumber()!)
-        XCTAssertEqual("145553117492300", result?.getReturnedValueAsString())
-        XCTAssertTrue(result!.getReturnedValueAsBool()!)
-        XCTAssertNil(result?.getReturnedValueAsArray())
-        XCTAssertNil(result?.getReturnedValueAsDictionary())
+        XCTAssertEqual(145553117492300, result!.returnedValueAsNSNumber!)
+        XCTAssertEqual("145553117492300", result?.returnedValueAsString)
+        XCTAssertTrue(result!.returnedValueAsBool!)
+        XCTAssertNil(result?.returnedValueAsArray)
+        XCTAssertNil(result?.returnedValueAsDictionary)
 
         // Number double
         testData = "{\"succeeded\":true,\"executedAt\":1455531174923,\"endpoint\":\"func\",\"returnedValue\":1234.567}"
         resultDict = try! JSONSerialization.jsonObject(with: testData.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
         result = TriggeredServerCodeResult.resultWithNSDict(resultDict!)!
-        XCTAssertEqual(1234.567, result!.getReturnedValueAsNSNumber()!)
-        XCTAssertEqual("1234.567", result?.getReturnedValueAsString())
-        XCTAssertTrue(result!.getReturnedValueAsBool()!)
-        XCTAssertNil(result?.getReturnedValueAsArray())
-        XCTAssertNil(result?.getReturnedValueAsDictionary())
+        XCTAssertEqual(1234.567, result!.returnedValueAsNSNumber!)
+        XCTAssertEqual("1234.567", result?.returnedValueAsString)
+        XCTAssertTrue(result!.returnedValueAsBool!)
+        XCTAssertNil(result?.returnedValueAsArray)
+        XCTAssertNil(result?.returnedValueAsDictionary)
         
         // Array
         testData = "{\"succeeded\":true,\"executedAt\":1455531174923,\"endpoint\":\"func\",\"returnedValue\":[123, true, \"456\"]}"
         resultDict = try! JSONSerialization.jsonObject(with: testData.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
         result = TriggeredServerCodeResult.resultWithNSDict(resultDict!)!
-        let array = result!.getReturnedValueAsArray()!
+        let array = result!.returnedValueAsArray!
         XCTAssertEqual(123, array[0] as? NSNumber)
         XCTAssertTrue(array[0] as! Bool)
         XCTAssertEqual("456", array[2] as? String)
-        XCTAssertNil(result?.getReturnedValueAsString())
-        XCTAssertNil(result?.getReturnedValueAsNSNumber())
-        XCTAssertNil(result?.getReturnedValueAsBool())
-        XCTAssertNil(result?.getReturnedValueAsDictionary())
+        XCTAssertNil(result?.returnedValueAsString)
+        XCTAssertNil(result?.returnedValueAsNSNumber)
+        XCTAssertNil(result?.returnedValueAsBool)
+        XCTAssertNil(result?.returnedValueAsDictionary)
         
         // Dictionary
         testData = "{\"succeeded\":true,\"executedAt\":1455531174923,\"endpoint\":\"func\",\"returnedValue\":{\"f1\":\"aaa\",\"f2\":false,\"f3\":1000,\"f4\":100.05}}"
         resultDict = try! JSONSerialization.jsonObject(with: testData.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
         result = TriggeredServerCodeResult.resultWithNSDict(resultDict!)!
-        let dict = result!.getReturnedValueAsDictionary()!
+        let dict = result!.returnedValueAsDictionary!
         XCTAssertEqual("aaa", dict["f1"] as? String)
         XCTAssertFalse(dict["f2"] as! Bool)
         XCTAssertEqual(1000, dict["f3"] as? NSNumber)
         XCTAssertEqual(100.05, dict["f4"] as? NSNumber)
-        XCTAssertNil(result?.getReturnedValueAsString())
-        XCTAssertNil(result?.getReturnedValueAsNSNumber())
-        XCTAssertNil(result?.getReturnedValueAsBool())
-        XCTAssertNil(result?.getReturnedValueAsArray())
+        XCTAssertNil(result?.returnedValueAsString)
+        XCTAssertNil(result?.returnedValueAsNSNumber)
+        XCTAssertNil(result?.returnedValueAsBool)
+        XCTAssertNil(result?.returnedValueAsArray)
     }
     func testIsEqual() {
         let testCases: [[Any]] = [


### PR DESCRIPTION
Some properties has getter method to make it read-only. However, in swift, read-only property can be declared.

I changed getter methods to read-only properties.

Related issue: #205 
Related PR: #188 