### PR TITLE
Fix ScheduleOncePredicate and SchedulePredicate

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		B6C2DAFF1E4DA5EA008DBA83 /* AggregatedResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2DAFE1E4DA5EA008DBA83 /* AggregatedResultTests.swift */; };
 		B6C2DB451E556312008DBA83 /* GroupedHistoryStatesQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2DB441E556312008DBA83 /* GroupedHistoryStatesQueryTests.swift */; };
 		B6C2DB491E55A1FD008DBA83 /* HistoryStatesQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2DB481E55A1FD008DBA83 /* HistoryStatesQueryTests.swift */; };
+		B6C2DB4B1E5AC281008DBA83 /* ScheduleOncePredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2DB4A1E5AC281008DBA83 /* ScheduleOncePredicateTests.swift */; };
+		B6C2DB4D1E5AC962008DBA83 /* SchedulePredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C2DB4C1E5AC962008DBA83 /* SchedulePredicateTests.swift */; };
 		B6C33EFF1E49770B00DF2BF5 /* ThingIFSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C33EFE1E49770B00DF2BF5 /* ThingIFSDKTests.swift */; };
 		B6C33F011E49770B00DF2BF5 /* ThingIFSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DD44DE91BD4B7CD00AE0249 /* ThingIFSDK.framework */; };
 		B6C33F0C1E4977C700DF2BF5 /* AggregationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C33F071E4977C700DF2BF5 /* AggregationTests.swift */; };
@@ -220,6 +222,8 @@
 		B6C2DAFE1E4DA5EA008DBA83 /* AggregatedResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AggregatedResultTests.swift; sourceTree = "<group>"; };
 		B6C2DB441E556312008DBA83 /* GroupedHistoryStatesQueryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupedHistoryStatesQueryTests.swift; sourceTree = "<group>"; };
 		B6C2DB481E55A1FD008DBA83 /* HistoryStatesQueryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryStatesQueryTests.swift; sourceTree = "<group>"; };
+		B6C2DB4A1E5AC281008DBA83 /* ScheduleOncePredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduleOncePredicateTests.swift; sourceTree = "<group>"; };
+		B6C2DB4C1E5AC962008DBA83 /* SchedulePredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchedulePredicateTests.swift; sourceTree = "<group>"; };
 		B6C33EFC1E49770B00DF2BF5 /* ThingIFSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ThingIFSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6C33EFE1E49770B00DF2BF5 /* ThingIFSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThingIFSDKTests.swift; sourceTree = "<group>"; };
 		B6C33F001E49770B00DF2BF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -446,6 +450,8 @@
 				B6C2DAFE1E4DA5EA008DBA83 /* AggregatedResultTests.swift */,
 				B6C2DB441E556312008DBA83 /* GroupedHistoryStatesQueryTests.swift */,
 				B6C2DB481E55A1FD008DBA83 /* HistoryStatesQueryTests.swift */,
+				B6C2DB4A1E5AC281008DBA83 /* ScheduleOncePredicateTests.swift */,
+				B6C2DB4C1E5AC962008DBA83 /* SchedulePredicateTests.swift */,
 			);
 			path = ThingIFSDKTests;
 			sourceTree = "<group>";
@@ -693,6 +699,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B6C2DB4D1E5AC962008DBA83 /* SchedulePredicateTests.swift in Sources */,
 				2262F1511E4B046700080DF6 /* HistoryStateTests.swift in Sources */,
 				B6C2DAFB1E4D941A008DBA83 /* AndClauseInTriggerTests.swift in Sources */,
 				22EA81DA1E4DB1A70069B0B8 /* GroupedHistoryStatesTests.swift in Sources */,
@@ -707,6 +714,7 @@
 				B6C33F181E4C3A2B00DF2BF5 /* AndClauseInQueryTests.swift in Sources */,
 				B6C33EFF1E49770B00DF2BF5 /* ThingIFSDKTests.swift in Sources */,
 				B6C33F1E1E4C61DB00DF2BF5 /* NotEqualsClauseInTriggerTests.swift in Sources */,
+				B6C2DB4B1E5AC281008DBA83 /* ScheduleOncePredicateTests.swift in Sources */,
 				2262F14D1E49994E00080DF6 /* AliasActionTests.swift in Sources */,
 				B6C33F101E4977C700DF2BF5 /* XCTest+Utils.swift in Sources */,
 				2262F14B1E49899300080DF6 /* ActionResultTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/Predicate.swift
+++ b/ThingIFSDK/ThingIFSDK/Predicate.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /** Protocol represents Predicate */
-public protocol Predicate :  NSCoding {
+public protocol Predicate: class, NSCoding {
 
 
     /** Get Predicate as NSDictionary instance

--- a/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
@@ -21,7 +21,7 @@ open class ScheduleOncePredicate: NSObject, Predicate {
         self.scheduleAt = scheduleAt
     }
 
-    public required init(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         self.scheduleAt = aDecoder.decodeObject(forKey: "scheduleAt") as! Date
     }
 

--- a/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
@@ -3,11 +3,11 @@
 //  ThingIFSDK
 //
 //  Created by syahRiza on 5/10/16.
-//  Copyright © 2016 Kii. All rights reserved.
+//  Copyright (c) 2016 Kii. All rights reserved.
 //
 
 /** Class represents ScheduleOncePredicate. */
-open class ScheduleOncePredicate: Predicate {
+open class ScheduleOncePredicate: NSObject, Predicate {
     /** Specified schedule. */
     open let scheduleAt: Date
 

--- a/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /** Class represents SchedulePredicate. */
-open class SchedulePredicate: Predicate {
+open class SchedulePredicate: NSObject, Predicate {
     /** Specified schedule. (cron tab format) */
     open let schedule: String
 

--- a/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
@@ -23,7 +23,7 @@ open class SchedulePredicate: NSObject, Predicate {
         self.schedule = schedule
     }
 
-    public required init(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         self.schedule = aDecoder.decodeObject(forKey: "schedule") as! String;
 
     }

--- a/ThingIFSDK/ThingIFSDKTests-Old/PredicateNSCodingTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests-Old/PredicateNSCodingTests.swift
@@ -19,19 +19,6 @@ class PredicateNSCodingTests: SmallTestBase {
         super.tearDown()
     }
 
-    func testSchedulePredicate() {
-        let predicate = SchedulePredicate(schedule: "test");
-
-        let data = NSKeyedArchiver.archivedData(withRootObject: predicate);
-
-        XCTAssertNotNil(data);
-
-        let decode = NSKeyedUnarchiver.unarchiveObject(with: data) as! SchedulePredicate;
-
-        XCTAssertNotNil(decode);
-        XCTAssertEqual(decode.schedule, predicate.schedule);
-    }
-
     func testStatePredicate() {
         let predicate = StatePredicate(
                 condition: Condition(clause: EqualsClause(field: "f", stringValue: "v")),

--- a/ThingIFSDK/ThingIFSDKTests/ScheduleOncePredicateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ScheduleOncePredicateTests.swift
@@ -1,0 +1,44 @@
+//
+//  ScheduleOncePredicateTests.swift
+//  ThingIFSDK
+//
+//  Created on 2017/02/20.
+//  Copyright (c) 2017 Kii. All rights reserved.
+//
+
+import XCTest
+
+@testable import ThingIFSDK
+
+class ScheduleOncePredicateTests: SmallTestBase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func test() {
+        let scheduleAt = Date()
+        let actual = ScheduleOncePredicate(scheduleAt)
+
+        XCTAssertEqual(scheduleAt, actual.scheduleAt)
+        XCTAssertEqual(EventSource.scheduleOnce, actual.eventSource)
+
+        let data: NSMutableData = NSMutableData(capacity: 1024)!;
+        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
+        actual.encode(with: coder);
+        coder.finishEncoding();
+
+        let decoder: NSKeyedUnarchiver =
+          NSKeyedUnarchiver(forReadingWith: data as Data);
+        let deserialized = ScheduleOncePredicate(coder: decoder)!
+        decoder.finishDecoding();
+
+        XCTAssertEqual(actual.scheduleAt, deserialized.scheduleAt)
+        XCTAssertEqual(actual.eventSource, deserialized.eventSource)
+    }
+}
+

--- a/ThingIFSDK/ThingIFSDKTests/SchedulePredicateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/SchedulePredicateTests.swift
@@ -1,0 +1,43 @@
+//
+//  SchedulePredicateTests.swift
+//  ThingIFSDK
+//
+//  Created on 2017/02/20.
+//  Copyright (c) 2017 Kii. All rights reserved.
+//
+
+import XCTest
+
+@testable import ThingIFSDK
+
+class SchedulePredicateTests: SmallTestBase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func test() {
+        let schedule = "00 * * * *"
+        let actual = SchedulePredicate(schedule)
+
+        XCTAssertEqual(schedule, actual.schedule)
+        XCTAssertEqual(EventSource.schedule, actual.eventSource)
+
+        let data: NSMutableData = NSMutableData(capacity: 1024)!;
+        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
+        actual.encode(with: coder);
+        coder.finishEncoding();
+
+        let decoder: NSKeyedUnarchiver =
+          NSKeyedUnarchiver(forReadingWith: data as Data);
+        let deserialized = SchedulePredicate(coder: decoder)!
+        decoder.finishDecoding();
+
+        XCTAssertEqual(actual.schedule, deserialized.schedule)
+        XCTAssertEqual(actual.eventSource, deserialized.eventSource)
+    }
+}


### PR DESCRIPTION
* Extends NSCoding to `ScheduleOncePredicate` and `SchedulePredicate`.
* Extends `class` to `Predicate` protocol. this means that only class implements `Predicate` protocol.
* Add tests for those classes.
* Remove a test. There was no test for `ScheduleOncePredicate` so I removed test for only `SchedulePredicate`

Related PR: #296