### PR TITLE
Fix initializer access level

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Command.swift
+++ b/ThingIFSDK/ThingIFSDK/Command.swift
@@ -88,25 +88,7 @@ open class Command: NSObject, NSCoding {
     /** Metadata of the Command */
     open let metadata: Dictionary<String, Any>?
 
-    public override init() {
-        // TODO: implement it with proper initilizer.
-        self.commandID = ""
-        self.targetID = TypedID(type: "", id: "")
-        self.issuerID = TypedID(type: "", id: "")
-        self.schemaName = ""
-        self.schemaVersion = 0
-        self.actions = []
-        self.actionResults = []
-        self.commandState = CommandState.sending
-        self.firedByTriggerID = nil
-        self.created = nil
-        self.modified = nil
-        self.title = nil
-        self.commandDescription = nil
-        self.metadata = nil
-    }
-
-    init(commandID: String?,
+    internal init(commandID: String?,
          targetID: TypedID,
          issuerID: TypedID,
          schemaName: String,

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -48,7 +48,7 @@ open class GatewayAPI: NSObject, NSCoding {
         self.accessToken = aDecoder.decodeObject(forKey: "accessToken") as? String
     }
 
-    init(app: App, gatewayAddress: URL, tag: String? = nil)
+    internal init(app: App, gatewayAddress: URL, tag: String? = nil)
     {
         self.tag = tag
         self.app = app

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayInformation.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayInformation.swift
@@ -11,7 +11,7 @@ open class GatewayInformation {
 
     open let vendorThingID: String
 
-    init(vendorThingID: String)
+    internal init(vendorThingID: String)
     {
         self.vendorThingID = vendorThingID
     }

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -77,7 +77,7 @@ open class ThingIFAPI: NSObject, NSCoding {
         self.tag = aDecoder.decodeObject(forKey: "tag") as? String
     }
 
-    init(app:App, owner: Owner, tag : String?=nil) {
+    internal init(app:App, owner: Owner, tag : String?=nil) {
         self.app = app
         self.baseURL = app.baseURL
         self.appID = app.appID

--- a/ThingIFSDK/ThingIFSDK/Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/Trigger.swift
@@ -124,7 +124,7 @@ open class Trigger: NSObject, NSCoding {
     - Parameter predicate: Predicate instance
     - Parameter command: Command instance
     */
-    public init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, command: Command, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, Any>? = nil) {
+    internal init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, command: Command, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, Any>? = nil) {
         self.triggerID = triggerID
         self.targetID = targetID
         self.enabled = enabled
@@ -143,7 +143,7 @@ open class Trigger: NSObject, NSCoding {
      - Parameter predicate: Predicate instance
      - Parameter serverCode: ServerCode instance
      */
-    public init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, serverCode: ServerCode, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, Any>? = nil) {
+    internal init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, serverCode: ServerCode, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, Any>? = nil) {
         self.triggerID = triggerID
         self.targetID = targetID
         self.enabled = enabled

--- a/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
@@ -82,7 +82,7 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
      - Parameter endpoint: The endpoint used in the server code invocation
      - Parameter error: Error object of the invocation if any
      */
-    public init(succeeded: Bool, returnedValue: Any?, executedAt: Date, endpoint: String, error: ServerError?) {
+    internal init(succeeded: Bool, returnedValue: Any?, executedAt: Date, endpoint: String, error: ServerError?) {
         self.succeeded = succeeded
         self.returnedValue = returnedValue
         self.executedAt = executedAt

--- a/ThingIFSDK/ThingIFSDKTests/TriggerNSCodingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TriggerNSCodingTests.swift
@@ -23,7 +23,16 @@ class TriggerNSCodingTests: SmallTestBase {
         let triggerID = "dummyID";
         let enabled = true;
         let predicate = SchedulePredicate(schedule: "dummySchedule");
-        let command = Command();
+        let command = Command(commandID: "commandID",
+                              targetID: TypedID(type: "thing",
+                                                id: "id"),
+                              issuerID: TypedID(type: "user",
+                                                id: "id"),
+                              schemaName: "schema",
+                              schemaVersion: 1,
+                              actions: [[ "key" : "value" ]],
+                              actionResults: [[ "key" : "value" ]],
+                              commandState: CommandState.sending)
         let title = "dummyTitle"
         let description = "dummyDescription"
         let key = "dummyKey"


### PR DESCRIPTION
Some initializers are declared as `public` but they can be declared as `internal` in its essence.

Followings are changed to `internal`

  * `Trigger` class
  *  `TriggeredServerCodeResult` class

Followings are added `internal`. Their initializers has no access modifier. To specify access level, `internal` is added.

  * `Command` class
  * `GatewayAPI` class
  * `GatewayInformation` class
  * `ThingIFAPI` class
  * 

In this PR, I also removed redundant initializer. `Command.Init()` is declared as public initializer but default initializer is needless.

API is changed at 746507d.
Test is fixed at 82ed565.

Related issue: #204 
Related PR: #188