### PR TITLE
schemaName and schemaVersion are removed from TriggredCommandForm.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
@@ -19,29 +19,21 @@ This class contains data in order to create or modify `Command` in
 
 Mandatory data are followings:
 
-  - Schema name
-  - Schema version
-  - List of actions
+  - Array of actions
 
 Optional data are followings:
 
   - Target thing id
-  - Title of a schema
-  - Description of a schema
-  - Meta data of a schema
+  - Title of a triggered command
+  - Description of a triggered command
+  - Meta data of a triggered command
 */
 open class TriggeredCommandForm: NSObject, NSCoding {
 
     // MARK: - Properties
 
-    /// Schema name.
-    open let schemaName: String
-
-    /// Schema version.
-    open let schemaVersion: Int
-
-    /// List of actions.
-    open let actions: [Dictionary<String, Any>]
+    /// Array of actions.
+    open let actions: [[String : Any]]
 
     /// Target thing ID.
     open let targetID: TypedID?
@@ -60,9 +52,9 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     /**
     Initializer of TriggeredCommandForm instance.
 
-    - Parameter schemaName: Schema name.
-    - Parameter schemaVersion: Schema version.
-    - Parameter actions: List of actions. Must not be empty.
+    - Parameter actions: Array of actions. Must not be empty. Both of
+      non trait action array and trait action array are acceptable but
+      non trait action and trait action must not be mixed in a array.
     - Parameter targetID: target thing ID.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.
@@ -70,16 +62,12 @@ open class TriggeredCommandForm: NSObject, NSCoding {
       equal or less than 200 characters.
     - Parameter metadata: Meta data of a command.
     */
-    public init(schemaName: String,
-                schemaVersion: Int,
-                actions: [Dictionary<String, Any>],
+    public init(actions: [[String : Any]],
                 targetID: TypedID? = nil,
                 title: String? = nil,
                 commandDescription: String? = nil,
                 metadata: Dictionary<String, Any>? = nil)
     {
-        self.schemaName = schemaName
-        self.schemaVersion = schemaVersion
         self.actions = actions
         self.targetID = targetID
         self.title = title
@@ -92,8 +80,6 @@ open class TriggeredCommandForm: NSObject, NSCoding {
 
     This initializer copies following fields:
 
-    - `Command.schemaName`
-    - `Command.schemaVersion`
     - `Command.actions`
     - `Command.targetID`
     - `Command.title`
@@ -104,9 +90,9 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     value, Optional argument values win against the `Command` values.
 
     - Parameter command: source command of this TriggeredCommandForm.
-    - Parameter schemaName: Schema name.
-    - Parameter schemaVersion: Schema version.
-    - Parameter actions: List of actions. Must not be empty.
+    - Parameter actions: Array of actions. Must not be empty. Both of
+      non trait action array and trait action array are acceptable but
+      non trait action and trait action must not be mixed in a array.
     - Parameter targetID: target thing ID.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.
@@ -115,17 +101,12 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     - Parameter metadata: Meta data of a command.
     */
     public init(command: Command,
-                schemaName: String? = nil,
-                schemaVersion: Int? = nil,
                 actions: [Dictionary<String, Any>]? = nil,
                 targetID: TypedID? = nil,
                 title: String? = nil,
                 commandDescription: String? = nil,
                 metadata: Dictionary<String, Any>? = nil)
     {
-        self.schemaName = schemaName != nil ? schemaName! : command.schemaName
-        self.schemaVersion =
-             schemaVersion != nil ? schemaVersion! : command.schemaVersion
         self.actions = actions != nil ? actions! : command.actions
         self.targetID = targetID != nil ? targetID : command.targetID
         self.title = title != nil ? title : command.title
@@ -136,8 +117,6 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     }
 
     open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.schemaName, forKey: "schemaName")
-        aCoder.encode(self.schemaVersion, forKey: "schemaVersion")
         aCoder.encode(self.actions, forKey: "actions")
         aCoder.encode(self.targetID, forKey: "targetID")
         aCoder.encode(self.title, forKey: "title")
@@ -147,8 +126,6 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     }
 
     public required init?(coder aDecoder: NSCoder) {
-        self.schemaName = aDecoder.decodeObject(forKey: "schemaName") as! String
-        self.schemaVersion = aDecoder.decodeInteger(forKey: "schemaVersion")
         self.actions = aDecoder.decodeObject(forKey: "actions")
                 as! [Dictionary<String, Any>];
         self.targetID = aDecoder.decodeObject(forKey: "targetID") as? TypedID
@@ -162,8 +139,6 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     func toDictionary() -> Dictionary<String, Any> {
         var retval: Dictionary<String, Any> =
             [
-                "schema": self.schemaName,
-                "schemaVersion": self.schemaVersion,
                 "actions": self.actions
             ]
         if let targetID = self.targetID {


### PR DESCRIPTION
This is a part of trait adaptable API design. This PR does not buildable and testable because this PR only changes API and does not changes implementation and tests. The target branch is not develop and migrate-swift3.0 so feel free to merge this.

### Summary

- Schema name and schema version are removed because they are not used next ThingIF framework.
- trait alias can be use without API change because actions are passed with dictionary type. I described about that in API document.

Related PR: #236