### PR TITLE
Remove NSObject inheritance

### DIFF
--- a/ThingIFSDK/ThingIFSDK/AbstractThing.swift
+++ b/ThingIFSDK/ThingIFSDK/AbstractThing.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /** Represents Target */
-open class AbstractThing : NSObject, TargetThing {
+open class AbstractThing : Equatable, TargetThing {
     open let typedID: TypedID
     open let accessToken: String?
     open var thingID: String {
@@ -39,10 +39,14 @@ open class AbstractThing : NSObject, TargetThing {
         self.vendorThingID = vendorThingID
     }
 
-    open override func isEqual(_ object: Any?) -> Bool {
+    open func isEqual(_ object: Any?) -> Bool {
         guard let aTarget = object as? AbstractThing else {
             return false
         }
         return self.typedID == aTarget.typedID && self.accessToken == aTarget.accessToken
+    }
+
+    public static func == (left: AbstractThing, right: AbstractThing) -> Bool{
+        return left.isEqual(right);
     }
 }

--- a/ThingIFSDK/ThingIFSDK/App.swift
+++ b/ThingIFSDK/ThingIFSDK/App.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /** Represents Kii Cloud Application */
-open class App: NSObject, NSCoding {
+open class App: NSCoding {
     /** ID of the App */
     open let appID: String
     /** Key of the APP */

--- a/ThingIFSDK/ThingIFSDK/Command.swift
+++ b/ThingIFSDK/ThingIFSDK/Command.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /** Class represents Command */
-open class Command: NSObject, NSCoding {
+open class Command: Equatable, NSCoding {
 
     // MARK: - Implements NSCoding protocol
     open func encode(with aCoder: NSCoder) {
@@ -107,7 +107,7 @@ open class Command: NSObject, NSCoding {
         self.metadata = metadata
     }
 
-    open override func isEqual(_ object: Any?) -> Bool {
+    open func isEqual(_ object: Any?) -> Bool {
         guard let aCommand = object as? Command else{
             return false
         }
@@ -115,6 +115,10 @@ open class Command: NSObject, NSCoding {
         return self.commandID == aCommand.commandID &&
             self.targetID == aCommand.targetID &&
             self.issuerID == aCommand.issuerID
+    }
+
+    public static func == (left: Command, right: Command) -> Bool {
+        return left.isEqual(right)
     }
 
     // TODO: We should replace this method with internal initializer.

--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -24,7 +24,7 @@ Optional data are followings:
   - Description of a command
   - Meta data of a command
 */
-open class CommandForm: NSObject, NSCoding {
+open class CommandForm: NSCoding {
 
     // MARK: - Properties
 

--- a/ThingIFSDK/ThingIFSDK/Condition.swift
+++ b/ThingIFSDK/ThingIFSDK/Condition.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 /** Class represents Condition */
-open class Condition : NSObject, NSCoding {
+open class Condition : NSCoding {
     open let clause: TriggerClause
 
     /** Init Condition with Clause

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-open class GatewayAPI: NSObject, NSCoding {
+open class GatewayAPI: NSCoding {
 
     private static let SHARED_NSUSERDEFAULT_KEY_INSTANCE = "GatewayAPI_INSTANCE"
     private static func getStoredInstanceKey(_ tag : String?) -> String{

--- a/ThingIFSDK/ThingIFSDK/Gateway/PendingEndNode.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/PendingEndNode.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-open class PendingEndNode: NSObject, NSCoding {
+open class PendingEndNode: NSCoding {
     let KEY_VENDORTHINGID = "vendorThingID"
     let KEY_THINGPROPERTIES = "thingProperties"
 

--- a/ThingIFSDK/ThingIFSDK/Owner.swift
+++ b/ThingIFSDK/ThingIFSDK/Owner.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Represents Owner */
-open class Owner: NSObject, NSCoding {
+open class Owner: Equatable, NSCoding {
 
     // MARK: - Implements NSCoding protocol
     open func encode(with aCoder: NSCoder) {
@@ -35,12 +35,15 @@ open class Owner: NSObject, NSCoding {
         self.accessToken = accessToken
     }
     
-    open override func isEqual(_ object: Any?) -> Bool {
+    open func isEqual(_ object: Any?) -> Bool {
         guard let anOwner = object as? Owner else{
             return false
         }
         
         return self.typedID == anOwner.typedID && self.accessToken == anOwner.accessToken
-        
+    }
+
+    public static func == (left: Owner, right: Owner) -> Bool {
+        return left.isEqual(right);
     }
 }

--- a/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
@@ -7,7 +7,7 @@
 //
 
 /** Class represents ScheduleOncePredicate. */
-open class ScheduleOncePredicate: NSObject,Predicate {
+open class ScheduleOncePredicate: Predicate {
     /** Specified schedule. */
     open let scheduleAt: Date
 
@@ -19,7 +19,6 @@ open class ScheduleOncePredicate: NSObject,Predicate {
      */
     public init(scheduleAt: Date) {
         self.scheduleAt = scheduleAt
-        super.init()
     }
 
     public required init(coder aDecoder: NSCoder) {

--- a/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /** Class represents SchedulePredicate. */
-open class SchedulePredicate: NSObject,Predicate {
+open class SchedulePredicate: Predicate {
     /** Specified schedule. (cron tab format) */
     open let schedule: String
 
@@ -21,8 +21,6 @@ open class SchedulePredicate: NSObject,Predicate {
      */
     public init(schedule: String) {
         self.schedule = schedule
-
-        super.init()
     }
 
     public required init(coder aDecoder: NSCoder) {

--- a/ThingIFSDK/ThingIFSDK/ServerCode.swift
+++ b/ThingIFSDK/ThingIFSDK/ServerCode.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-open class ServerCode : NSObject, NSCoding {
+open class ServerCode : NSCoding {
     // MARK: - Implements NSCoding protocol
     open func encode(with aCoder: NSCoder) {
         aCoder.encode(self.endpoint, forKey: "endpoint")

--- a/ThingIFSDK/ThingIFSDK/ServerCode.swift
+++ b/ThingIFSDK/ThingIFSDK/ServerCode.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-open class ServerCode : NSCoding {
+open class ServerCode : Equatable, NSCoding {
     // MARK: - Implements NSCoding protocol
     open func encode(with aCoder: NSCoder) {
         aCoder.encode(self.endpoint, forKey: "endpoint")
@@ -55,7 +55,7 @@ open class ServerCode : NSCoding {
         return dict
     }
 
-    open override func isEqual(_ object: Any?) -> Bool {
+    open func isEqual(_ object: Any?) -> Bool {
         guard let aServerCode = object as? ServerCode else{
             return false
         }
@@ -70,6 +70,10 @@ open class ServerCode : NSCoding {
             self.targetAppID == aServerCode.targetAppID &&
             NSDictionary(dictionary: self.parameters!).isEqual(to: aServerCode.parameters!)
 
+    }
+
+    public static func == (left: ServerCode, right: ServerCode) -> Bool {
+        return left.isEqual(right)
     }
 
     class func serverCodeWithNSDictionary(_ nsDict: NSDictionary!) -> ServerCode?{

--- a/ThingIFSDK/ThingIFSDK/StatePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/StatePredicate.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /** Class represents StatePredicate */
-open class StatePredicate: NSObject,Predicate {
+open class StatePredicate: Predicate {
     open let triggersWhen: TriggersWhen
     open let condition: Condition
 
@@ -26,7 +26,6 @@ open class StatePredicate: NSObject,Predicate {
     {
         self.triggersWhen = triggersWhen
         self.condition = condition
-        super.init();
     }
 
     public required convenience init(coder aDecoder: NSCoder) {

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Class provides API of the ThingIF. */
-open class ThingIFAPI: NSCoding {
+open class ThingIFAPI: Equatable, NSCoding {
 
     private static var SHARED_NSUSERDEFAULT_KEY_INSTANCE: String {
         get {

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Class provides API of the ThingIF. */
-open class ThingIFAPI: NSObject, NSCoding {
+open class ThingIFAPI: NSCoding {
 
     private static var SHARED_NSUSERDEFAULT_KEY_INSTANCE: String {
         get {
@@ -102,7 +102,6 @@ open class ThingIFAPI: NSObject, NSCoding {
         self.owner = owner
         self.target = target
         self.tag = tag
-        super.init()
     }
 
     // MARK: - On board methods
@@ -987,7 +986,7 @@ open class ThingIFAPI: NSObject, NSCoding {
         return true
     }
 
-    open override func isEqual(_ object: Any?) -> Bool {
+    open func isEqual(_ object: Any?) -> Bool {
         guard let anAPI = object as? ThingIFAPI else{
             return false
         }
@@ -999,6 +998,10 @@ open class ThingIFAPI: NSObject, NSCoding {
             self.target?.typedID == anAPI.target?.typedID &&
             self.installationID == anAPI.installationID &&
             self.tag == anAPI.tag
+    }
+
+    public static func == (left: ThingIFAPI, right: ThingIFAPI) -> Bool {
+        return left.isEqual(right)
     }
 
     

--- a/ThingIFSDK/ThingIFSDK/Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/Trigger.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Class represents Trigger */
-open class Trigger: NSObject, NSCoding {
+open class Trigger: Equatable, NSCoding {
 
     // MARK: - Implements NSCoding protocol
     open func encode(with aCoder: NSCoder) {
@@ -164,6 +164,10 @@ open class Trigger: NSObject, NSCoding {
         return self.enabled == aTrigger.enabled &&
             self.command == aTrigger.command &&
             self.serverCode == aTrigger.serverCode
+    }
+
+    public static func == (left: Trigger, right: Trigger) -> Bool {
+        return left.isEqual(right)
     }
 
 }

--- a/ThingIFSDK/ThingIFSDK/Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/Trigger.swift
@@ -156,7 +156,7 @@ open class Trigger: Equatable, NSCoding {
         self.metadata = metadata
     }
 
-    open override func isEqual(_ object: Any?) -> Bool {
+    open func isEqual(_ object: Any?) -> Bool {
         guard let aTrigger = object as? Trigger else{
             return false
         }

--- a/ThingIFSDK/ThingIFSDK/TriggerOptions.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggerOptions.swift
@@ -17,7 +17,7 @@ This class contains optional data in order to create and modify
  - `ThingIFAPI.postNewTrigger(_:predicate:options:completionHandler:)`
  - `ThingIFAPI.patchTrigger(_:triggeredCommandForm:predicate:options:completionHandler:)`
 */
-open class TriggerOptions: NSObject, NSCoding {
+open class TriggerOptions: NSCoding {
 
     /// Title of a command.
     open let title: String?

--- a/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredCommandForm.swift
@@ -28,7 +28,7 @@ Optional data are followings:
   - Description of a triggered command
   - Meta data of a triggered command
 */
-open class TriggeredCommandForm: NSObject, NSCoding {
+open class TriggeredCommandForm: NSCoding {
 
     // MARK: - Properties
 

--- a/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
@@ -138,7 +138,7 @@ open class TriggeredServerCodeResult: Equatable, NSCoding {
         return self.succeeded == aResult.succeeded && self.executedAt == aResult.executedAt && self.endpoint == aResult.endpoint
     }
 
-    public static func == (left: TriggeredServerCodeResult, right: TriggeredServerCodeResult) {
+    public static func == (left: TriggeredServerCodeResult, right: TriggeredServerCodeResult) -> Bool {
         return left.isEqual(right);
     }
     private func isEqualArray(_ arr1:[Any], arr2:[Any]) -> Bool {

--- a/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /** Class represents result of server code trigged by trigger */
-open class TriggeredServerCodeResult: NSObject, NSCoding {
+open class TriggeredServerCodeResult: Equatable, NSCoding {
     
     // MARK: - Implements NSCoding protocol
     open func encode(with aCoder: NSCoder) {
@@ -97,7 +97,7 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
         self.error = error
     }
     
-    open override func isEqual(_ object: Any?) -> Bool {
+    open func isEqual(_ object: Any?) -> Bool {
         guard let aResult = object as? TriggeredServerCodeResult else{
             return false
         }
@@ -136,6 +136,10 @@ open class TriggeredServerCodeResult: NSObject, NSCoding {
             return false
         }
         return self.succeeded == aResult.succeeded && self.executedAt == aResult.executedAt && self.endpoint == aResult.endpoint
+    }
+
+    public static func == (left: TriggeredServerCodeResult, right: TriggeredServerCodeResult) {
+        return left.isEqual(right);
     }
     private func isEqualArray(_ arr1:[Any], arr2:[Any]) -> Bool {
         if arr1.count != arr2.count {

--- a/ThingIFSDK/ThingIFSDK/TypedID.swift
+++ b/ThingIFSDK/ThingIFSDK/TypedID.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /** Represents entity type and its ID. */
-open class TypedID : NSObject, NSCoding {
+open class TypedID : Equatable, NSCoding {
 
     // MARK: - Implements NSCoding protocol
     open func encode(with aCoder: NSCoder) {
@@ -43,10 +43,14 @@ open class TypedID : NSObject, NSCoding {
         return "\(type):\(id)"
     }
 
-    open override func isEqual(_ object: Any?) -> Bool {
+    open func isEqual(_ object: Any?) -> Bool {
         guard let aType = object as? TypedID else{
             return false
         }
         return (self.type == aType.type) && (self.id == aType.id)
+    }
+
+    public static func == (left: TypedID, right: TypedID) {
+        return left.isEqual(right)
     }
 }

--- a/ThingIFSDK/ThingIFSDK/TypedID.swift
+++ b/ThingIFSDK/ThingIFSDK/TypedID.swift
@@ -50,7 +50,7 @@ open class TypedID : Equatable, NSCoding {
         return (self.type == aType.type) && (self.id == aType.id)
     }
 
-    public static func == (left: TypedID, right: TypedID) {
+    public static func == (left: TypedID, right: TypedID) -> Bool {
         return left.isEqual(right)
     }
 }

--- a/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
+++ b/ThingIFSDK/ThingIFSDK/Utils/SDKVersion.swift
@@ -7,12 +7,12 @@
 import UIKit
 
 /** Accessor of the Thing-IF SDK version. */
-open class SDKVersion: NSObject {
+open class SDKVersion {
     open static let sharedInstance = SDKVersion()
     /** Version of the Thing-IF SDK */
     open let versionString:String
     internal var kiiSDKHeader:String
-    private override init() {
+    private init() {
         let b:Bundle? = Bundle.allFrameworks.filter{$0.bundleIdentifier == "Kii-Corporation.ThingIFSDK"}.first
         if let v = b?.infoDictionary?["CFBundleShortVersionString"] as? String {
             versionString = v


### PR DESCRIPTION
- Remove NSObject from the inheritance tree for the following classes
  - AbstractThing
  - App
  - Command
  - CommandForm
  - Condition
  - GatewayAPI
  - PendingNode
  - Owner
  - ScheduleOncePredicate
  - SchedulePredicate
  - SeverCode
  - StatePredicate
  - ThingIFAPI
  - Trigger
  - TriggerOptions
  - TriggeredCommandForm
  - TriggeredServerCodeResult
  - TypedID
  - SDKVersion
- Extend `Equatable` from some class, which need to override `==` operator
  - AbstractThing
  - Command
  - Owner
  - ServerCode
  - ThingIFAPI
  - Trigger
  - TriggeredServerCodeResult
  - TypedID

