### PR TITLE
APIs to update thing information are added.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -619,6 +619,13 @@ open class ThingIFAPI: NSObject, NSCoding {
         }
     }
 
+    // MARK: - Firmware version
+    /**
+     */
+    open func update(firmwareVersion: String) {
+        // TODO: implement me.
+    }
+
     // MARK: - Copy with new target instance
 
     /** Get new instance with new target

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -619,10 +619,36 @@ open class ThingIFAPI: NSObject, NSCoding {
         }
     }
 
-    // MARK: - Firmware version
-    /**
+    // MARK: - Update thing information.
+
+    /** Update firmware version of thing.
+
+     - Parameter firmwareVersion: new firmware version to be updated.
+     - Parameter completionHandler: A closure to be executed once when
+       this method is finished. The closure takes 1 argument: an
+       instance of ThingIFError is set when execution is
+       failed. Otherwise nil.
      */
-    open func update(firmwareVersion: String) {
+    open func update(
+        firmwareVersion: String,
+        completionHandler: @escaping(ThingIFError?) -> Void) -> Void
+    {
+        // TODO: implement me.
+    }
+
+    /** Update thingType of thing. This method must be used to make
+     thing start to use trait.
+
+     - Parameter thingType: Thing type must be alreday defined.
+     - Parameter completionHandler: A closure to be executed once when
+       this method is finished. The closure takes 1 argument: an
+       instance of ThingIFError is set when execution is
+       failed. Otherwise nil.
+     */
+    open func update(
+        thingType: String,
+        completionHandler: @escaping(ThingIFError?) -> Void) -> Void
+    {
         // TODO: implement me.
     }
 


### PR DESCRIPTION
This is a part of trait adaptable API design. This PR does not buildable and testable because this PR only changes API and does not changes implementation and tests. The target branch is not develop and migrate-swift3.0 so feel free to merge this.

### Summary

- A method to update firmware version is added to ThingIFAPI.
- A method to update thing type is added to ThingIFAPI.

Related PR: #236 