### PR TITLE
I change CommandForm and add Actions.

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		A56B0A471C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B0A461C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift */; };
 		A56B0A491C62143000E653EF /* PatchServerCodeTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B0A481C62143000E653EF /* PatchServerCodeTriggerTests.swift */; };
 		B60BBBD21DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */; };
+		B62EBCEB1E012795008338DE /* Alias.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62EBCEA1E012795008338DE /* Alias.swift */; };
 		B6323D291DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */; };
 		B6323D2B1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */; };
 		B6323D2D1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6323D2C1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift */; };
@@ -264,6 +265,7 @@
 		A56B0A461C61EA7A00E653EF /* PostNewServerCodeTriggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewServerCodeTriggerTests.swift; sourceTree = "<group>"; };
 		A56B0A481C62143000E653EF /* PatchServerCodeTriggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchServerCodeTriggerTests.swift; sourceTree = "<group>"; };
 		B60BBBD11DA5024D004B4AFB /* PostNewTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
+		B62EBCEA1E012795008338DE /* Alias.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alias.swift; sourceTree = "<group>"; };
 		B6323D281DA6271B0012D6A1 /* PatchTriggerWithTriggeredCommandFormTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchTriggerWithTriggeredCommandFormTests.swift; sourceTree = "<group>"; };
 		B6323D2A1DA7572E0012D6A1 /* PostNewServerCodeTriggerWithTriggerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewServerCodeTriggerWithTriggerOptionsTests.swift; sourceTree = "<group>"; };
 		B6323D2C1DA78BC70012D6A1 /* PatchServerCodeTriggerWIthTriggerOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatchServerCodeTriggerWIthTriggerOptionsTests.swift; sourceTree = "<group>"; };
@@ -392,6 +394,7 @@
 				229039D91D473FFB00B9D0B7 /* OnboardEndnodeWithGatewayOptions.swift */,
 				B6AC4A191D991CE1001A80DE /* TriggeredCommandForm.swift */,
 				B6AC4A1B1D991DF2001A80DE /* TriggerOptions.swift */,
+				B62EBCEA1E012795008338DE /* Alias.swift */,
 			);
 			path = ThingIFSDK;
 			sourceTree = "<group>";
@@ -680,6 +683,7 @@
 				7D36B6721BD4D03100D9B821 /* BlockObserver.swift in Sources */,
 				7D36B67C1BD4D03100D9B821 /* NSLock+Operations.swift in Sources */,
 				7D36B6731BD4D03100D9B821 /* BlockOperation.swift in Sources */,
+				B62EBCEB1E012795008338DE /* Alias.swift in Sources */,
 				B6F9F2BD1CB22A4C009A990F /* CommandForm.swift in Sources */,
 				225E43381CC5FF55003A3C4B /* GatewayInformation.swift in Sources */,
 				226EA0CF1CD0D1A9002C1821 /* Target.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/Alias.swift
+++ b/ThingIFSDK/ThingIFSDK/Alias.swift
@@ -1,0 +1,61 @@
+//
+//  Alias.swift
+//  ThingIFSDK
+//
+//  Created on 2016/12/14.
+//  Copyright (c) 2016 Kii. All rights reserved.
+//
+
+import Foundation
+
+/**
+ A protocol representing alias.
+ */
+public protocol Alias: NSCoding {
+
+}
+
+/**
+ A class representing trait alias.
+ */
+open class TraitAlias: NSObject, Alias {
+
+    /**
+     Name of trait alias.
+     */
+    open let name: String
+
+    /**
+     Initializer for `TraitAlias`.
+
+     - Parameter name: Name of trait alias.
+     */
+    public init(_ name: String) {
+        self.name = name
+    }
+
+    public required convenience init(coder aDecoder: NSCoder) {
+        self.init(aDecoder.decodeObject() as! String)
+    }
+
+    open func encode(with aCoder: NSCoder) {
+        aCoder.encode(self.name)
+    }
+}
+
+/**
+ A class representing no trait alias.
+
+ There is no alias for non trait actions. If you want to non trait
+ version of thing if SDK, You need to use `NonTraitAlias` instead of
+ `TraitAlias`.
+ */
+open class NonTraitAlias: NSObject, Alias {
+
+    public required convenience init(coder aDecoder: NSCoder) {
+        self.init()
+    }
+
+    open func encode(with aCoder: NSCoder) {
+    }
+}

--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -16,28 +16,20 @@ This class contains data in order to create `Command` with
 
 Mandatory data are followings:
 
-  - Schema name
-  - Schema version
-  - List of actions
+  - Array of actions
 
 Optional data are followings:
 
-  - Title of a schema
-  - Description of a schema
-  - Meta data of a schema
+  - Title of a command
+  - Description of a command
+  - Meta data of a command
 */
 open class CommandForm: NSObject, NSCoding {
 
     // MARK: - Properties
 
-    /// Schema name.
-    open let schemaName: String
-
-    /// Schema version.
-    open let schemaVersion: Int
-
-    /// List of actions.
-    open let actions: [Dictionary<String, Any>]
+    /// Array of actions.
+    open let actions: [(alias: Alias, actions: [String : Any])]
 
     /// Title of a command.
     open let title: String?
@@ -46,31 +38,25 @@ open class CommandForm: NSObject, NSCoding {
     open let commandDescription: String?
 
     /// Meta data of ad command.
-    open let metadata: Dictionary<String, Any>?
+    open let metadata: [String : Any]?
 
 
     // MARK: - Initializing CommandForm instance.
     /**
     Initializer of CommandForm instance.
 
-    - Parameter schemaName: Schema name.
-    - Parameter schemaVersion: Schema version.
-    - Parameter actions: List of actions. Must not be empty.
+    - Parameter actions: Array of actions. Must not be empty.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.
     - Parameter description: Description of a comand. This should be
       equal or less than 200 characters.
     - Parameter metadata: Meta data of a command.
     */
-    public init(schemaName: String,
-                schemaVersion: Int,
-                actions: [Dictionary<String, Any>],
+    public init(actions: [(alias: Alias, actions: [String : Any])],
                 title: String? = nil,
                 commandDescription: String? = nil,
-                metadata: Dictionary<String, Any>? = nil)
+                metadata: [String : Any]? = nil)
     {
-        self.schemaName = schemaName
-        self.schemaVersion = schemaVersion
         self.actions = actions
         self.title = title;
         self.commandDescription = commandDescription;
@@ -78,8 +64,6 @@ open class CommandForm: NSObject, NSCoding {
     }
 
     open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.schemaName, forKey: "schemaName")
-        aCoder.encode(self.schemaVersion, forKey: "schemaVersion")
         aCoder.encode(self.actions, forKey: "actions")
         aCoder.encode(self.title, forKey: "title")
         aCoder.encode(self.commandDescription,
@@ -88,14 +72,12 @@ open class CommandForm: NSObject, NSCoding {
     }
 
     public required init?(coder aDecoder: NSCoder) {
-        self.schemaName = aDecoder.decodeObject(forKey: "schemaName") as! String
-        self.schemaVersion = aDecoder.decodeInteger(forKey: "schemaVersion")
         self.actions = aDecoder.decodeObject(forKey: "actions")
-                as! [Dictionary<String, Any>];
+          as! [(alias: Alias, actions: [String : Any])];
         self.title = aDecoder.decodeObject(forKey: "title") as? String
         self.commandDescription =
             aDecoder.decodeObject(forKey: "commandDescription") as? String;
         self.metadata = aDecoder.decodeObject(forKey: "metadata")
-                as? Dictionary<String, Any>;
+          as? [String :  Any];
     }
 }


### PR DESCRIPTION
***This PR is not buildable but this PR is not merged to develop. Please feel free to merge this.***

We distribute SDK as one framework. We recommend trait. We supply non trait version but we do not recommend it.

In this PR, I fixed `CommandForm` to adapt trait version. I added following a protocol and classes:

* `Alias`
* `TraitAalis`
* `NonTraitAlias`

I replaced type of `CommandForm.actions` from `Dictionary<String, Any>` to `[(alias: Alias, actions: [String : Any])]`

Related PR: #252