### PR TITLE
APIs to retrieve thing information are added.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -619,7 +619,7 @@ open class ThingIFAPI: NSObject, NSCoding {
         }
     }
 
-    // MARK: - Update thing information.
+    // MARK: - Thing information.
 
     /** Update firmware version of thing.
 
@@ -648,6 +648,36 @@ open class ThingIFAPI: NSObject, NSCoding {
     open func update(
         thingType: String,
         completionHandler: @escaping(ThingIFError?) -> Void) -> Void
+    {
+        // TODO: implement me.
+    }
+
+    /** Retrieve firmwareVersion version of thing.
+
+     - Parameter completionHandler: A closure to be executed once when
+       this method is finished. The closure takes 2 arguments: First
+       argument is firmeware version. An instance of String is set
+       when execution success. Otherwise nil. Second argument is error
+       reason. An instance of ThingIFError is set when execution is
+       failed. Otherwise nil
+     */
+    open func retrieveFirmwareVersion(
+        completionHandler: @escaping(String?, ThingIFError?) -> Void) -> Void
+    {
+        // TODO: implement me.
+    }
+
+    /** Retrieve thing type of thing.
+
+     - Parameter completionHandler: A closure to be executed once when
+       this method is finished. The closure takes 2 arguments: First
+       argument is thinig type. An instance of String is set when
+       execution success. Otherwise nil. Second argument is error
+       reason. An instance of ThingIFError is set when execution is
+       failed. Otherwise nil
+     */
+    open func retrieveThingType(
+        completionHandler: @escaping(String?, ThingIFError?) -> Void) -> Void
     {
         // TODO: implement me.
     }


### PR DESCRIPTION
This is a part of trait adaptable API design. This PR does not buildable and testable because this PR only changes API and does not changes implementation and tests. The target branch is not develop and migrate-swift3.0 so feel free to merge this.

### Summary

- A method to retrieve firmware version is added to ThingIFAPI.
- A method to retrieve thing type is added to ThingIFAPI.

These methods are not defined in thing-if AndroidSDK, but, I think these methods are useful for users. What do you think?

Related PR: #236 