### PR TITLE
schemaName and schemaVersion are removed from CommandForm.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -46,7 +46,7 @@ open class CommandForm: NSObject, NSCoding {
     Initializer of CommandForm instance.
 
     - Parameter actions: List of actions. Must not be empty. Both of
-      non trait acation list and trait action list are acceptable but
+      non trait action list and trait action list are acceptable but
       non trait action and trait action must not be mixed in a list.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.

--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -16,7 +16,7 @@ This class contains data in order to create `Command` with
 
 Mandatory data are followings:
 
-  - List of actions
+  - Array of actions
 
 Optional data are followings:
 
@@ -28,7 +28,7 @@ open class CommandForm: NSObject, NSCoding {
 
     // MARK: - Properties
 
-    /// List of actions.
+    /// Array of actions.
     open let actions: [[String : Any]]
 
     /// Title of a command.
@@ -45,9 +45,9 @@ open class CommandForm: NSObject, NSCoding {
     /**
     Initializer of CommandForm instance.
 
-    - Parameter actions: List of actions. Must not be empty. Both of
-      non trait action list and trait action list are acceptable but
-      non trait action and trait action must not be mixed in a list.
+    - Parameter actions: Array of actions. Must not be empty. Both of
+      non trait action array and trait action array are acceptable but
+      non trait action and trait action must not be mixed in a array.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.
     - Parameter description: Description of a comand. This should be

--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -16,28 +16,20 @@ This class contains data in order to create `Command` with
 
 Mandatory data are followings:
 
-  - Schema name
-  - Schema version
   - List of actions
 
 Optional data are followings:
 
-  - Title of a schema
-  - Description of a schema
-  - Meta data of a schema
+  - Title of a command
+  - Description of a command
+  - Meta data of a command
 */
 open class CommandForm: NSObject, NSCoding {
 
     // MARK: - Properties
 
-    /// Schema name.
-    open let schemaName: String
-
-    /// Schema version.
-    open let schemaVersion: Int
-
     /// List of actions.
-    open let actions: [Dictionary<String, Any>]
+    open let actions: [[String : Any]]
 
     /// Title of a command.
     open let title: String?
@@ -53,24 +45,20 @@ open class CommandForm: NSObject, NSCoding {
     /**
     Initializer of CommandForm instance.
 
-    - Parameter schemaName: Schema name.
-    - Parameter schemaVersion: Schema version.
-    - Parameter actions: List of actions. Must not be empty.
+    - Parameter actions: List of actions. Must not be empty. Both of
+      non trait acation list and trait action list are acceptable but
+      non trait action and trait action must not be mixed in a list.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.
     - Parameter description: Description of a comand. This should be
       equal or less than 200 characters.
     - Parameter metadata: Meta data of a command.
     */
-    public init(schemaName: String,
-                schemaVersion: Int,
-                actions: [Dictionary<String, Any>],
+    public init(actions: [[String : Any]],
                 title: String? = nil,
                 commandDescription: String? = nil,
                 metadata: Dictionary<String, Any>? = nil)
     {
-        self.schemaName = schemaName
-        self.schemaVersion = schemaVersion
         self.actions = actions
         self.title = title;
         self.commandDescription = commandDescription;
@@ -78,8 +66,6 @@ open class CommandForm: NSObject, NSCoding {
     }
 
     open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.schemaName, forKey: "schemaName")
-        aCoder.encode(self.schemaVersion, forKey: "schemaVersion")
         aCoder.encode(self.actions, forKey: "actions")
         aCoder.encode(self.title, forKey: "title")
         aCoder.encode(self.commandDescription,
@@ -88,8 +74,6 @@ open class CommandForm: NSObject, NSCoding {
     }
 
     public required init?(coder aDecoder: NSCoder) {
-        self.schemaName = aDecoder.decodeObject(forKey: "schemaName") as! String
-        self.schemaVersion = aDecoder.decodeInteger(forKey: "schemaVersion")
         self.actions = aDecoder.decodeObject(forKey: "actions")
                 as! [Dictionary<String, Any>];
         self.title = aDecoder.decodeObject(forKey: "title") as? String


### PR DESCRIPTION
This is a part of trait adaptable API design. This PR does not buildable and testable because this PR only changes API and does not changes implementation and tests. The target branch is not develop and migrate-swift3.0 so feel free to merge this.

### Summary

- Schema name and schema version are removed because they are not used next ThingIF framework.
- trait alias can be use without API change because `actions` are passed with dictionary type. I described about that in API document.

Related PR: #236