### PR TITLE
Workaround for using xcinvoke is removed.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,13 +12,6 @@ dependencies:
     - sudo update_rubygems
 test:
   pre:
-    # This is workaround.
-    # xcinvoke-0.2.1 is not adapt Xcode 8.
-    # xcinvoke-0.2.1 is used from jazzy-0.7.2.
-    # So we need to fix to generate document with this workaround.
-    # ref: https://github.com/segiddins/xcinvoke/issues/6
-    - sed "s/cmd = \[@xcrun_path\] + cmd/cmd = \['xcrun'\] + cmd/g" /opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/xcinvoke-0.2.1/lib/xcinvoke/xcode.rb > xcode.rb
-    - sudo mv xcode.rb /opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/xcinvoke-0.2.1/lib/xcinvoke
     # Build sdk
     - cd ThingIFSDK; make all
     # Copy docs to artifacts


### PR DESCRIPTION
To use xcinvoke-0.2.1, I added a workaround in circle.yml.

In xcinvoke-0.3.0, the bug is fixed.
https://github.com/segiddins/xcinvoke/pull/7

The workaround is removed.