### PR TITLE
Predicate classes and Condition becomes struct.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Condition.swift
+++ b/ThingIFSDK/ThingIFSDK/Condition.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 /** Class represents Condition */
-open class Condition : NSObject, NSCoding {
-    open let clause: TriggerClause
+public struct Condition {
+    public let clause: TriggerClause
 
     /** Init Condition with Clause
 
@@ -17,14 +17,6 @@ open class Condition : NSObject, NSCoding {
      */
     public init(_ clause: TriggerClause) {
         self.clause = clause
-    }
-
-    public required convenience init?(coder aDecoder: NSCoder) {
-        self.init(aDecoder.decodeObject() as! TriggerClause);
-    }
-
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.clause)
     }
 
 }

--- a/ThingIFSDK/ThingIFSDK/Predicate.swift
+++ b/ThingIFSDK/ThingIFSDK/Predicate.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /** Protocol represents Predicate */
-public protocol Predicate: class, NSCoding {
+public protocol Predicate {
 
 
     /** Event source of this predicate.

--- a/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/ScheduleOncePredicate.swift
@@ -7,11 +7,11 @@
 //
 
 /** Class represents ScheduleOncePredicate. */
-open class ScheduleOncePredicate: NSObject, Predicate {
+public struct ScheduleOncePredicate: Predicate {
     /** Specified schedule. */
-    open let scheduleAt: Date
+    public let scheduleAt: Date
 
-    open let eventSource: EventSource = EventSource.scheduleOnce
+    public let eventSource: EventSource = EventSource.scheduleOnce
 
     /** Instantiate new ScheduleOncePredicate.
 
@@ -21,13 +21,4 @@ open class ScheduleOncePredicate: NSObject, Predicate {
         self.scheduleAt = scheduleAt
     }
 
-    public required init?(coder aDecoder: NSCoder) {
-        self.scheduleAt = aDecoder.decodeObject(forKey: "scheduleAt") as! Date
-    }
-
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.scheduleAt, forKey: "scheduleAt")
-    }
-
 }
-

--- a/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/SchedulePredicate.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 /** Class represents SchedulePredicate. */
-open class SchedulePredicate: NSObject, Predicate {
+public struct SchedulePredicate: Predicate {
     /** Specified schedule. (cron tab format) */
-    open let schedule: String
+    public let schedule: String
 
-    open let eventSource: EventSource = EventSource.schedule
+    public let eventSource: EventSource = EventSource.schedule
 
     /** Instantiate new SchedulePredicate.
 
@@ -21,15 +21,6 @@ open class SchedulePredicate: NSObject, Predicate {
      */
     public init(_ schedule: String) {
         self.schedule = schedule
-    }
-
-    public required init?(coder aDecoder: NSCoder) {
-        self.schedule = aDecoder.decodeObject(forKey: "schedule") as! String;
-
-    }
-
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.schedule, forKey: "schedule");
     }
 
 }

--- a/ThingIFSDK/ThingIFSDK/StatePredicate.swift
+++ b/ThingIFSDK/ThingIFSDK/StatePredicate.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 /** Class represents StatePredicate */
-open class StatePredicate: NSObject, Predicate {
-    open let triggersWhen: TriggersWhen
-    open let condition: Condition
+public struct StatePredicate: Predicate {
+    public let triggersWhen: TriggersWhen
+    public let condition: Condition
 
-    open let eventSource: EventSource = EventSource.states
+    public let eventSource: EventSource = EventSource.states
 
     /** Initialize StatePredicate with Condition and TriggersWhen
 
@@ -26,21 +26,6 @@ open class StatePredicate: NSObject, Predicate {
     {
         self.triggersWhen = triggersWhen
         self.condition = condition
-    }
-
-    public required convenience init?(coder aDecoder: NSCoder) {
-        self.init(
-          aDecoder.decodeObject(forKey: "condition")
-            as! Condition,
-          triggersWhen: TriggersWhen(
-            rawValue: aDecoder.decodeObject(forKey: "triggersWhen")
-              as! String)!
-        )
-    }
-
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.triggersWhen.rawValue, forKey: "triggersWhen");
-        aCoder.encode(self.condition, forKey: "condition");
     }
 
 }

--- a/ThingIFSDK/ThingIFSDKTests/ConditionTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ConditionTests.swift
@@ -25,18 +25,5 @@ class ConditionTests: SmallTestBase {
         let actual = Condition(clause)
 
         assertEqualsTriggerClause(clause, actual.clause)
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver =
-          NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = Condition(coder: decoder)!;
-        decoder.finishDecoding();
-
-        assertEqualsTriggerClause(actual.clause, deserialized.clause)
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/ScheduleOncePredicateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ScheduleOncePredicateTests.swift
@@ -26,19 +26,6 @@ class ScheduleOncePredicateTests: SmallTestBase {
 
         XCTAssertEqual(scheduleAt, actual.scheduleAt)
         XCTAssertEqual(EventSource.scheduleOnce, actual.eventSource)
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = ScheduleOncePredicate(coder: decoder)!
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.scheduleAt, deserialized.scheduleAt)
-        XCTAssertEqual(actual.eventSource, deserialized.eventSource)
     }
 }
 

--- a/ThingIFSDK/ThingIFSDKTests/SchedulePredicateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/SchedulePredicateTests.swift
@@ -26,18 +26,5 @@ class SchedulePredicateTests: SmallTestBase {
 
         XCTAssertEqual(schedule, actual.schedule)
         XCTAssertEqual(EventSource.schedule, actual.eventSource)
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = SchedulePredicate(coder: decoder)!
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.schedule, deserialized.schedule)
-        XCTAssertEqual(actual.eventSource, deserialized.eventSource)
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/StatePredicateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/StatePredicateTests.swift
@@ -75,30 +75,6 @@ class StatePredicateTests: SmallTestBase {
               actual.triggersWhen,
               "\(index)")
             XCTAssertEqual(EventSource.states, actual.eventSource, "\(index)")
-
-            let data: NSMutableData = NSMutableData(capacity: 1024)!;
-            let coder: NSKeyedArchiver =
-              NSKeyedArchiver(forWritingWith: data);
-            actual.encode(with: coder);
-            coder.finishEncoding();
-
-            let decoder: NSKeyedUnarchiver =
-              NSKeyedUnarchiver(forReadingWith: data as Data);
-            let deserialized = StatePredicate(coder: decoder)!
-            decoder.finishDecoding();
-
-            assertEqualsTriggerClause(
-              actual.condition.clause,
-              deserialized.condition.clause,
-              "\(index)")
-            XCTAssertEqual(
-              actual.triggersWhen,
-              deserialized.triggersWhen,
-              "\(index)")
-            XCTAssertEqual(
-              actual.eventSource,
-              deserialized.eventSource,
-              "\(index)")
         }
     }
 }


### PR DESCRIPTION
* Remove `class` and `NSCoding` from `Predicate` protocol
* `ScheduleOncePredicate` becomes `struct`
  * Remove `NSObject`
  * Remove encoder and decoder
* `SchedulePredicate` becomes `struct`
  * Remove `NSObject`
  * Remove encoder and decoder
* `StatePredicate` becomes `struct`
  * Remove `NSObject`
  * Remove encoder and decoder
* `Condition` becomes `struct`
  * Remove `NSObject`
  * Remove encoder and decoder
* Fix small tests

Related PR: #296