### PR TITLE
Implement encoder and decoder for NSCoding.

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		B6ABF9761E372F0300981AC4 /* TriggerClause.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ABF9751E372F0300981AC4 /* TriggerClause.swift */; };
 		B6AC4A1A1D991CE1001A80DE /* TriggeredCommandForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AC4A191D991CE1001A80DE /* TriggeredCommandForm.swift */; };
 		B6AC4A1C1D991DF2001A80DE /* TriggerOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AC4A1B1D991DF2001A80DE /* TriggerOptions.swift */; };
+		B6C2DAF91E4D69C5008DBA83 /* NSCoderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2DAF81E4D69C5008DBA83 /* NSCoderExtension.swift */; };
 		B6C33EFF1E49770B00DF2BF5 /* ThingIFSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C33EFE1E49770B00DF2BF5 /* ThingIFSDKTests.swift */; };
 		B6C33F011E49770B00DF2BF5 /* ThingIFSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DD44DE91BD4B7CD00AE0249 /* ThingIFSDK.framework */; };
 		B6C33F0C1E4977C700DF2BF5 /* AggregationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C33F071E4977C700DF2BF5 /* AggregationTests.swift */; };
@@ -208,6 +209,7 @@
 		B6ABF9751E372F0300981AC4 /* TriggerClause.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TriggerClause.swift; sourceTree = "<group>"; };
 		B6AC4A191D991CE1001A80DE /* TriggeredCommandForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TriggeredCommandForm.swift; sourceTree = "<group>"; };
 		B6AC4A1B1D991DF2001A80DE /* TriggerOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TriggerOptions.swift; sourceTree = "<group>"; };
+		B6C2DAF81E4D69C5008DBA83 /* NSCoderExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCoderExtension.swift; sourceTree = "<group>"; };
 		B6C33EFC1E49770B00DF2BF5 /* ThingIFSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ThingIFSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6C33EFE1E49770B00DF2BF5 /* ThingIFSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingIFSDKTests.swift; sourceTree = "<group>"; };
 		B6C33F001E49770B00DF2BF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -389,6 +391,7 @@
 			children = (
 				7D36B6621BD4D03100D9B821 /* Logger.swift */,
 				747EB4B91C858BFC00E30C31 /* SDKVersion.swift */,
+				B6C2DAF81E4D69C5008DBA83 /* NSCoderExtension.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -625,6 +628,7 @@
 				7D36B6821BD4D03100D9B821 /* OperationQueue.swift in Sources */,
 				7D36B6801BD4D03100D9B821 /* OperationErrors.swift in Sources */,
 				D5636AFB1CE1E9E000760564 /* ScheduleOncePredicate.swift in Sources */,
+				B6C2DAF91E4D69C5008DBA83 /* NSCoderExtension.swift in Sources */,
 				7D36B68B1BD4D03100D9B821 /* Logger.swift in Sources */,
 				B6AC4A1A1D991CE1001A80DE /* TriggeredCommandForm.swift in Sources */,
 				7D36B6BC1BD4D43700D9B821 /* ThingIFAPI+GetState.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/AliasActionResult.swift
+++ b/ThingIFSDK/ThingIFSDK/AliasActionResult.swift
@@ -22,28 +22,13 @@ open class AliasActionResult: NSCoding {
     }
 
     public required convenience init?(coder aDecoder: NSCoder) {
-        let alias = aDecoder.decodeObject(forKey: "alias") as! String
-        let count = aDecoder.decodeInteger(forKey: "count")
-        var results: [ActionResult] = []
-        for i in 0..<count {
-            let data = aDecoder.decodeObject(forKey: String(i))
-            let decoder: NSKeyedUnarchiver = NSKeyedUnarchiver(forReadingWith: data as! Data);
-            let result = ActionResult(coder: decoder)!
-            decoder.finishDecoding()
-            results.append(result)
-        }
-        self.init(alias, results: results)
+        self.init(
+          aDecoder.decodeObject(forKey: "alias") as! String,
+          results: aDecoder.decodeNSCodingArray(forKey: "results")!)
     }
 
     public func encode(with aCoder: NSCoder) {
         aCoder.encode(self.alias, forKey: "alias")
-        aCoder.encode(self.results.count, forKey: "count")
-        for i in 0..<self.results.count {
-            let data = NSMutableData(capacity: 1024)!
-            let coder = NSKeyedArchiver(forWritingWith: data)
-            self.results[i].encode(with: coder)
-            coder.finishEncoding()
-            aCoder.encode(data, forKey: String(i))
-        }
+        aCoder.encodeNSCodingArray(self.results, forKey: "results")
     }
 }

--- a/ThingIFSDK/ThingIFSDK/Utils/NSCoderExtension.swift
+++ b/ThingIFSDK/ThingIFSDK/Utils/NSCoderExtension.swift
@@ -1,0 +1,83 @@
+//
+//  NSCoderExtension.swift
+//  ThingIFSDK
+//
+//  Created on 2017/02/10.
+//  Copyright (c) 2017 Kii. All rights reserved.
+//
+
+import Foundation
+
+extension NSCoder {
+
+    internal func encodeNSCodingObject(
+      _ object: NSCoding,
+      forKey: String) -> Void
+    {
+        let data: NSMutableData = NSMutableData(capacity: 1024)!
+        let coder: NSKeyedArchiver =
+            NSKeyedArchiver(forWritingWith: data);
+        object.encode(with: coder);
+        coder.finishEncoding();
+        self.encode(data, forKey: forKey)
+    }
+
+    internal func decodeNSCodingObject<T: NSCoding>(forKey: String) -> T! {
+        guard let data = self.decodeObject(forKey: forKey) as? Data else {
+            return nil
+        }
+        let decoder: NSKeyedUnarchiver =
+          NSKeyedUnarchiver(forReadingWith: data);
+        let retval = T(coder: decoder)
+        decoder.finishDecoding();
+        return retval
+    }
+
+    internal func encodeNSCodingArray<T: NSCoding>(
+      _ array: [T],
+      forKey: String) -> Void
+    {
+        var dataArray: [NSMutableData] = []
+        for object in array {
+            let data: NSMutableData = NSMutableData(capacity: 1024)!
+            let coder: NSKeyedArchiver =
+              NSKeyedArchiver(forWritingWith: data);
+            object.encode(with: coder);
+            coder.finishEncoding();
+            dataArray.append(data)
+        }
+
+        let wholeData: NSMutableData = NSMutableData(capacity: 1024)!
+        let coder: NSKeyedArchiver =
+          NSKeyedArchiver(forWritingWith: wholeData);
+        coder.encode(dataArray.count, forKey: "count")
+        for (index, data) in dataArray.enumerated() {
+            coder.encode(data, forKey: "\(index)")
+        }
+        coder.finishEncoding();
+        self.encode(wholeData, forKey: forKey)
+    }
+
+    internal func decodeNSCodingArray<T: NSCoding>(
+      forKey: String) -> [T]?
+    {
+        guard let wholeData =
+                self.decodeObject(forKey: forKey) as? Data else {
+            return nil
+        }
+
+        var retval: [T] = []
+        let wholeDecoder: NSKeyedUnarchiver =
+            NSKeyedUnarchiver(forReadingWith: wholeData);
+        for index in 0..<wholeDecoder.decodeInteger(forKey: "count") {
+            let data = wholeDecoder.decodeObject(forKey: "\(index)") as! Data
+            let decoder: NSKeyedUnarchiver =
+              NSKeyedUnarchiver(forReadingWith: data);
+            retval.append(T(coder: decoder)!)
+            decoder.finishDecoding()
+
+        }
+        wholeDecoder.finishDecoding();
+        return retval
+    }
+}


### PR DESCRIPTION
`NSCoder.encode()` and `NSCoder.decode()` does not accept NSCoding objects. It is very troublesome.

I implemented encoder and decoder for a NSCoding object and array of NSCoding objects.

Related PR: #296 