### PR TITLE
Duplicated feature APIs are removed.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -90,45 +90,6 @@ open class ThingIFAPI: NSObject, NSCoding {
     // MARK: - On board methods
 
     /** On board IoT Cloud with the specified vendor thing ID.
-    Specified thing will be owned by owner who consumes this API.
-    (Specified on creation of ThingIFAPI instance.)
-
-    If you are using a gateway, you need to use
-    `ThingIFAPI.onboard(pendingEndnode:endnodePassword:options:completionHandler:)`
-    to onboard endnode instead.
-    
-    **Note**: You should not call onboard second time, after successfully onboarded. Otherwise, ThingIFError.ALREADY_ONBOARDED will be returned in completionHandler callback.
-
-    - Parameter vendorThingID: Thing ID given by vendor. Must be specified.
-    - Parameter thingPassword: Thing Password given by vendor.
-    Must be specified.
-    - Parameter thingType: Type of the thing given by vendor.
-    If the thing is already registered,
-    this value would be ignored by IoT Cloud.
-    - Parameter thingProperties: Properties of thing.
-    If the thing is already registered, this value would be ignored by
-    IoT Cloud.
-    Refer to the [REST API DOC](http://docs.kii.com/rest/#thing_management-register_a_thing)
-    About the format of this Document.
-    - Parameter completionHandler: A closure to be executed once on board has finished. The closure takes 2 arguments: an target, an ThingIFError
-    */
-    open func onboard(
-        _ vendorThingID:String,
-        thingPassword:String,
-        thingType:String?,
-        thingProperties:Dictionary<String, Any>?,
-        completionHandler: @escaping (Target?, ThingIFError?)-> Void
-        ) ->Void
-    {
-        _onboard(true, IDString: vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { (target, error) -> Void in
-            if error == nil {
-                self.saveToUserDefault()
-            }
-            completionHandler(target, error)
-        }
-    }
-    
-    /** On board IoT Cloud with the specified vendor thing ID.
      Specified thing will be owned by owner who consumes this API.
      (Specified on creation of ThingIFAPI instance.)
 
@@ -156,36 +117,6 @@ open class ThingIFAPI: NSObject, NSCoding {
             thingProperties: options?.thingProperties,
             layoutPosition: options?.layoutPosition,
             dataGroupingInterval: options?.dataGroupingInterval) { (target, error) -> Void in
-            if error == nil {
-                self.saveToUserDefault()
-            }
-            completionHandler(target, error)
-        }
-    }
-
-    /** On board IoT Cloud with the specified thing ID.
-    Specified thing will be owned by owner who consumes this API.
-    (Specified on creation of ThingIFAPI instance.)
-    When you're sure that the on board process has been done,
-    this method is convenient.
-     If you are using a gateway, you need to use
-    `ThingIFAPI.onboard(pendingEndnode:endnodePassword:options:completionHandler:)`
-    to onboard endnode instead.
-
-    **Note**: You should not call onboard second time, after successfully onboarded. Otherwise, ThingIFError.ALREADY_ONBOARDED will be returned in completionHandler callback.
-
-    - Parameter thingID: Thing ID given by IoT Cloud. Must be specified.
-    - Parameter thingPassword: Thing Password given by vendor.
-    Must be specified.
-    - Parameter completionHandler: A closure to be executed once on board has finished. The closure takes 2 arguments: an target, an ThingIFError
-    */
-    open func onboard(
-        _ thingID:String,
-        thingPassword:String,
-        completionHandler: @escaping (Target?, ThingIFError?)-> Void
-        ) ->Void
-    {
-         _onboard(false, IDString: thingID, thingPassword: thingPassword) { (target, error) -> Void in
             if error == nil {
                 self.saveToUserDefault()
             }
@@ -295,28 +226,6 @@ open class ThingIFAPI: NSObject, NSCoding {
     /** Post new command to IoT Cloud.
     Command will be delivered to specified target and result will be notified
     through push notification.
-    
-    **Note**: Please onboard first, or provide a target instance by calling copyWithTarget. Otherwise, KiiCloudError.TARGET_NOT_AVAILABLE will be return in completionHandler callback
-    
-    - Parameter schemaName: Name of the Schema of which the Command is defined.
-    - Parameter schemaVersion: Version of the Schema of which the Command is
-    defined.
-    - Parameter actions: List of Actions to be executed in the Target.
-    - Parameter completionHandler: A closure to be executed once finished. The closure takes 2 arguments: an instance of created command, an instance of ThingIFError when failed.
-    */
-    open func postNewCommand(
-        _ schemaName:String,
-        schemaVersion:Int,
-        actions:[Dictionary<String, Any>],
-        completionHandler: @escaping (Command?, ThingIFError?)-> Void
-        ) -> Void
-    {
-        _postNewCommand(schemaName, schemaVersion: schemaVersion, actions: actions, completionHandler: completionHandler)
-    }
-
-    /** Post new command to IoT Cloud.
-    Command will be delivered to specified target and result will be notified
-    through push notification.
 
     **Note**: Please onboard first, or provide a target instance by calling copyWithTarget. Otherwise, KiiCloudError.TARGET_NOT_AVAILABLE will be return in completionHandler callback
 
@@ -412,41 +321,6 @@ open class ThingIFAPI: NSObject, NSCoding {
     }
 
     /** Post new Trigger to IoT Cloud.
-
-    **Note**: Please onboard first, or provide a target instance by calling copyWithTarget. Otherwise, KiiCloudError.TARGET_NOT_AVAILABLE will be return in completionHandler callback
-
-    When thing related to this ThingIFAPI instance meets condition
-    described by predicate, A registered command sends to thing
-    related to target.
-
-    `target` property and target argument must be same owner's things.
-
-    - Parameter schemaName: Name of the Schema of which the Command specified in
-    Trigger is defined.
-    - Parameter schemaVersion: Version of the Schema of which the Command
-    specified in Trigger is defined.
-    - Parameter actions: Actions to be executed by the Trigger.
-    - Parameter predicate: Predicate of the Command.
-    - Parameter completionHandler: A closure to be executed once finished. The closure takes 2 arguments: 1st one is an created Trigger instance, 2nd one is an ThingIFError instance when failed.
-    */
-    open func postNewTrigger(
-        _ schemaName:String,
-        schemaVersion:Int,
-        actions:[Dictionary<String, Any>],
-        predicate:Predicate,
-        completionHandler: @escaping (Trigger?, ThingIFError?)-> Void
-        )
-    {
-        _postNewTrigger(
-            TriggeredCommandForm(
-                schemaName: schemaName,
-                schemaVersion: schemaVersion,
-                actions: actions),
-            predicate: predicate,
-            completionHandler: completionHandler);
-    }
-    
-    /** Post new Trigger to IoT Cloud.
      
      **Note**: Please onboard first, or provide a target instance by calling copyWithTarget. Otherwise, KiiCloudError.TARGET_NOT_AVAILABLE will be return in completionHandler callback
      
@@ -525,45 +399,6 @@ open class ThingIFAPI: NSObject, NSCoding {
             completionHandler: completionHandler)
     }
 
-    /** Apply patch to a registered Trigger
-    Modify a registered Trigger with the specified patch.
-
-    **Note**: Please onboard first, or provide a target instance by calling copyWithTarget. Otherwise, KiiCloudError.TARGET_NOT_AVAILABLE will be return in completionHandler callback
-
-    - Parameter triggerID: ID of the Trigger to which the patch is applied.
-    - Parameter schemaName: Name of the Schema of which the Command specified in
-    Trigger is defined.
-    - Parameter schemaVersion: Version of the Schema of which the Command
-    specified in Trigger is defined.
-    - Parameter actions: Modified Actions to be applied as patch.
-    - Parameter predicate: Modified Predicate to be applied as patch.
-    - Parameter completionHandler: A closure to be executed once finished. The closure takes 2 arguments: 1st one is the modified Trigger instance, 2nd one is an ThingIFError instance when failed.
-    */
-    open func patchTrigger(
-        _ triggerID:String,
-        schemaName:String?,
-        schemaVersion:Int?,
-        actions:[Dictionary<String, Any>]?,
-        predicate:Predicate?,
-        completionHandler: @escaping (Trigger?, ThingIFError?)-> Void
-        )
-    {
-        let triggeredCommandForm: TriggeredCommandForm?
-        if (schemaName != nil && schemaVersion != nil && actions != nil) {
-            triggeredCommandForm = TriggeredCommandForm(
-                schemaName: schemaName!,
-                schemaVersion: schemaVersion!,
-                actions: actions!)
-        } else {
-            triggeredCommandForm = nil
-        }
-        _patchTrigger(
-            triggerID,
-            triggeredCommandForm: triggeredCommandForm,
-            predicate: predicate,
-            completionHandler: completionHandler)
-    }
-    
     /** Apply patch to a registered Trigger
      Modify a registered Trigger with the specified patch.
      

--- a/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
@@ -52,7 +52,12 @@ class GetStateTests: SmallTestBase {
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
-            setting.api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
+            setting.api.onboardWith(
+              vendorThingID: vendorThingID,
+              thingPassword: thingPassword,
+              options: OnboardWithVendorThingIDOptions(
+                thingType: thingType,
+                thingProperties: thingProperties)) { ( target, error) -> Void in
                 if error == nil{
                     XCTAssertEqual(target!.typedID.toString(), "thing:th.0267251d9d60-1858-5e11-3dc3-00f3f0b5")
                 }else {

--- a/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/IoTCloudSDKTests.swift
@@ -57,7 +57,11 @@ class ThingIFSDKTests: SmallTestBase {
         
         var expectation = self.expectation(description: "testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
-        api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api1.onboardWith(
+          vendorThingID: "vendor-0001",
+          thingPassword: "password1",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -71,7 +75,11 @@ class ThingIFSDKTests: SmallTestBase {
         
         expectation = self.expectation(description: "testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
-        api2.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api2.onboardWith(
+          vendorThingID: "vendor-0002",
+          thingPassword: "password2",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -85,7 +93,11 @@ class ThingIFSDKTests: SmallTestBase {
         
         expectation = self.expectation(description: "testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000003", thingID: "th.00000003", setting: setting)
-        api3.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api3.onboardWith(
+          vendorThingID: "vendor-0002",
+          thingPassword: "password2",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -139,7 +151,11 @@ class ThingIFSDKTests: SmallTestBase {
         
         var expectation = self.expectation(description: "testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
-        api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api1.onboardWith(
+          vendorThingID: "vendor-0001",
+          thingPassword: "password1",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -153,7 +169,11 @@ class ThingIFSDKTests: SmallTestBase {
 
         expectation = self.expectation(description: "testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
-        api2.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api2.onboardWith(
+          vendorThingID: "vendor-0002",
+          thingPassword: "password2",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -167,7 +187,11 @@ class ThingIFSDKTests: SmallTestBase {
 
         expectation = self.expectation(description: "testSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000003", thingID: "th.00000003", setting: setting)
-        api3.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api3.onboardWith(
+          vendorThingID: "vendor-0002",
+          thingPassword: "password2",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -233,7 +257,11 @@ class ThingIFSDKTests: SmallTestBase {
         
         var expectation = self.expectation(description: "testOverwriteSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
-        api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api1.onboardWith(
+          vendorThingID: "vendor-0001",
+          thingPassword: "password1",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -249,7 +277,11 @@ class ThingIFSDKTests: SmallTestBase {
 
         expectation = self.expectation(description: "testOverwriteSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000002", thingID: "th.00000002", setting: setting)
-        api2.onboard("vendor-0002", thingPassword: "password2", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api2.onboardWith(
+          vendorThingID: "vendor-0002",
+          thingPassword: "password2",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -277,7 +309,11 @@ class ThingIFSDKTests: SmallTestBase {
         
         let expectation = self.expectation(description: "testOverwriteSavedInstanceWithOnboard")
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
-        api1.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api1.onboardWith(
+          vendorThingID: "vendor-0001",
+          thingPassword: "password1",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -568,7 +604,11 @@ class ThingIFSDKTests: SmallTestBase {
         let api = ThingIFAPIBuilder(app:app, owner:owner).make()
 
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
-        api.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api.onboardWith(
+          vendorThingID: "vendor-0001",
+          thingPassword: "password1",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -611,7 +651,11 @@ class ThingIFSDKTests: SmallTestBase {
         let api = ThingIFAPIBuilder(app:app, owner:owner, tag:tagName).make()
 
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
-        api.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api.onboardWith(
+          vendorThingID: "vendor-0001",
+          thingPassword: "password1",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }
@@ -655,7 +699,11 @@ class ThingIFSDKTests: SmallTestBase {
         let api = ThingIFAPIBuilder(app:app, owner:owner).make()
 
         setMockResponse4Onboard("access-token-00000001", thingID: "th.00000001", setting: setting)
-        api.onboard("vendor-0001", thingPassword: "password1", thingType: "smart-light", thingProperties: nil) { ( target, error) -> Void in
+        api.onboardWith(
+          vendorThingID: "vendor-0001",
+          thingPassword: "password1",
+          options: OnboardWithVendorThingIDOptions(
+            thingType: "smart-light")) { ( target, error) -> Void in
             if error != nil{
                 XCTFail("should success")
             }

--- a/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
@@ -62,7 +62,9 @@ class OnboardingTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             
             iotSession = MockSession.self
-            api.onboard("th.0267251d9d60-1858-5e11-3dc3-00f3f0b5", thingPassword: "dummyPassword") { ( target, error) -> Void in
+            api.onboardWith(
+              thingID: "th.0267251d9d60-1858-5e11-3dc3-00f3f0b5",
+              thingPassword: "dummyPassword") { ( target, error) -> Void in
                 if error == nil{
                     XCTFail("should fail")
                 }else {
@@ -129,7 +131,12 @@ class OnboardingTests: SmallTestBase {
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
-            api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
+            api.onboardWith(
+              vendorThingID: vendorThingID,
+              thingPassword: thingPassword,
+              options: OnboardWithVendorThingIDOptions(
+                thingType: thingType,
+                thingProperties: thingProperties)) { ( target, error) -> Void in
                 if error == nil{
                     XCTAssertEqual(target!.typedID.toString(), "thing:\(setting.thingID)")
                     XCTAssertEqual(target!.typedID.toString(), "thing:\(setting.thingID)")
@@ -157,7 +164,9 @@ class OnboardingTests: SmallTestBase {
         let api = setting.api
 
         api._target = setting.target
-        api.onboard("dummyThingID", thingPassword: "dummyPassword") { (target, error) -> Void in
+        api.onboardWith(
+          thingID: "dummyThingID",
+          thingPassword: "dummyPassword") { (target, error) -> Void in
             if error == nil{
                 XCTFail("should fail")
             }else {
@@ -217,7 +226,12 @@ class OnboardingTests: SmallTestBase {
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
-            api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
+            api.onboardWith(
+              vendorThingID:vendorThingID,
+              thingPassword: thingPassword,
+              options: OnboardWithVendorThingIDOptions(
+                thingType: thingType,
+                thingProperties: thingProperties)) { ( target, error) -> Void in
                 if error == nil{
                     XCTAssertEqual(target!.typedID.toString(), "thing:\(setting.thingID)")
                     XCTAssertEqual(target!.typedID.toString(), "thing:\(setting.thingID)")

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -88,7 +88,12 @@ class PostNewCommandTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
-            setting.api.postNewCommand(testcase.schema, schemaVersion: testcase.schemaVersion, actions: testcase.actions, completionHandler: { (command, error) -> Void in
+            setting.api.postNewCommand(
+              CommandForm(
+                schemaName: testcase.schema,
+                schemaVersion: testcase.schemaVersion,
+                actions: testcase.actions),
+              completionHandler: { (command, error) -> Void in
                 if error == nil{
                     XCTAssertNotNil(command, tag)
                     XCTAssertEqual(command!.commandID, expectedCommandID, tag)
@@ -155,7 +160,12 @@ class PostNewCommandTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
-            api.postNewCommand("", schemaVersion: setting.schemaVersion, actions: [], completionHandler: { (command, error) -> Void in
+            api.postNewCommand(
+              CommandForm(
+                schemaName: "",
+                schemaVersion: setting.schemaVersion,
+                actions: []),
+              completionHandler: { (command, error) -> Void in
                 if error == nil{
                     XCTFail("should fail")
                 }else {
@@ -188,7 +198,12 @@ class PostNewCommandTests: SmallTestBase {
         let setting = TestSetting()
         let api = setting.api
 
-        api.postNewCommand("", schemaVersion: setting.schemaVersion, actions: [], completionHandler: { (command, error) -> Void in
+        api.postNewCommand(
+          CommandForm(
+            schemaName: "",
+            schemaVersion: setting.schemaVersion,
+            actions: []),
+          completionHandler: { (command, error) -> Void in
             if error == nil{
                 XCTFail("should fail")
             }else {

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerForScheduleTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerForScheduleTests.swift
@@ -259,14 +259,15 @@ class PostNewTriggerForScheduleTests: SmallTestBase {
         setting.api._target = setting.target
 
         setting.api.postNewTrigger(
-            testCase.parameter.schemaName,
+          TriggeredCommandForm(
+            schemaName: testCase.parameter.schemaName,
             schemaVersion: testCase.parameter.schemaVersion,
-            actions: testCase.parameter.actions,
-            predicate: testCase.parameter.predicate,
-            completionHandler: { (trigger, error) -> Void in
-                testCase.verifier.callbackVerifier.verifier(trigger, error)
-                expectation.fulfill()
-            })
+            actions: testCase.parameter.actions),
+          predicate: testCase.parameter.predicate,
+          completionHandler: { (trigger, error) -> Void in
+              testCase.verifier.callbackVerifier.verifier(trigger, error)
+              expectation.fulfill()
+          })
         self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
             if error != nil {
                 XCTFail("execution timeout for \(testCase.verifier.requestVerifier.tag)")

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
@@ -99,7 +99,13 @@ class PostNewTriggerTests: SmallTestBase {
                 sharedMockSession.requestVerifier = requestVerifier
                 iotSession = MockSession.self
 
-                setting.api.postNewTrigger(setting.schema, schemaVersion: setting.schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
+                setting.api.postNewTrigger(
+                  TriggeredCommandForm(
+                    schemaName: setting.schema,
+                    schemaVersion: setting.schemaVersion,
+                    actions: actions),
+                  predicate: predicate,
+                  completionHandler: { (trigger, error) -> Void in
                     if error == nil{
                         XCTAssertEqual(trigger!.triggerID, expectedTriggerID, tag)
                         XCTAssertEqual(trigger!.targetID, setting.target.typedID, tag)
@@ -218,7 +224,13 @@ class PostNewTriggerTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
-            api.postNewTrigger(schema, schemaVersion: schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
+            api.postNewTrigger(
+              TriggeredCommandForm(
+                schemaName: schema,
+                schemaVersion: schemaVersion,
+                actions: actions),
+              predicate: predicate,
+              completionHandler: { (trigger, error) -> Void in
                 if error == nil{
                     XCTFail("should fail")
                 }else {
@@ -297,7 +309,13 @@ class PostNewTriggerTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
-            api.postNewTrigger(schema, schemaVersion: schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
+            api.postNewTrigger(
+              TriggeredCommandForm(
+                schemaName: schema,
+                schemaVersion: schemaVersion,
+                actions: actions),
+              predicate: predicate,
+              completionHandler: { (trigger, error) -> Void in
                 if error == nil{
                     XCTFail("should fail")
                 }else {
@@ -372,7 +390,13 @@ class PostNewTriggerTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
-            api.postNewTrigger(schema, schemaVersion: schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
+            api.postNewTrigger(
+              TriggeredCommandForm(
+                schemaName: schema,
+                schemaVersion: schemaVersion,
+                actions: actions),
+              predicate: predicate,
+              completionHandler: { (trigger, error) -> Void in
                 if error == nil{
                     XCTFail("should fail")
                 }else {
@@ -409,7 +433,13 @@ class PostNewTriggerTests: SmallTestBase {
         let actions: [Dictionary<String, Any>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
         let predicate = StatePredicate(condition: Condition(clause: EqualsClause(field: "color", intValue: 0)), triggersWhen: TriggersWhen.conditionFalseToTrue)
 
-        api.postNewTrigger(schema, schemaVersion: schemaVersion, actions: actions, predicate: predicate, completionHandler: { (trigger, error) -> Void in
+        api.postNewTrigger(
+          TriggeredCommandForm(
+            schemaName: schema,
+            schemaVersion: schemaVersion,
+            actions: actions),
+          predicate: predicate,
+          completionHandler: { (trigger, error) -> Void in
             if error == nil{
                 XCTFail("should fail")
             }else {

--- a/ThingIFSDK/ThingIFSDKTests/PushInstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushInstallationTests.swift
@@ -64,11 +64,16 @@ class PushInstallationTests: SmallTestBase {
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
-            setting.api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
+            setting.api.onboardWith(
+              vendorThingID: vendorThingID,
+              thingPassword: thingPassword,
+              options: OnboardWithVendorThingIDOptions(
+                thingType: thingType,
+                thingProperties: thingProperties)) { ( target, error) -> Void in
                 if error == nil{
                     XCTAssertEqual(target!.typedID.toString(), "thing:th.0267251d9d60-1858-5e11-3dc3-00f3f0b5")
                 }else {
-                    XCTFail("should success")
+                    XCTFail("should     success")
                 }
                 expectation.fulfill()
             }

--- a/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
@@ -62,7 +62,12 @@ class PushUninstallationTests: SmallTestBase {
             sharedMockSession.mockResponse = (jsonData, urlResponse: urlResponse, error: nil)
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
-            setting.api.onboard(vendorThingID, thingPassword: thingPassword, thingType: thingType, thingProperties: thingProperties) { ( target, error) -> Void in
+            setting.api.onboardWith(
+              vendorThingID: vendorThingID,
+              thingPassword: thingPassword,
+              options: OnboardWithVendorThingIDOptions(
+                thingType: thingType,
+                thingProperties: thingProperties)) { ( target, error) -> Void in
                 if error == nil{
                     XCTAssertEqual(target!.typedID.toString(), "thing:th.0267251d9d60-1858-5e11-3dc3-00f3f0b5")
                 }else {


### PR DESCRIPTION
ThingAPIの機能的に重複しているAPIを削除しました。削除したAPIは以下の通りです。

  * `onboard(_:thingPassword:thingType:thingProperties:completionHandler:)`
    `onboardWith(vendorThingID:thingPassword:options:completionHandler:)` の導入に伴い、不要になりました。
  * `onboard(_:thingPassword:completionHandler:)`
    `onboardWith(thingID:thingPassword:options:completionHandler:)` の導入に伴い、不要になりました。
  * `postNewCommand(_:schemaVersion:actions:completionHandler:)`
    `postNewCommand(_:completionHandler:)`の導入に伴い、不要になりました。
  * `postNewTrigger(_:schemaVersion:actions:predicate:completionHandler)`
    `postNewTrigger(_:predicate:options:completionHandler:)` の導入に伴い、不要になりました。
  * `patchTrigger(_:schemaName:schemaVersion:actions:predicate:completionHandler:)`
    `patchTrigger(_:predicate:options:completionHandler:)` の導入に伴い、不要になりました。
  
APIの修正は 0d6b853 で、テストの修正は dd5b9ed で行いました。

Related issue: #204 
Related PR: #188 