### PR TITLE
postNewCommand and TraitCommandForm are defined.

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		B61FEC611DF80E860090DF6B /* TraitThingIFAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61FEC601DF80E860090DF6B /* TraitThingIFAPI.swift */; };
 		B61FEC631DF80F2C0090DF6B /* TraitThingIFAPIBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61FEC621DF80F2C0090DF6B /* TraitThingIFAPIBuilder.swift */; };
 		B61FEC651DF941A40090DF6B /* TraitCommandForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61FEC641DF941A40090DF6B /* TraitCommandForm.swift */; };
+		B61FEC751DFA84E90090DF6B /* TraitCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61FEC741DFA84E90090DF6B /* TraitCommand.swift */; };
 		B6323D291DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */; };
 		B6323D2B1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */; };
 		B6323D2D1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D2C1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift */; };
@@ -270,6 +271,7 @@
 		B61FEC601DF80E860090DF6B /* TraitThingIFAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TraitThingIFAPI.swift; path = Trait/TraitThingIFAPI.swift; sourceTree = "<group>"; };
 		B61FEC621DF80F2C0090DF6B /* TraitThingIFAPIBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TraitThingIFAPIBuilder.swift; path = Trait/TraitThingIFAPIBuilder.swift; sourceTree = "<group>"; };
 		B61FEC641DF941A40090DF6B /* TraitCommandForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TraitCommandForm.swift; path = Trait/TraitCommandForm.swift; sourceTree = "<group>"; };
+		B61FEC741DFA84E90090DF6B /* TraitCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TraitCommand.swift; path = Trait/TraitCommand.swift; sourceTree = "<group>"; };
 		B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
 		B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewServerCodeTriggerWithTriggerOptionsTests.swift; sourceTree = "<group>"; };
 		B6323D2C1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchServerCodeTriggerWIthTriggerOptionsTests.swift; sourceTree = "<group>"; };
@@ -517,6 +519,7 @@
 			isa = PBXGroup;
 			children = (
 				B61FEC641DF941A40090DF6B /* TraitCommandForm.swift */,
+				B61FEC741DFA84E90090DF6B /* TraitCommand.swift */,
 				B61FEC601DF80E860090DF6B /* TraitThingIFAPI.swift */,
 				B61FEC621DF80F2C0090DF6B /* TraitThingIFAPIBuilder.swift */,
 			);
@@ -739,6 +742,7 @@
 				7D36B6701BD4D03100D9B821 /* NetworkObserver.swift in Sources */,
 				226EA0CD1CD0CCFD002C1821 /* PendingEndNode.swift in Sources */,
 				7D36B6BF1BD4D43700D9B821 /* ThingIFAPI+Trigger.swift in Sources */,
+				B61FEC751DFA84E90090DF6B /* TraitCommand.swift in Sources */,
 				22E486341CC4E1C000269A1E /* GatewayAPI.swift in Sources */,
 				7D36B6BE1BD4D43700D9B821 /* ThingIFAPI+Push.swift in Sources */,
 				7D36B6851BD4D03100D9B821 /* URLSessionTaskOperation.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		B60BBBD21DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */; };
 		B61FEC611DF80E860090DF6B /* TraitThingIFAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61FEC601DF80E860090DF6B /* TraitThingIFAPI.swift */; };
 		B61FEC631DF80F2C0090DF6B /* TraitThingIFAPIBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61FEC621DF80F2C0090DF6B /* TraitThingIFAPIBuilder.swift */; };
+		B61FEC651DF941A40090DF6B /* TraitCommandForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61FEC641DF941A40090DF6B /* TraitCommandForm.swift */; };
 		B6323D291DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */; };
 		B6323D2B1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */; };
 		B6323D2D1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D2C1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift */; };
@@ -268,6 +269,7 @@
 		B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
 		B61FEC601DF80E860090DF6B /* TraitThingIFAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TraitThingIFAPI.swift; path = Trait/TraitThingIFAPI.swift; sourceTree = "<group>"; };
 		B61FEC621DF80F2C0090DF6B /* TraitThingIFAPIBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TraitThingIFAPIBuilder.swift; path = Trait/TraitThingIFAPIBuilder.swift; sourceTree = "<group>"; };
+		B61FEC641DF941A40090DF6B /* TraitCommandForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TraitCommandForm.swift; path = Trait/TraitCommandForm.swift; sourceTree = "<group>"; };
 		B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
 		B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewServerCodeTriggerWithTriggerOptionsTests.swift; sourceTree = "<group>"; };
 		B6323D2C1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchServerCodeTriggerWIthTriggerOptionsTests.swift; sourceTree = "<group>"; };
@@ -514,6 +516,7 @@
 		B61FEC5F1DF80E660090DF6B /* Trait */ = {
 			isa = PBXGroup;
 			children = (
+				B61FEC641DF941A40090DF6B /* TraitCommandForm.swift */,
 				B61FEC601DF80E860090DF6B /* TraitThingIFAPI.swift */,
 				B61FEC621DF80F2C0090DF6B /* TraitThingIFAPIBuilder.swift */,
 			);
@@ -724,6 +727,7 @@
 				7D36B6C01BD4D43700D9B821 /* ThingIFAPIBuilder.swift in Sources */,
 				B6AC4A1A1D991CE1001A80DE /* TriggeredCommandForm.swift in Sources */,
 				7D36B6BC1BD4D43700D9B821 /* ThingIFAPI+GetState.swift in Sources */,
+				B61FEC651DF941A40090DF6B /* TraitCommandForm.swift in Sources */,
 				B61FEC611DF80E860090DF6B /* TraitThingIFAPI.swift in Sources */,
 				7D36B6BD1BD4D43700D9B821 /* ThingIFAPI+OnBoard.swift in Sources */,
 				226402201CD1E96300E30967 /* Gateway.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/Trait/TraitCommand.swift
+++ b/ThingIFSDK/ThingIFSDK/Trait/TraitCommand.swift
@@ -1,0 +1,132 @@
+//
+//  File.swift
+//  ThingIFSDK
+//
+//  Created on 2016/12/09.
+//  Copyright (c) 2016 Kii. All rights reserved.
+//
+
+import Foundation
+
+/** Class represents TraitCommand */
+open class TraitCommand: NSObject, NSCoding {
+
+    // MARK: - Implements NSCoding protocol
+    open func encode(with aCoder: NSCoder) {
+        aCoder.encode(self.commandID, forKey: "commandID")
+        aCoder.encode(self.targetID, forKey: "targetID")
+        aCoder.encode(self.issuerID, forKey: "issuerID")
+        aCoder.encode(self.actions, forKey: "actions")
+        aCoder.encode(self.actionResults, forKey: "actionResults")
+        aCoder.encode(self.commandState.rawValue, forKey: "commandState")
+        aCoder.encode(self.firedByTriggerID, forKey: "firedByTriggerID")
+        if let date = self.created {
+            aCoder.encode(date.timeIntervalSince1970, forKey: "created")
+        }
+        if let date = self.modified {
+            aCoder.encode(date.timeIntervalSince1970, forKey: "modified")
+        }
+        aCoder.encode(self.title, forKey: "title")
+        aCoder.encode(self.commandDescription, forKey: "commandDescription")
+        aCoder.encode(self.metadata, forKey: "metadata")
+    }
+
+    public required init(coder aDecoder: NSCoder) {
+        self.commandID = aDecoder.decodeObject(forKey: "commandID") as! String
+        self.targetID = aDecoder.decodeObject(forKey: "targetID") as! TypedID
+        self.issuerID = aDecoder.decodeObject(forKey: "issuerID") as! TypedID
+        self.actions = aDecoder.decodeObject(forKey: "actions")
+                as! [[String : [String : Any]]];
+        self.actionResults = aDecoder.decodeObject(forKey: "actionResults")
+                as! [[String : [String : Any]]];
+        self.commandState = CommandState(
+          rawValue: aDecoder.decodeInteger(forKey: "commandState"))!;
+        self.firedByTriggerID =
+          aDecoder.decodeObject(forKey: "firedByTriggerID") as? String
+
+        var created: Date? = nil
+        if aDecoder.containsValue(forKey: "created") {
+            created = Date(
+              timeIntervalSince1970: aDecoder.decodeDouble(forKey: "created"))
+        }
+        self.created = created
+
+        var modified: Date? = nil
+        if aDecoder.containsValue(forKey: "modified") {
+            modified = Date(
+              timeIntervalSince1970: aDecoder.decodeDouble(forKey: "modified"))
+        }
+        self.modified = modified
+
+        self.title = aDecoder.decodeObject(forKey: "title") as? String
+        self.commandDescription =
+          aDecoder.decodeObject(forKey: "commandDescription") as? String
+        self.metadata =
+          aDecoder.decodeObject(forKey: "metadata") as? [String : Any]
+    }
+
+    // MARK: Properties
+
+    /** ID of the Command. */
+    open let commandID: String
+    /** ID of the Command Target. */
+    open let targetID: TypedID
+    /** ID of the issuer of the Command. */
+    open let issuerID: TypedID
+    /** Actions to be executed. */
+    open let actions: [[String : [String : Any]]]
+    /** Results of the action. */
+    open let actionResults: [[String : [String : Any]]]
+    /** State of the Command. */
+    open let commandState: CommandState
+    /** ID of the trigger which fired this command */
+    open let firedByTriggerID: String?
+    /** Creation time of the Command.*/
+    open let created: Date?
+    /** Modification time of the Command. */
+    open let modified: Date?
+    /** Title of the Command */
+    open let title: String?
+    /** Description of the Command */
+    open let commandDescription: String?
+    /** Metadata of the Command */
+    open let metadata: [String : Any]?
+
+    internal init(commandID: String,
+         targetID: TypedID,
+         issuerID: TypedID,
+         actions:[[String : [String : Any]]],
+         actionResults:[[String : [String : Any]]]?,
+         commandState: CommandState,
+         firedByTriggerID: String? = nil,
+         created: Date? = nil,
+         modified: Date? = nil,
+         title: String? = nil,
+         commandDescription: String? = nil,
+         metadata: [String : Any]? = nil)
+    {
+        self.commandID = commandID
+        self.targetID = targetID
+        self.issuerID = issuerID
+        self.actions = actions
+        self.actionResults = actionResults ?? []
+        self.commandState = commandState
+        self.firedByTriggerID = firedByTriggerID
+        self.created = created
+        self.modified = modified
+        self.title = title
+        self.commandDescription = commandDescription
+        self.metadata = metadata
+    }
+
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let aCommand = object as? TraitCommand else{
+            return false
+        }
+
+        return self.commandID == aCommand.commandID &&
+            self.targetID == aCommand.targetID &&
+            self.issuerID == aCommand.issuerID
+    }
+
+}

--- a/ThingIFSDK/ThingIFSDK/Trait/TraitCommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/Trait/TraitCommandForm.swift
@@ -1,0 +1,83 @@
+//
+//  TraitCommandForm.swift
+//  ThingIFSDK
+//
+//  Created on 2016/12/08.
+//  Copyright (c) 2016 Kii. All rights reserved.
+//
+
+import Foundation
+
+/**
+Form of a command for trait version thing.
+
+This class contains data in order to create `Command` with
+`TraitThingIFAPI.postNewCommand(_:completionHandler:)`.
+
+Mandatory data are followings:
+
+  - List of actions
+
+Optional data are followings:
+
+  - Title of a command
+  - Description of a command
+  - Meta data of a command
+*/
+open class TraitCommandForm: NSObject, NSCoding {
+
+    // MARK: - Properties
+
+    /// List of actions.
+    open let actions: [[String : [String : Any]]]
+
+    /// Title of a command.
+    open let title: String?
+
+    /// Description of a command.
+    open let commandDescription: String?
+
+    /// Meta data of ad command.
+    open let metadata: [String : Any]?
+
+
+    // MARK: - Initializing TraitCommandForm instance.
+    /**
+     Initializer of TraitCommandForm instance.
+
+     - Parameter actions: List of actions. Must not be empty.
+     - Parameter title: Title of a command. This should be equal or
+       less than 50 characters.
+     - Parameter description: Description of a comand. This should be
+       equal or less than 200 characters.
+     - Parameter metadata: Meta data of a command.
+    */
+    public init(actions: [[String : [String : Any]]],
+                title: String? = nil,
+                commandDescription: String? = nil,
+                metadata: [String : Any]? = nil)
+    {
+        self.actions = actions
+        self.title = title;
+        self.commandDescription = commandDescription;
+        self.metadata = metadata;
+    }
+
+    open func encode(with aCoder: NSCoder) {
+        aCoder.encode(self.actions, forKey: "actions")
+        aCoder.encode(self.title, forKey: "title")
+        aCoder.encode(self.commandDescription,
+                forKey: "commandDescription");
+        aCoder.encode(self.metadata, forKey: "metadata")
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        self.actions = aDecoder.decodeObject(forKey: "actions")
+          as! [[String : [String : Any]]];
+        self.title = aDecoder.decodeObject(forKey: "title") as? String
+        self.commandDescription =
+            aDecoder.decodeObject(forKey: "commandDescription") as? String;
+        self.metadata = aDecoder.decodeObject(forKey: "metadata")
+          as? [String : Any];
+    }
+}

--- a/ThingIFSDK/ThingIFSDK/Trait/TraitThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Trait/TraitThingIFAPI.swift
@@ -183,6 +183,30 @@ open class TraitThingIFAPI: NSObject, NSCoding {
                                       completionHandler: completionHandler)
     }
 
+    // MARK: - Command methods
+
+    /** Post new command to IoT Cloud.
+
+     Command will be delivered to specified target and result will be
+     notified through push notification.
+
+     **Note**: Please onboard first, or provide a target instance by
+     calling copyWithTarget. Otherwise,
+     KiiCloudError.TARGET_NOT_AVAILABLE will be return in
+     completionHandler callback
+
+     - Parameter commandForm: Command form of posting command.
+     - Parameter completionHandler: A closure to be executed once
+       finished. The closure takes 2 arguments: an instance of created
+       command, an instance of ThingIFError when failed.
+    */
+    open func postNewCommand(
+        _ commandForm: TraitCommandForm,
+        completionHandler: @escaping (Command?, ThingIFError?) -> Void) -> Void
+    {
+        // TODO: implement me.
+    }
+
     // MARK: - Trigger methods
 
     /** Enable/Disable a registered Trigger


### PR DESCRIPTION
This PR will be merged to topic branch not develop and migrate-swift3.0 so feel free to merge this.

### Summary

`TraitThingIFAPI.postNewCommand(commandForm:completionHandler:)` and `TraitCommandForm` are defined.

`CommandForm` can be used for `TraitThingIFAPI.postNewCommand(commandForm:completionHandler:)` but it may cause to confuse application programmers. So I added `TraitCommandForm`.

Related PR: #245 