### PR TITLE
Initializers are added to distinguish trait or not.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -41,7 +41,7 @@ open class CommandForm: NSObject, NSCoding {
     open let metadata: Dictionary<String, Any>?
 
     /// Use trait or not.
-    open let useTrait: Bool
+    internal let useTrait: Bool
 
     // MARK: - Initializing CommandForm instance.
 

--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -45,11 +45,11 @@ open class CommandForm: NSObject, NSCoding {
 
     // MARK: - Initializing CommandForm instance.
 
-    init(actions: [[String : Any]],
-         useTrait: Bool,
-         title: String? = nil,
-         commandDescription: String? = nil,
-         metadata: Dictionary<String, Any>? = nil)
+    private init(actions: [[String : Any]],
+                 useTrait: Bool,
+                 title: String? = nil,
+                 commandDescription: String? = nil,
+                 metadata: Dictionary<String, Any>? = nil)
     {
         self.actions = actions
         self.useTrait = useTrait

--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -40,29 +40,68 @@ open class CommandForm: NSObject, NSCoding {
     /// Meta data of ad command.
     open let metadata: Dictionary<String, Any>?
 
+    /// Use trait or not.
+    open let useTrait: Bool
 
     // MARK: - Initializing CommandForm instance.
-    /**
-    Initializer of CommandForm instance.
 
-    - Parameter actions: Array of actions. Must not be empty. Both of
-      non trait action array and trait action array are acceptable but
-      non trait action and trait action must not be mixed in a array.
+    init(actions: [[String : Any]],
+         useTrait: Bool,
+         title: String? = nil,
+         commandDescription: String? = nil,
+         metadata: Dictionary<String, Any>? = nil)
+    {
+        self.actions = actions
+        self.useTrait = useTrait
+        self.title = title;
+        self.commandDescription = commandDescription;
+        self.metadata = metadata;
+    }
+
+    /**
+    Initializer of CommandForm instance for non trait.
+
+    - Parameter actions: Array of actions. Must not be empty. The
+      contente of this array must be non trait actions.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.
     - Parameter description: Description of a comand. This should be
       equal or less than 200 characters.
     - Parameter metadata: Meta data of a command.
     */
-    public init(actions: [[String : Any]],
-                title: String? = nil,
-                commandDescription: String? = nil,
-                metadata: Dictionary<String, Any>? = nil)
+    public convenience init(actions: [[String : Any]],
+                            title: String? = nil,
+                            commandDescription: String? = nil,
+                            metadata: Dictionary<String, Any>? = nil)
     {
-        self.actions = actions
-        self.title = title;
-        self.commandDescription = commandDescription;
-        self.metadata = metadata;
+        self.init(actions: actions,
+                  useTrait: false,
+                  title: title,
+                  commandDescription: commandDescription,
+                  metadata: metadata)
+    }
+
+    /**
+    Initializer of CommandForm instance for trait.
+
+    - Parameter actions: Array of trait actions. Must not be
+      empty. The contente of this array must be trait actions.
+    - Parameter title: Title of a command. This should be equal or
+      less than 50 characters.
+    - Parameter description: Description of a comand. This should be
+      equal or less than 200 characters.
+    - Parameter metadata: Meta data of a command.
+    */
+    public convenience init(traitActions: [[String : [String : Any]]],
+                            title: String? = nil,
+                            commandDescription: String? = nil,
+                            metadata: Dictionary<String, Any>? = nil)
+    {
+        self.init(actions: traitActions,
+                  useTrait: true,
+                  title: title,
+                  commandDescription: commandDescription,
+                  metadata: metadata)
     }
 
     open func encode(with aCoder: NSCoder) {

--- a/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
@@ -51,12 +51,12 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     open let useTrait: Bool
 
     // MARK: - Initializing TriggeredCommandForm instance.
-    init(actions: [[String : Any]],
-         useTrait: Bool,
-         targetID: TypedID? = nil,
-         title: String? = nil,
-         commandDescription: String? = nil,
-         metadata: Dictionary<String, Any>? = nil)
+    private init(actions: [[String : Any]],
+                 useTrait: Bool,
+                 targetID: TypedID? = nil,
+                 title: String? = nil,
+                 commandDescription: String? = nil,
+                 metadata: Dictionary<String, Any>? = nil)
     {
         self.actions = actions
         self.targetID = targetID

--- a/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
@@ -47,32 +47,73 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     /// Meta data of ad command.
     open let metadata: Dictionary<String, Any>?
 
+    /// Use trait or not.
+    open let useTrait: Bool
 
     // MARK: - Initializing TriggeredCommandForm instance.
-    /**
-    Initializer of TriggeredCommandForm instance.
+    init(actions: [[String : Any]],
+         useTrait: Bool,
+         targetID: TypedID? = nil,
+         title: String? = nil,
+         commandDescription: String? = nil,
+         metadata: Dictionary<String, Any>? = nil)
+    {
+        self.actions = actions
+        self.targetID = targetID
+        self.useTrait = useTrait
+        self.title = title;
+        self.commandDescription = commandDescription;
+        self.metadata = metadata;
+    }
 
-    - Parameter actions: Array of actions. Must not be empty. Both of
-      non trait action array and trait action array are acceptable but
-      non trait action and trait action must not be mixed in a array.
-    - Parameter targetID: target thing ID.
+    /**
+    Initializer of TriggeredCommandForm instance for non trait.
+
+    - Parameter actions: Array of actions. Must not be empty. The
+      contente of this array must be non trait actions.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.
     - Parameter description: Description of a comand. This should be
       equal or less than 200 characters.
     - Parameter metadata: Meta data of a command.
     */
-    public init(actions: [[String : Any]],
-                targetID: TypedID? = nil,
-                title: String? = nil,
-                commandDescription: String? = nil,
-                metadata: Dictionary<String, Any>? = nil)
+    public convenience init(actions: [[String : Any]],
+                            targetID: TypedID? = nil,
+                            title: String? = nil,
+                            commandDescription: String? = nil,
+                            metadata: Dictionary<String, Any>? = nil)
     {
-        self.actions = actions
-        self.targetID = targetID
-        self.title = title
-        self.commandDescription = commandDescription
-        self.metadata = metadata
+        self.init(actions: actions,
+                  useTrait: false,
+                  targetID: targetID,
+                  title: title,
+                  commandDescription: commandDescription,
+                  metadata: metadata)
+    }
+
+    /**
+    Initializer of TriggeredCommandForm instance for trait.
+
+    - Parameter actions: Array of actions. Must not be empty. The
+      contente of this array must be trait actions.
+    - Parameter title: Title of a command. This should be equal or
+      less than 50 characters.
+    - Parameter description: Description of a comand. This should be
+      equal or less than 200 characters.
+    - Parameter metadata: Meta data of a command.
+    */
+    public convenience init(traitActions: [[String : [String : Any]]],
+                            targetID: TypedID? = nil,
+                            title: String? = nil,
+                            commandDescription: String? = nil,
+                            metadata: Dictionary<String, Any>? = nil)
+    {
+        self.init(actions: traitActions,
+                  useTrait: true,
+                  targetID: targetID,
+                  title: title,
+                  commandDescription: commandDescription,
+                  metadata: metadata)
     }
 
     /**

--- a/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
@@ -48,7 +48,7 @@ open class TriggeredCommandForm: NSObject, NSCoding {
     open let metadata: Dictionary<String, Any>?
 
     /// Use trait or not.
-    open let useTrait: Bool
+    internal let useTrait: Bool
 
     // MARK: - Initializing TriggeredCommandForm instance.
     private init(actions: [[String : Any]],


### PR DESCRIPTION
This is a part of trait adaptable API design. This PR does not buildable and testable because this PR only changes API and does not changes implementation and tests. The target branch is not develop and migrate-swift3.0 so feel free to merge this.

### Summary

- According to [thing-if JSSDK fix](https://github.com/KiiPlatform/thing-if-JSSDK/pull/155/commits/330900d5302d7ec99705d7c52bfc176bd565e1c4), initializers are added to `CommandForm` and `TriggeredCommandForm` to distinguish trait or not.

Related PR: #236 