### PR TITLE
Remove public makeDictionary().

### DIFF
--- a/ThingIFSDK/ThingIFSDK/BaseClause.swift
+++ b/ThingIFSDK/ThingIFSDK/BaseClause.swift
@@ -11,12 +11,6 @@ import Foundation
 /** Base protocol for all clause classes. */
 public protocol BaseClause: class, NSCoding {
 
-    /** Get Clause as Dictionary instance
-
-     - Returns: a Dictionary instance.
-     */
-    func makeDictionary() -> [ String : Any ]
-
 }
 
 /** Protocol for Equals clause classes */

--- a/ThingIFSDK/ThingIFSDK/QueryClause.swift
+++ b/ThingIFSDK/ThingIFSDK/QueryClause.swift
@@ -13,6 +13,25 @@ public protocol QueryClause: BaseClause {
 
 }
 
+internal extension QueryClause {
+
+    internal func makeDictionary() -> [String : Any] {
+        if type(of: self) === EqualsClauseInQuery.self {
+            return (self as! EqualsClauseInQuery).makeDictionary()
+        } else if type(of: self) === NotEqualsClauseInQuery.self {
+            return (self as! NotEqualsClauseInQuery).makeDictionary()
+        } else if type(of: self) === RangeClauseInQuery.self {
+            return (self as! RangeClauseInQuery).makeDictionary()
+        } else if type(of: self) === AndClauseInQuery.self {
+            return (self as! AndClauseInQuery).makeDictionary()
+        } else if type(of: self) === OrClauseInQuery.self {
+            return (self as! OrClauseInQuery).makeDictionary()
+        } else {
+            fatalError("unexpected class")
+        }
+    }
+}
+
 /** Class represents Equals clause for query methods. */
 open class EqualsClauseInQuery: NSObject, QueryClause, BaseEquals {
 
@@ -57,7 +76,7 @@ open class EqualsClauseInQuery: NSObject, QueryClause, BaseEquals {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         return [
           "type" : "eq",
           "field" : self.field,
@@ -99,7 +118,7 @@ open class NotEqualsClauseInQuery: NSObject, QueryClause, BaseNotEquals {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         return [
           "type" : "not",
           "clause" : self.equals.makeDictionary()
@@ -255,7 +274,7 @@ open class RangeClauseInQuery: NSObject, QueryClause, BaseRange {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         var retval: [String : Any] = ["type": "range", "field": self.field]
         retval["upperLimit"] = self.upper?.limit
         retval["upperIncluded"] = self.upper?.included
@@ -344,7 +363,7 @@ open class AndClauseInQuery: NSObject, QueryClause, BaseAnd {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         var clauses: [[String : Any]] = []
         self.clauses.forEach { clauses.append($0.makeDictionary()) }
         return ["type": "and", "clauses": clauses] as [String : Any]
@@ -398,7 +417,7 @@ open class OrClauseInQuery: NSObject, QueryClause, BaseOr {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         var clauses: [[String : Any]] = []
         self.clauses.forEach { clauses.append($0.makeDictionary()) }
         return ["type": "or", "clauses": clauses] as [String : Any]

--- a/ThingIFSDK/ThingIFSDK/ServerCode.swift
+++ b/ThingIFSDK/ThingIFSDK/ServerCode.swift
@@ -47,7 +47,7 @@ open class ServerCode : Equatable, NSCoding {
         self.parameters = parameters
     }
 
-    func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         var dict: [ String : Any ] = ["endpoint": self.endpoint]
         dict["executorAccessToken"] = self.executorAccessToken
         dict["targetAppID"] = self.targetAppID

--- a/ThingIFSDK/ThingIFSDK/TriggerClause.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggerClause.swift
@@ -13,6 +13,25 @@ public protocol TriggerClause: BaseClause {
 
 }
 
+internal extension TriggerClause {
+
+    internal func makeDictionary() -> [String : Any] {
+        if type(of: self) === EqualsClauseInTrigger.self {
+            return (self as! EqualsClauseInTrigger).makeDictionary()
+        } else if type(of: self) === NotEqualsClauseInTrigger.self {
+            return (self as! NotEqualsClauseInTrigger).makeDictionary()
+        } else if type(of: self) === RangeClauseInTrigger.self {
+            return (self as! RangeClauseInTrigger).makeDictionary()
+        } else if type(of: self) === AndClauseInTrigger.self {
+            return (self as! AndClauseInTrigger).makeDictionary()
+        } else if type(of: self) === OrClauseInTrigger.self {
+            return (self as! OrClauseInTrigger).makeDictionary()
+        } else {
+            fatalError("unexpected class")
+        }
+    }
+}
+
 /** Class represents Equals clause for trigger methods. */
 open class EqualsClauseInTrigger: NSObject, TriggerClause, BaseEquals {
 
@@ -64,7 +83,7 @@ open class EqualsClauseInTrigger: NSObject, TriggerClause, BaseEquals {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         return [
           "type" : "eq",
           "alias" : self.alias,
@@ -105,7 +124,7 @@ open class NotEqualsClauseInTrigger: NSObject, TriggerClause, BaseNotEquals {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         return [
           "type" : "not",
           "clause" : self.equals.makeDictionary()
@@ -287,7 +306,7 @@ open class RangeClauseInTrigger: NSObject, TriggerClause, BaseRange {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         var retval: [String : Any] = [
           "type": "range",
           "alias": alias,
@@ -381,7 +400,7 @@ open class AndClauseInTrigger: NSObject, TriggerClause, BaseAnd {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         var clauses: [[String : Any]] = []
         self.clauses.forEach { clauses.append($0.makeDictionary()) }
         return ["type": "and", "clauses": clauses] as [String : Any]
@@ -435,7 +454,7 @@ open class OrClauseInTrigger: NSObject, TriggerClause, BaseOr {
 
      - Returns: A Dictionary instance.
      */
-    open func makeDictionary() -> [ String : Any ] {
+    internal func makeDictionary() -> [ String : Any ] {
         var clauses: [[String : Any]] = []
         self.clauses.forEach { clauses.append($0.makeDictionary()) }
         return ["type": "or", "clauses": clauses] as [String : Any]


### PR DESCRIPTION
* make `makeDictionary()` methods internal  in following classes:
  * Trigger clause classes
  * Query clause classes
  * `ServerCode`
* implement protocol extension to use `makeDictionary` in subclasses.

Related PR: #296