### PR TITLE
I fixed some computed properties.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+OnBoard.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+OnBoard.swift
@@ -94,7 +94,7 @@ extension ThingIFAPI {
                                     accessToken: accessToken)
                         }
 
-                        self._target = target
+                        self.target = target
                     }
                     self.saveToUserDefault()
                     DispatchQueue.main.async {

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
@@ -35,11 +35,11 @@ extension ThingIFAPI {
             let request = buildDefaultRequest(.POST,urlString: requestURL, requestHeaderDict: requestHeaderDict, requestBodyData: requestBodyData, completionHandler: { (response, error) -> Void in
                 
                 if let installationID = response?["installationID"] as? String{
-                    self._installationID = installationID
+                    self.installationID = installationID
                 }
                 self.saveToUserDefault()
                 DispatchQueue.main.async {
-                    completionHandler(self._installationID, error)
+                    completionHandler(self.installationID, error)
                 }
             })
             let operation = IoTRequestOperation(request: request)
@@ -59,7 +59,7 @@ extension ThingIFAPI {
         completionHandler: @escaping (ThingIFError?)-> Void
         )
     {
-        let idParam = installationID != nil ? installationID : self._installationID
+        let idParam = installationID != nil ? installationID : self.installationID
         let requestURL = "\(baseURL)/api/apps/\(appID)/installations/\(idParam!)"
         
         // generate header
@@ -68,7 +68,7 @@ extension ThingIFAPI {
         let request = buildDefaultRequest(.DELETE,urlString: requestURL, requestHeaderDict: requestHeaderDict, requestBodyData: nil, completionHandler: { (response, error) -> Void in
             
             if error == nil{
-                self._installationID = nil
+                self.installationID = nil
             }
             self.saveToUserDefault()
             DispatchQueue.main.async {

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -33,26 +33,15 @@ open class ThingIFAPI: NSObject, NSCoding {
     /** owner of target */
     open let owner: Owner
 
-    var _installationID:String?
-    var _target: Target?
-
     /** Get installationID if the push is already installed.
     null will be returned if the push installation has not been done.
 
     - Returns: Installation ID used in IoT Cloud.
     */
-    open var installationID: String? {
-        get {
-            return _installationID
-        }
-    }
+    open internal(set) var installationID: String?
 
     /** target */
-    open var target: Target? {
-        get {
-            return _target
-        }
-    }
+    open internal(set) var target: Target?
 
     // MARK: - Implements NSCoding protocol
     open func encode(with aCoder: NSCoder) {
@@ -61,8 +50,8 @@ open class ThingIFAPI: NSObject, NSCoding {
         aCoder.encode(self.appID, forKey: "appID")
         aCoder.encode(self.appKey, forKey: "appKey")
         aCoder.encode(self.owner, forKey: "owner")
-        aCoder.encode(self._installationID, forKey: "_installationID")
-        aCoder.encode(self._target, forKey: "_target")
+        aCoder.encode(self.installationID, forKey: "_installationID")
+        aCoder.encode(self.target, forKey: "_target")
         aCoder.encode(self.tag, forKey: "tag")
     }
 
@@ -72,8 +61,8 @@ open class ThingIFAPI: NSObject, NSCoding {
         self.appID = aDecoder.decodeObject(forKey: "appID") as! String
         self.appKey = aDecoder.decodeObject(forKey: "appKey") as! String
         self.owner = aDecoder.decodeObject(forKey: "owner") as! Owner
-        self._installationID = aDecoder.decodeObject(forKey: "_installationID") as? String
-        self._target = aDecoder.decodeObject(forKey: "_target") as? Target
+        self.installationID = aDecoder.decodeObject(forKey: "_installationID") as? String
+        self.target = aDecoder.decodeObject(forKey: "_target") as? Target
         self.tag = aDecoder.decodeObject(forKey: "tag") as? String
     }
 
@@ -631,8 +620,8 @@ open class ThingIFAPI: NSObject, NSCoding {
 
         let newIotapi = ThingIFAPI(app: self.app, owner: self.owner, tag: tag)
 
-        newIotapi._target = newTarget
-        newIotapi._installationID = self._installationID
+        newIotapi.target = newTarget
+        newIotapi.installationID = self.installationID
         newIotapi.saveToUserDefault()
         return newIotapi
     }

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPIBuilder.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPIBuilder.swift
@@ -31,7 +31,7 @@ open class ThingIFAPIBuilder {
      */
     open func make() -> ThingIFAPI {
         let thingIFAPI = ThingIFAPI(app: self.app, owner: self.owner, tag: self.tag)
-        thingIFAPI._target = self.target
+        thingIFAPI.target = self.target
         return thingIFAPI
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/DeleteTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/DeleteTriggerTests.swift
@@ -24,7 +24,7 @@ class DeleteTriggerTests: SmallTestBase {
         let expectation = self.expectation(description: "enableTriggerTests")
 
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
 
@@ -67,7 +67,7 @@ class DeleteTriggerTests: SmallTestBase {
         let expectation = self.expectation(description: "enableTrigger404Error")
 
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         do{
             let triggerID = "triggerID"

--- a/ThingIFSDK/ThingIFSDKTests/EnableTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/EnableTriggerTests.swift
@@ -26,7 +26,7 @@ class EnableTriggerTests: SmallTestBase {
         let expectation = self.expectation(description: "enableTriggerTests")
 
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         let expectedTriggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
 
@@ -135,7 +135,7 @@ class EnableTriggerTests: SmallTestBase {
             ((data: jsonData!, urlResponse: mockResponse2, error: nil),getRequestVerifier)
         ]
         
-        api._target = setting.target
+        api.target = setting.target
         api.enableTrigger(expectedTriggerID, enable: false) { (trigger, error) -> Void in
             if error == nil{
                 XCTAssertEqual(trigger!.triggerID, expectedTriggerID)
@@ -160,7 +160,7 @@ class EnableTriggerTests: SmallTestBase {
         let setting = TestSetting()
         let api = setting.api
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         do{
             let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"

--- a/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetCommandTest.swift
@@ -36,7 +36,7 @@ class GetCommandTests: SmallTestBase {
         let setting:TestSetting = TestSetting()
         let api = setting.api
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         let testcases = [
             TestCase(target: setting.target, schema: setting.schema, schemaVersion: setting.schemaVersion, actions: [["turnPower":["power": true]]], issuerIDString: "\(setting.owner.typedID.type):\(setting.owner.typedID.id)", targetIDString: "\(setting.target.typedID.type):\(setting.target.typedID.id)", actionResults: [["turnPower":["power": true]]], commandState: CommandState.incomplete, commandStateString: "INCOMPLETE", firedByTriggerID:"trigger-0001", created:Date(timeIntervalSince1970:1456377631.467), modified:Date(timeIntervalSince1970:1456377633.467)),
@@ -145,7 +145,7 @@ class GetCommandTests: SmallTestBase {
             let commandID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"
 
             // perform onboarding
-            api._target = setting.target
+            api.target = setting.target
 
             // mock response
             let responsedDict = ["errorCode" : "TARGET_NOT_FOUND",

--- a/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetStateTests.swift
@@ -73,7 +73,7 @@ class GetStateTests: SmallTestBase {
                 XCTFail("execution timeout")
             }
         }
-        setting.api._installationID = "dummyInstallationID"
+        setting.api.installationID = "dummyInstallationID"
     }
     func testGetStates_success() {
         let setting = TestSetting()
@@ -112,7 +112,7 @@ class GetStateTests: SmallTestBase {
             return;
         }
 
-        setting.api._target = setting.target
+        setting.api.target = setting.target
         setting.api.getState() { (result, error) -> Void in
 
             XCTAssertNotNil(result,"should not nil")
@@ -165,7 +165,7 @@ class GetStateTests: SmallTestBase {
             return;
         }
 
-        setting.api._target = setting.target
+        setting.api.target = setting.target
         setting.api.getState() { (result, error) -> Void in
             if error == nil{
                 XCTFail("should fail")
@@ -223,7 +223,7 @@ class GetStateTests: SmallTestBase {
             return;
         }
 
-        setting.api._target = setting.target
+        setting.api.target = setting.target
         setting.api.getState() { (result, error) -> Void in
             if error == nil{
                 XCTFail("should fail")
@@ -290,7 +290,7 @@ class GetStateTests: SmallTestBase {
             return;
         }
 
-        setting.api._target = setting.target
+        setting.api.target = setting.target
         setting.api.getState() { (result, error) -> Void in
 
             XCTAssertNotNil(result,"should not nil")

--- a/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetTriggerTests.swift
@@ -23,7 +23,7 @@ class GetTriggerTests: SmallTestBase {
         let api = setting.api
 
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         let simpleStatementsToTest = [
             ["type":"eq","field":"color", "value": 0],
@@ -56,7 +56,7 @@ class GetTriggerTests: SmallTestBase {
         let setting = TestSetting()
         let api = setting.api
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         let triggersWhensToTest = ["CONDITION_TRUE", "CONDITION_FALSE_TO_TRUE", "CONDITION_CHANGED"]
         for triggersWhen in triggersWhensToTest {
@@ -170,7 +170,7 @@ class GetTriggerTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
-            api._target = setting.target
+            api.target = setting.target
             api.getTrigger(expectedTriggerID, completionHandler: { (trigger, error) -> Void in
                 if(error != nil) {
                     XCTFail("should success")
@@ -208,7 +208,7 @@ class GetTriggerTests: SmallTestBase {
         let api = setting.api
 
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         do{
             let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"

--- a/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GetVendorThingIDTests.swift
@@ -28,7 +28,7 @@ class GetVendorThingIDTests: SmallTestBase {
         let target = setting.target
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         do {
             // verify request
@@ -85,7 +85,7 @@ class GetVendorThingIDTests: SmallTestBase {
         let target = setting.target
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in

--- a/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListCommandsTests.swift
@@ -64,7 +64,7 @@ class ListCommandsTests: SmallTestBase {
         let commandIDPrifex = "0267251d9d60-1858-5e11-3dc3-00f3f0b"
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         let testcases = [
             // test cases request without best effort and paginationKey
@@ -144,7 +144,7 @@ class ListCommandsTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
 
-            api._target = setting.target
+            api.target = setting.target
             api.listCommands(testcase.bestEffortLimit, paginationKey: testcase.paginationKey, completionHandler: { (commands, nextPaginationKey, error) -> Void in
                 if(error != nil) {
                     XCTFail("should success")
@@ -197,7 +197,7 @@ class ListCommandsTests: SmallTestBase {
         let owner = setting.owner
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         do{
             // mock response

--- a/ThingIFSDK/ThingIFSDKTests/ListTriggeredServerCodeResultsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListTriggeredServerCodeResultsTests.swift
@@ -60,7 +60,7 @@ class ListTriggeredServerCodeResultsTests: SmallTestBase {
                 ((data: resJson2, urlResponse: urlResponse2, error: nil), requestVerifier2)
             ]
 
-            api._target = setting.target
+            api.target = setting.target
             api.listTriggeredServerCodeResults(triggerID, bestEffortLimit: 0, paginationKey: nil) { (results, paginationKey, error) -> Void in
                 XCTAssertNil(error)
                 XCTAssertEqual(2, results!.count)

--- a/ThingIFSDK/ThingIFSDKTests/ListTriggersTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ListTriggersTests.swift
@@ -37,7 +37,7 @@ class ListTriggersTests: SmallTestBase {
         let triggerIDPrifex = "0267251d9d60-1858-5e11-3dc3-00f3f0b"
 
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         var expectedTriggerStructs: [ExpectedTriggerStruct] = [
             ExpectedTriggerStruct(statement: ["type":"eq","field":"color", "value": 0], triggerID: "\(triggerIDPrifex)1", triggersWhenString: "CONDITION_TRUE", enabled: true),
@@ -136,7 +136,7 @@ class ListTriggersTests: SmallTestBase {
         let api = setting.api
 
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         do{
             let triggerID = "0267251d9d60-1858-5e11-3dc3-00f3f0b5"

--- a/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardEndnodeWithGatewayTests.swift
@@ -33,7 +33,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         do {
             // verify request
@@ -128,7 +128,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
@@ -218,7 +218,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
@@ -308,7 +308,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
@@ -436,7 +436,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         let src: Dictionary<String, Any> = [
             "thingProperties": thingProperties
@@ -477,7 +477,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         let src = [
             "vendorThingID": "",
@@ -519,7 +519,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         let src = [
             "vendorThingID": vendorThingID,
@@ -562,7 +562,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         let options = OnboardEndnodeWithGatewayOptions(interval: DataGroupingInterval.interval1Minute)
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         do {
             // verify request
@@ -660,7 +660,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         let options = OnboardEndnodeWithGatewayOptions(interval: DataGroupingInterval.interval15Minutes)
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
@@ -753,7 +753,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         let options = OnboardEndnodeWithGatewayOptions(interval: DataGroupingInterval.interval30Minutes)
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
@@ -846,7 +846,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         let options = OnboardEndnodeWithGatewayOptions(interval: DataGroupingInterval.interval1Hour)
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
@@ -977,7 +977,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         let src: Dictionary<String, Any> = [
             "thingProperties": thingProperties
@@ -1019,7 +1019,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         let src = [
             "vendorThingID": "",
@@ -1062,7 +1062,7 @@ class OnboardEndnodeWithGatewayThingIDTests: SmallTestBase {
         ]
 
         // perform onboarding
-        setting.api._target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
+        setting.api.target = Gateway(thingID: gatewayThingID, vendorThingID: vendorThingID)
 
         let src = [
             "vendorThingID": vendorThingID,

--- a/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OnboardingTests.swift
@@ -163,7 +163,7 @@ class OnboardingTests: SmallTestBase {
         let setting = TestSetting()
         let api = setting.api
 
-        api._target = setting.target
+        api.target = setting.target
         api.onboardWith(
           thingID: "dummyThingID",
           thingPassword: "dummyPassword") { (target, error) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerTests.swift
@@ -86,7 +86,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
                 ((data: jsonData4Get, urlResponse: urlResponse4Get, error: nil),getRequestVerifier)
             ]
             
-            api._target = setting.target
+            api.target = setting.target
             api.patchTrigger(expectedTriggerID, serverCode: serverCode, predicate: predicate, completionHandler: { (trigger, error) -> Void in
                 if error == nil{
                     XCTAssertEqual(trigger!.triggerID, expectedTriggerID, tag)
@@ -170,7 +170,7 @@ class PatchServerCodeTriggerTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
-            api._target = setting.target
+            api.target = setting.target
             api.patchTrigger(triggerID, serverCode:serverCode, predicate: predicate, completionHandler: { (trigger, error) -> Void in
                 if error == nil{
                     XCTFail("should fail")

--- a/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerWIthTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchServerCodeTriggerWIthTriggerOptionsTests.swift
@@ -72,7 +72,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
         ]
 
         let setting = TestSetting()
-        setting.api._target = setting.target
+        setting.api.target = setting.target
         let serverCode =  ServerCode(endpoint: "my_function",
                                      executorAccessToken: "executorAccessToken",
                                      targetAppID: "targetAppID",
@@ -225,7 +225,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
         let predicate = SchedulePredicate(schedule: "1 * * * *")
 
         let setting = TestSetting()
-        setting.api._target = setting.target
+        setting.api.target = setting.target
 
 
         weak var expectation : XCTestExpectation!
@@ -354,7 +354,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
         let predicate = SchedulePredicate(schedule: "1 * * * *")
 
         let setting = TestSetting()
-        setting.api._target = setting.target
+        setting.api.target = setting.target
 
         weak var expectation : XCTestExpectation!
         defer {
@@ -471,7 +471,7 @@ class PatchServerCodeTriggeWIthTriggerOptions: SmallTestBase {
 
     func testNoOptionalArgument() {
         let setting = TestSetting()
-        setting.api._target = setting.target
+        setting.api.target = setting.target
         var executed: Bool = false;
 
         setting.api.patchTrigger(

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerTests.swift
@@ -66,7 +66,7 @@ class PatchTriggerTests: SmallTestBase {
         let schemaVersion = setting.schemaVersion
 
         // perform onboarding
-        api._target = setting.target
+        api.target = setting.target
 
         let testsCases: [TestCase] = [
             //
@@ -151,7 +151,7 @@ class PatchTriggerTests: SmallTestBase {
         }
 
 
-        api._target = setting.target
+        api.target = setting.target
         api.patchTrigger(
           expectedTriggerID,
           triggeredCommandForm: TriggeredCommandForm(
@@ -229,7 +229,7 @@ class PatchTriggerTests: SmallTestBase {
         let setting = TestSetting()
         let api = setting.api
 
-        api._target = setting.target
+        api.target = setting.target
 
         api.patchTrigger(
           "0267251d9d60-1858-5e11-3dc3-00f3f0b5",

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggerOptionsTests.swift
@@ -61,7 +61,7 @@ class PatchTriggerWithTriggerOptionsTests: SmallTestBase {
         ]
 
         let setting = TestSetting()
-        setting.api._target = setting.target
+        setting.api.target = setting.target
 
         for options_index in 0..<optionsArray.count {
             let options: TriggerOptions = optionsArray[options_index]

--- a/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggeredCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PatchTriggerWithTriggeredCommandFormTests.swift
@@ -121,7 +121,7 @@ class PatchTriggerWithTriggeredCommandFormTest: SmallTestBase {
         ]
 
         let setting = TestSetting()
-        setting.api._target = setting.target
+        setting.api.target = setting.target
 
         for form_index in 0..<forms.count {
             let form: TriggeredCommandForm = forms[form_index]

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandTests.swift
@@ -34,7 +34,7 @@ class PostNewCommandTests: SmallTestBase {
         let owner = setting.owner
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         let testCases = [
             TestCase(target: target, schema: schema, schemaVersion: schemaVersion, actions: [["turnPower":["power": true]]], issuerID: owner.typedID),
@@ -123,7 +123,7 @@ class PostNewCommandTests: SmallTestBase {
         let target = setting.target
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         do{
             // mock response

--- a/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewCommandWithCommandFormTests.swift
@@ -37,7 +37,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
         let owner = setting.owner
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         let testCases = [
             TestCase(target: target,
@@ -212,7 +212,7 @@ class PostNewCommandWithCommandFormTests: SmallTestBase {
         let target = setting.target
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         do{
             // mock response

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerTests.swift
@@ -72,7 +72,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
-            api._target = setting.target
+            api.target = setting.target
             api.postNewTrigger(serverCode, predicate: predicate, completionHandler: { (trigger, error) -> Void in
                 if error == nil{
                     XCTAssertEqual(trigger!.triggerID, expectedTriggerID, tag)
@@ -157,7 +157,7 @@ class PostNewServerCodeTriggerTests: SmallTestBase {
             sharedMockSession.requestVerifier = requestVerifier
             iotSession = MockSession.self
             
-            api._target = setting.target
+            api.target = setting.target
             api.postNewTrigger(serverCode, predicate: predicate, completionHandler: { (trigger, error) -> Void in
                 if error == nil{
                     XCTFail("should fail")

--- a/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerWithTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewServerCodeTriggerWithTriggerOptionsTests.swift
@@ -62,7 +62,7 @@ class PostNewServerCodeTriggerWithTriggerOptionsTests: SmallTestBase {
         ]
 
         let setting = TestSetting()
-        setting.api._target = setting.target
+        setting.api.target = setting.target
         let serverCode =  ServerCode(endpoint: "my_function",
                                      executorAccessToken: "executorAccessToken",
                                      targetAppID: "targetAppID",

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerForScheduleTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerForScheduleTests.swift
@@ -256,7 +256,7 @@ class PostNewTriggerForScheduleTests: SmallTestBase {
         sharedMockSession.mockResponse = testCase.mockResponse
         iotSession = MockSession.self
 
-        setting.api._target = setting.target
+        setting.api.target = setting.target
 
         setting.api.postNewTrigger(
           TriggeredCommandForm(

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerTests.swift
@@ -131,7 +131,7 @@ class PostNewTriggerTests: SmallTestBase {
         let api = setting.api
         let target = setting.target
         // perform onboarding
-        api._target = target
+        api.target = target
 
         let orClauseClause = ["type": "or", "clauses": [["type":"eq","field":"color", "value": 0], ["type": "not", "clause": ["type":"eq","field":"power", "value": true]] ]] as [String : Any]
         let andClauseClause = ["type": "and", "clauses": [["type":"eq","field":"color", "value": 0], ["type": "not", "clause": ["type":"eq","field":"power", "value": true]] ]] as [String : Any]
@@ -182,7 +182,7 @@ class PostNewTriggerTests: SmallTestBase {
         let schemaVersion = setting.schemaVersion
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         do{
             let actions: [Dictionary<String, Any>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
@@ -267,7 +267,7 @@ class PostNewTriggerTests: SmallTestBase {
         let schemaVersion = setting.schemaVersion
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         do{
             let actions: [Dictionary<String, Any>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]
@@ -352,7 +352,7 @@ class PostNewTriggerTests: SmallTestBase {
         let schemaVersion = setting.schemaVersion
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         do{
             let actions: [Dictionary<String, Any>] = [["turnPower":["power":true]],["setBrightness":["bribhtness":90]]]

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggerOptionsTests.swift
@@ -62,7 +62,7 @@ class PostNewTriggerWithTriggerOptionsTests: SmallTestBase {
         ]
 
         let setting = TestSetting()
-        setting.api._target = setting.target
+        setting.api.target = setting.target
 
         for index in 0..<optionsArray.count {
             let options = optionsArray[index]

--- a/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggeredCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PostNewTriggerWithTriggeredCommandFormTests.swift
@@ -123,7 +123,7 @@ class PostNewTriggerWithTriggeredCommandFormTests: SmallTestBase {
         ]
 
         let setting = TestSetting()
-        setting.api._target = setting.target
+        setting.api.target = setting.target
 
         for index in 0..<forms.count {
             let form = forms[index]

--- a/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/PushUninstallationTests.swift
@@ -83,7 +83,7 @@ class PushUninstallationTests: SmallTestBase {
                 XCTFail("execution timeout")
             }
         }
-        setting.api._installationID = "dummyInstallationID"
+        setting.api.installationID = "dummyInstallationID"
     }
     func testPushUninstallation_success() {
         let setting = TestSetting()
@@ -111,7 +111,7 @@ class PushUninstallationTests: SmallTestBase {
         
         setting.api.uninstallPush(installID) { (error) -> Void in
             XCTAssertTrue(error==nil,"should not error")
-            XCTAssertNil(setting.api._installationID,"Should be nil")
+            XCTAssertNil(setting.api.installationID,"Should be nil")
             expectation.fulfill()
         }
         self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in

--- a/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/UpdateVendorThingIDTests.swift
@@ -30,7 +30,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         let newPassword = "dummyPassword"
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
@@ -101,7 +101,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         let newPassword = "dummyPassword"
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
@@ -178,7 +178,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         let newPassword = "dummyPassword"
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         // verify request
         let requestVerifier: ((URLRequest) -> Void) = {(request) in
@@ -255,7 +255,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         let newPassword = "dummyPassword"
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         setting.api.update(
             newVendorThingID,
@@ -288,7 +288,7 @@ class UpdateVendorThingIDTests: SmallTestBase {
         let newPassword = ""
 
         // perform onboarding
-        api._target = target
+        api.target = target
 
         setting.api.update(
             newVendorThingID,


### PR DESCRIPTION
I refactored thing-if iOSSDK.

I fixed following 2 computed properties to stored properties.

* `ThingIFAPI.installationID`
* `ThingIFAPI.target`

I assumed that original programmer want to make readonly optional property. The programmer used computed property to achieve readonly property. However, Swift can provide different access level to a property.