### PR TITLE
 I added methods according to Additional thing operations.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -662,7 +662,7 @@ open class ThingIFAPI<ConcreteAlias: Alias>: NSObject, NSCoding {
 
      - Parameter firmwareVersion: firmwareVersion to be updated.
      - Parameter completionHandler: A closure to be executed once on
-       checking has finished The closure takes 1 argument. The
+       updating has finished The closure takes 1 argument. The
        argument is ThingIFError.
      */
     open func update(
@@ -677,7 +677,7 @@ open class ThingIFAPI<ConcreteAlias: Alias>: NSObject, NSCoding {
      This method gets firmware version for `target` thing.
 
      - Parameter completionHandler: A closure to be executed once on
-       checking has finished The closure takes 2 arguments. First one
+       getting has finished The closure takes 2 arguments. First one
        is firmware version. Second one is ThingIFError.
      */
     open func getFirmewareVerson(
@@ -692,7 +692,7 @@ open class ThingIFAPI<ConcreteAlias: Alias>: NSObject, NSCoding {
 
      - Parameter thingType: thing type to be updated.
      - Parameter completionHandler: A closure to be executed once on
-       checking has finished The closure takes 1 argument. The
+       updating has finished The closure takes 1 argument. The
        argument is ThingIFError.
      */
     open func update(
@@ -707,7 +707,7 @@ open class ThingIFAPI<ConcreteAlias: Alias>: NSObject, NSCoding {
      This method gets thing type for `target` thing.
 
      - Parameter completionHandler: A closure to be executed once on
-       checking has finished The closure takes 2 arguments. First one
+       getting has finished The closure takes 2 arguments. First one
        is thing type. Second one is ThingIFError.
      */
     open func getThingType(

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -584,7 +584,7 @@ open class ThingIFAPI<ConcreteAlias: Alias>: NSObject, NSCoding {
      - Parameter completionHandler: A closure to be executed once finished. The closure takes 1 argument: an instance of ThingIFError when failed.
      */
     open func update(
-        _ vendorThingID: String,
+        vendorThingID: String,
         password: String,
         completionHandler: @escaping (ThingIFError?)-> Void
         )
@@ -642,9 +642,9 @@ open class ThingIFAPI<ConcreteAlias: Alias>: NSObject, NSCoding {
 
      - Parameter thingType: thing type to check firmware version.
      - Parameter firmwareVersion: firmwareVersion to be checked.
-     - completionHandler: A closure to be executed once on checking
-       has finished The closure takes 2 argument. First one is
-       existence of firmware version. If true, firmware version for
+     - Parameter completionHandler: A closure to be executed once on
+       checking has finished The closure takes 2 arguments. First one
+       is existence of firmware version. If true, firmware version for
        the thing type exists. If false, not exist. Second one is
        ThingIFError.
      */
@@ -652,6 +652,66 @@ open class ThingIFAPI<ConcreteAlias: Alias>: NSObject, NSCoding {
       _ thingType: String,
       _ firmwareVersion: String,
       _ completionHandler: @escaping (Bool?, ThingIFError?) -> Void) -> Void
+    {
+        // TODO: implement me.
+    }
+
+    /** Update firmware version.
+
+     This method updates firmware version for `target` thing.
+
+     - Parameter firmwareVersion: firmwareVersion to be updated.
+     - Parameter completionHandler: A closure to be executed once on
+       checking has finished The closure takes 1 argument. The
+       argument is ThingIFError.
+     */
+    open func update(
+      firmwareVersion: String,
+      completionHandler: @escaping (ThingIFError?)-> Void) -> Void
+    {
+        // TODO: implement me.
+    }
+
+    /** Get firmeware version.
+
+     This method gets firmware version for `target` thing.
+
+     - Parameter completionHandler: A closure to be executed once on
+       checking has finished The closure takes 2 arguments. First one
+       is firmware version. Second one is ThingIFError.
+     */
+    open func getFirmewareVerson(
+      completionHandler: @escaping (String?, ThingIFError?) -> Void) -> Void
+    {
+        // TODO: implement me.
+    }
+
+    /** Update thing type.
+
+     This method updates thing type for `target` thing.
+
+     - Parameter firmwareVersion: firmwareVersion to be updated.
+     - Parameter completionHandler: A closure to be executed once on
+       checking has finished The closure takes 1 argument. The
+       argument is ThingIFError.
+     */
+    open func update(
+      thingType: String,
+      completionHandler: @escaping (ThingIFError?)-> Void) -> Void
+    {
+        // TODO: implement me.
+    }
+
+    /** Get firmeware version.
+
+     This method gets thing type for `target` thing.
+
+     - Parameter completionHandler: A closure to be executed once on
+       checking has finished The closure takes 2 arguments. First one
+       is thing type. Second one is ThingIFError.
+     */
+    open func getThingType(
+      completionHandler: @escaping (String?, ThingIFError?) -> Void) -> Void
     {
         // TODO: implement me.
     }

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -690,7 +690,7 @@ open class ThingIFAPI<ConcreteAlias: Alias>: NSObject, NSCoding {
 
      This method updates thing type for `target` thing.
 
-     - Parameter firmwareVersion: firmwareVersion to be updated.
+     - Parameter thingType: thing type to be updated.
      - Parameter completionHandler: A closure to be executed once on
        checking has finished The closure takes 1 argument. The
        argument is ThingIFError.
@@ -702,7 +702,7 @@ open class ThingIFAPI<ConcreteAlias: Alias>: NSObject, NSCoding {
         // TODO: implement me.
     }
 
-    /** Get firmeware version.
+    /** Get thing type.
 
      This method gets thing type for `target` thing.
 


### PR DESCRIPTION
***This PR is not buildable but this PR is not merged to develop. Please feel free to merge this.***

I added additional thing operations APIs according to [this document](https://docs.google.com/document/edit?hgd=1&id=1iYlAhVKxKN1Xu__DbU1TKs7VxO5Hbcs3vg84KsvndFs#heading=h.capyo148fbqq).


I made a list to check REST API which are required in SDK or not. The document is [here](https://docs.google.com/spreadsheets/d/1Psj-ZACXGzOw9aNMIOnBFOM-Jx9OR_oChA8YdebYnas/edit#gid=555858335).

In additional thing operation, there are 8 REST APIs. but I designed 4 APIs. Because 4 REST APIs are additional thing operation with ***thing ID***. Other 4 APIs are additional thing operation with ***vendor thing ID***. In SDK, `ThingIFAPI` has thing ID and vendor thing ID. So developer does not need to specify it.

Related PR: #252, #264