### PR TITLE
Clause classes become struct

### DIFF
--- a/ThingIFSDK/ThingIFSDK/BaseClause.swift
+++ b/ThingIFSDK/ThingIFSDK/BaseClause.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /** Base protocol for all clause classes. */
-public protocol BaseClause: class {
+public protocol BaseClause {
 
 }
 
@@ -57,7 +57,7 @@ public protocol BaseAnd: BaseClause {
     var clauses: [ClausesType] { get }
 
     /** Add a clause. */
-    func add(_ clause: ClausesType) -> Self
+    mutating func add(_ clause: ClausesType) -> Void
 }
 
 
@@ -71,5 +71,5 @@ public protocol BaseOr: BaseClause {
     var clauses: [ClausesType] { get }
 
     /** Add a clause. */
-    func add(_ clause: ClausesType) -> Self
+    mutating func add(_ clause: ClausesType) -> Void
 }

--- a/ThingIFSDK/ThingIFSDK/QueryClause.swift
+++ b/ThingIFSDK/ThingIFSDK/QueryClause.swift
@@ -16,7 +16,19 @@ public protocol QueryClause: BaseClause {
 internal extension QueryClause {
 
     internal func makeDictionary() -> [String : Any] {
-        fatalError("should implement makeDictionary()")
+        if type(of: self) == EqualsClauseInQuery.self {
+            return (self as! EqualsClauseInQuery).makeDictionary()
+        } else if type(of: self) == NotEqualsClauseInQuery.self {
+            return (self as! NotEqualsClauseInQuery).makeDictionary()
+        } else if type(of: self) == RangeClauseInQuery.self {
+            return (self as! RangeClauseInQuery).makeDictionary()
+        } else if type(of: self) == AndClauseInQuery.self {
+            return (self as! AndClauseInQuery).makeDictionary()
+        } else if type(of: self) == OrClauseInQuery.self {
+            return (self as! OrClauseInQuery).makeDictionary()
+        } else {
+            fatalError("unexpected class")
+        }
     }
 }
 

--- a/ThingIFSDK/ThingIFSDK/QueryClause.swift
+++ b/ThingIFSDK/ThingIFSDK/QueryClause.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/** Base protocol for query clause classes. */
+/** Base protocol for query clause struct. */
 public protocol QueryClause: BaseClause {
 
 }
@@ -16,29 +16,17 @@ public protocol QueryClause: BaseClause {
 internal extension QueryClause {
 
     internal func makeDictionary() -> [String : Any] {
-        if type(of: self) === EqualsClauseInQuery.self {
-            return (self as! EqualsClauseInQuery).makeDictionary()
-        } else if type(of: self) === NotEqualsClauseInQuery.self {
-            return (self as! NotEqualsClauseInQuery).makeDictionary()
-        } else if type(of: self) === RangeClauseInQuery.self {
-            return (self as! RangeClauseInQuery).makeDictionary()
-        } else if type(of: self) === AndClauseInQuery.self {
-            return (self as! AndClauseInQuery).makeDictionary()
-        } else if type(of: self) === OrClauseInQuery.self {
-            return (self as! OrClauseInQuery).makeDictionary()
-        } else {
-            fatalError("unexpected class")
-        }
+        fatalError("should implement makeDictionary()")
     }
 }
 
-/** Class represents Equals clause for query methods. */
-open class EqualsClauseInQuery: QueryClause, BaseEquals {
+/** Struct represents Equals clause for query methods. */
+public struct EqualsClauseInQuery: QueryClause, BaseEquals {
 
     /** Name of a field. */
-    open let field: String
+    public let field: String
     /** Value of a field. */
-    open let value: AnyObject
+    public let value: AnyObject
 
     private init(_ field: String, value: AnyObject) {
         self.field = field
@@ -50,7 +38,7 @@ open class EqualsClauseInQuery: QueryClause, BaseEquals {
      - Parameter field: Name of the field to be compared.
      - Parameter intValue: Left hand side value to be compared.
      */
-    public convenience init(_ field: String, intValue: Int) {
+    public init(_ field: String, intValue: Int) {
         self.init(field, value: intValue as AnyObject)
     }
 
@@ -59,7 +47,7 @@ open class EqualsClauseInQuery: QueryClause, BaseEquals {
      - Parameter field: Name of the field to be compared.
      - Parameter stringValue: Left hand side value to be compared.
      */
-    public convenience init(_ field: String, stringValue: String) {
+    public init(_ field: String, stringValue: String) {
         self.init(field, value: stringValue as AnyObject)
     }
 
@@ -68,7 +56,7 @@ open class EqualsClauseInQuery: QueryClause, BaseEquals {
      - Parameter field: Name of the field to be compared.
      - Parameter boolValue: Left hand side value to be compared.
      */
-    public convenience init(_ field: String, boolValue: Bool) {
+    public init(_ field: String, boolValue: Bool) {
         self.init(field, value: boolValue as AnyObject)
     }
 
@@ -86,12 +74,12 @@ open class EqualsClauseInQuery: QueryClause, BaseEquals {
 
 }
 
-/** Class represents Not Equals clause for query methods.  */
-open class NotEqualsClauseInQuery: QueryClause, BaseNotEquals {
+/** Struct represents Not Equals clause for query methods.  */
+public struct NotEqualsClauseInQuery: QueryClause, BaseNotEquals {
     public typealias EqualClauseType = EqualsClauseInQuery
 
     /** Contained Equals clause instance. */
-    open let equals: EqualsClauseInQuery
+    public let equals: EqualsClauseInQuery
 
     /** Initialize with `EqualsClauseInQuery`.
 
@@ -114,38 +102,38 @@ open class NotEqualsClauseInQuery: QueryClause, BaseNotEquals {
 
 }
 
-/** Class represents Range clause for query methods. */
-open class RangeClauseInQuery: QueryClause, BaseRange {
+/** Struct represents Range clause for query methods. */
+public struct RangeClauseInQuery: QueryClause, BaseRange {
 
     private let lower: (limit: NSNumber, included: Bool)?
     private let upper: (limit: NSNumber, included: Bool)?
 
     /** Name of a field. */
-    open let field: String
+    public let field: String
 
     /** Lower limit for an instance. */
-    open var lowerLimit: NSNumber? {
+    public var lowerLimit: NSNumber? {
         get {
             return self.lower?.limit
         }
     }
 
     /** Include or not lower limit. */
-    open var lowerIncluded: Bool? {
+    public var lowerIncluded: Bool? {
         get {
             return self.lower?.included
         }
     }
 
     /** Upper limit for an instance. */
-    open var upperLimit: NSNumber? {
+    public var upperLimit: NSNumber? {
         get {
             return self.upper?.limit
         }
     }
 
     /** Include or not upper limit. */
-    open var upperIncluded: Bool? {
+    public var upperIncluded: Bool? {
         get {
             return self.upper?.included
         }
@@ -176,7 +164,7 @@ open class RangeClauseInQuery: QueryClause, BaseRange {
        included
      - Returns: An instance of `RangeClauseInQuery`.
      */
-    open static func range(
+    public static func range(
       _ field: String,
       lowerLimit: NSNumber,
       lowerIncluded: Bool,
@@ -196,7 +184,7 @@ open class RangeClauseInQuery: QueryClause, BaseRange {
        or float.
      - Returns: An instance of `RangeClauseInQuery`.
      */
-    open static func greaterThan(
+    public static func greaterThan(
       _ field: String,
       limit: NSNumber) -> RangeClauseInQuery
     {
@@ -211,7 +199,7 @@ open class RangeClauseInQuery: QueryClause, BaseRange {
        or float.
      - Returns: An instance of `RangeClauseInQuery`.
      */
-    open static func greaterThanOrEqualTo(
+    public static func greaterThanOrEqualTo(
       _ field: String,
       limit: NSNumber) -> RangeClauseInQuery
     {
@@ -225,7 +213,7 @@ open class RangeClauseInQuery: QueryClause, BaseRange {
        or float.
      - Returns: An instance of `RangeClauseInQuery`.
      */
-    open static func lessThan(
+    public static func lessThan(
       _ field: String,
       limit: NSNumber) -> RangeClauseInQuery
     {
@@ -240,7 +228,7 @@ open class RangeClauseInQuery: QueryClause, BaseRange {
        or float.
      - Returns: An instance of `RangeClauseInQuery`.
      */
-    open static func lessThanOrEqualTo(
+    public static func lessThanOrEqualTo(
       _ field: String,
       limit: NSNumber) -> RangeClauseInQuery
     {
@@ -263,11 +251,11 @@ open class RangeClauseInQuery: QueryClause, BaseRange {
 }
 
 
-/** Class represents And clause for query methods. */
-open class AndClauseInQuery: QueryClause, BaseAnd {
+/** Struct represents And clause for query methods. */
+public struct AndClauseInQuery: QueryClause, BaseAnd {
 
     /** Clauses conjuncted with And. */
-    open internal(set) var clauses: [QueryClause]
+    public internal(set) var clauses: [QueryClause]
 
     /** Initialize with clauses array.
 
@@ -281,7 +269,7 @@ open class AndClauseInQuery: QueryClause, BaseAnd {
 
      - Parameter clauses: Clause array for And clauses
      */
-    public convenience init(_ clause: QueryClause...) {
+    public init(_ clause: QueryClause...) {
         self.init(clause)
     }
 
@@ -289,10 +277,8 @@ open class AndClauseInQuery: QueryClause, BaseAnd {
 
      - Parameter clause: Clause to be added to and clauses.
      */
-    @discardableResult
-    open func add(_ clause: QueryClause) -> Self {
+    public mutating func add(_ clause: QueryClause) -> Void {
         self.clauses.append(clause)
-        return self
     }
 
     /** Get And clause for query as a Dictionary instance
@@ -307,11 +293,11 @@ open class AndClauseInQuery: QueryClause, BaseAnd {
 
 }
 
-/** Class represents Or clause for query methods. */
-open class OrClauseInQuery: QueryClause, BaseOr {
+/** Struct represents Or clause for query methods. */
+public struct OrClauseInQuery: QueryClause, BaseOr {
 
     /** Clauses conjuncted with Or. */
-    open internal(set) var clauses: [QueryClause]
+    public internal(set) var clauses: [QueryClause]
 
     /** Initialize with clauses array.
 
@@ -325,7 +311,7 @@ open class OrClauseInQuery: QueryClause, BaseOr {
 
      - Parameter clauses: Clause array for Or clauses
      */
-    public convenience init(_ clause: QueryClause...) {
+    public init(_ clause: QueryClause...) {
         self.init(clause)
     }
 
@@ -333,10 +319,8 @@ open class OrClauseInQuery: QueryClause, BaseOr {
 
      - Parameter clause: Clause to be added to or clauses.
      */
-    @discardableResult
-    open func add(_ clause: QueryClause) -> Self {
+    public mutating func add(_ clause: QueryClause) -> Void {
         self.clauses.append(clause)
-        return self
     }
 
     /** Get Or clause for query as a Dictionary instance

--- a/ThingIFSDK/ThingIFSDK/TriggerClause.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggerClause.swift
@@ -8,39 +8,27 @@
 
 import Foundation
 
-/** Base protocol for trigger clause classes. */
-public protocol TriggerClause: NSCoding, BaseClause {
+/** Base protocol for trigger clause structs. */
+public protocol TriggerClause: BaseClause {
 
 }
 
 internal extension TriggerClause {
 
     internal func makeDictionary() -> [String : Any] {
-        if type(of: self) === EqualsClauseInTrigger.self {
-            return (self as! EqualsClauseInTrigger).makeDictionary()
-        } else if type(of: self) === NotEqualsClauseInTrigger.self {
-            return (self as! NotEqualsClauseInTrigger).makeDictionary()
-        } else if type(of: self) === RangeClauseInTrigger.self {
-            return (self as! RangeClauseInTrigger).makeDictionary()
-        } else if type(of: self) === AndClauseInTrigger.self {
-            return (self as! AndClauseInTrigger).makeDictionary()
-        } else if type(of: self) === OrClauseInTrigger.self {
-            return (self as! OrClauseInTrigger).makeDictionary()
-        } else {
-            fatalError("unexpected class")
-        }
+        fatalError("should implement makeDictionary()")
     }
 }
 
-/** Class represents Equals clause for trigger methods. */
-open class EqualsClauseInTrigger: NSObject, TriggerClause, BaseEquals {
+/** Struct represents Equals clause for trigger methods. */
+public struct EqualsClauseInTrigger: TriggerClause, BaseEquals {
 
     /** Alias of this clause. */
-    open let alias: String
+    public let alias: String
     /** Name of a field. */
-    open let field: String
+    public let field: String
     /** Value of a field. */
-    open let value: AnyObject
+    public let value: AnyObject
 
     private init(_ alias: String, field: String, value: AnyObject) {
         self.alias = alias
@@ -53,7 +41,7 @@ open class EqualsClauseInTrigger: NSObject, TriggerClause, BaseEquals {
      - Parameter field: Name of the field to be compared.
      - Parameter intValue: Left hand side value to be compared.
      */
-    public convenience init(_ alias: String, field: String, intValue: Int) {
+    public init(_ alias: String, field: String, intValue: Int) {
         self.init(alias, field: field, value: intValue as AnyObject)
     }
 
@@ -62,7 +50,7 @@ open class EqualsClauseInTrigger: NSObject, TriggerClause, BaseEquals {
      - Parameter field: Name of the field to be compared.
      - Parameter stringValue: Left hand side value to be compared.
      */
-    public convenience init(
+    public init(
       _ alias: String,
       field: String,
       stringValue: String)
@@ -75,7 +63,7 @@ open class EqualsClauseInTrigger: NSObject, TriggerClause, BaseEquals {
      - Parameter field: Name of the field to be compared.
      - Parameter boolValue: Left hand side value to be compared.
      */
-    public convenience init(_ alias: String, field: String, boolValue: Bool) {
+    public init(_ alias: String, field: String, boolValue: Bool) {
         self.init(alias, field: field, value: boolValue as AnyObject)
     }
 
@@ -92,29 +80,14 @@ open class EqualsClauseInTrigger: NSObject, TriggerClause, BaseEquals {
         ] as [String : Any]
     }
 
-    /** Decoder confirming `NSCoding`. */
-    public required convenience init?(coder aDecoder: NSCoder) {
-        self.init(
-          aDecoder.decodeObject(forKey: "alias") as! String,
-          field: aDecoder.decodeObject(forKey: "field") as! String,
-          value: aDecoder.decodeObject(forKey: "value") as AnyObject)
-    }
-
-    /** Encoder confirming `NSCoding`. */
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.alias, forKey: "alias")
-        aCoder.encode(self.field, forKey: "field")
-        aCoder.encode(self.value, forKey: "value")
-    }
-
 }
 
-/** Class represents Not Equals clause for trigger methods.  */
-open class NotEqualsClauseInTrigger: NSObject, TriggerClause, BaseNotEquals {
+/** Struct represents Not Equals clause for trigger methods.  */
+public struct NotEqualsClauseInTrigger: TriggerClause, BaseNotEquals {
     public typealias EqualClauseType = EqualsClauseInTrigger
 
     /** Contained Equals clause instance. */
-    open let equals: EqualsClauseInTrigger
+    public let equals: EqualsClauseInTrigger
 
     public init(_ equals: EqualsClauseInTrigger) {
         self.equals = equals
@@ -131,52 +104,42 @@ open class NotEqualsClauseInTrigger: NSObject, TriggerClause, BaseNotEquals {
         ] as [String : Any]
     }
 
-    /** Decoder confirming `NSCoding`. */
-    public required convenience init?(coder aDecoder: NSCoder) {
-        self.init(aDecoder.decodeObject() as! EqualsClauseInTrigger)
-    }
-
-    /** Encoder confirming `NSCoding`. */
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.equals)
-    }
-
 }
 
-/** Class represents Range clause for trigger methods. */
-open class RangeClauseInTrigger: NSObject, TriggerClause, BaseRange {
+/** Struct represents Range clause for trigger methods. */
+public struct RangeClauseInTrigger: TriggerClause, BaseRange {
 
     private let lower: (limit: NSNumber, included: Bool)?
     private let upper: (limit: NSNumber, included: Bool)?
 
     /** Alias of this clause. */
-    open let alias: String
+    public let alias: String
     /** Name of a field. */
-    open let field: String
+    public let field: String
 
     /** Lower limit for an instance. */
-    open var lowerLimit: NSNumber? {
+    public var lowerLimit: NSNumber? {
         get {
             return self.lower?.limit
         }
     }
 
     /** Include or not lower limit. */
-    open var lowerIncluded: Bool? {
+    public var lowerIncluded: Bool? {
         get {
             return self.lower?.included
         }
     }
 
     /** Upper limit for an instance. */
-    open var upperLimit: NSNumber? {
+    public var upperLimit: NSNumber? {
         get {
             return self.upper?.limit
         }
     }
 
     /** Include or not upper limit. */
-    open var upperIncluded: Bool? {
+    public var upperIncluded: Bool? {
         get {
             return self.upper?.included
         }
@@ -210,7 +173,7 @@ open class RangeClauseInTrigger: NSObject, TriggerClause, BaseRange {
        included
      - Returns: An instance of `RangeClauseInTrigger`.
      */
-    open static func range(
+    public static func range(
       _ alias: String,
       field: String,
       lowerLimit: NSNumber,
@@ -233,7 +196,7 @@ open class RangeClauseInTrigger: NSObject, TriggerClause, BaseRange {
        or float.
      - Returns: An instance of `RangeClauseInTrigger`.
      */
-    open static func greaterThan(
+    public static func greaterThan(
       _ alias: String,
        field: String,
       limit: NSNumber) -> RangeClauseInTrigger
@@ -253,7 +216,7 @@ open class RangeClauseInTrigger: NSObject, TriggerClause, BaseRange {
        or float.
      - Returns: An instance of `RangeClauseInTrigger`.
      */
-    open static func greaterThanOrEqualTo(
+    public static func greaterThanOrEqualTo(
       _ alias: String,
        field: String,
       limit: NSNumber) -> RangeClauseInTrigger
@@ -272,7 +235,7 @@ open class RangeClauseInTrigger: NSObject, TriggerClause, BaseRange {
        or float.
      - Returns: An instance of `RangeClauseInTrigger`.
      */
-    open static func lessThan(
+    public static func lessThan(
       _ alias: String,
        field: String,
       limit: NSNumber) -> RangeClauseInTrigger
@@ -291,7 +254,7 @@ open class RangeClauseInTrigger: NSObject, TriggerClause, BaseRange {
        or float.
      - Returns: An instance of `RangeClauseInTrigger`.
      */
-    open static func lessThanOrEqualTo(
+    public static func lessThanOrEqualTo(
       _ alias: String,
        field: String,
       limit: NSNumber) -> RangeClauseInTrigger
@@ -319,46 +282,13 @@ open class RangeClauseInTrigger: NSObject, TriggerClause, BaseRange {
         return retval
     }
 
-    /** Decoder confirming `NSCoding`. */
-    public required convenience init?(coder aDecoder: NSCoder) {
-        let lower = aDecoder.decodeObject(forKey: "lower") as? [String : Any]
-        let upper = aDecoder.decodeObject(forKey: "upper") as? [String : Any]
-
-        if lower == nil && upper == nil {
-            fatalError("unexpected case.")
-        }
-        self.init(
-          aDecoder.decodeObject(forKey: "alias") as! String,
-          field: aDecoder.decodeObject(forKey: "field") as! String,
-          lower: lower != nil ?
-            (lower!["limit"] as! NSNumber, lower!["included"] as! Bool) : nil,
-          upper: upper != nil ?
-            (upper!["limit"] as! NSNumber, upper!["included"] as! Bool) : nil)
-    }
-
-    /** Encoder confirming `NSCoding`. */
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.alias, forKey: "alias")
-        aCoder.encode(self.field, forKey: "field")
-        if let lower = self.lower {
-            aCoder.encode(
-              ["limit": lower.limit, "included": lower.included],
-              forKey: "lower")
-        }
-        if let upper = self.upper {
-            aCoder.encode(
-              ["limit": upper.limit, "included": upper.included],
-              forKey: "upper")
-        }
-    }
-
 }
 
-/** Class represents And clause for trigger methods. */
-open class AndClauseInTrigger: NSObject, TriggerClause, BaseAnd {
+/** Struct represents And clause for trigger methods. */
+public struct AndClauseInTrigger: TriggerClause, BaseAnd {
 
     /** Clauses conjuncted with And. */
-    open internal(set) var clauses: [TriggerClause]
+    public internal(set) var clauses: [TriggerClause]
 
     /** Initialize with clauses array.
 
@@ -372,28 +302,16 @@ open class AndClauseInTrigger: NSObject, TriggerClause, BaseAnd {
 
      - Parameter clauses: Clause array for And clauses
      */
-    public convenience init(_ clause: TriggerClause...) {
+    public init(_ clause: TriggerClause...) {
         self.init(clause)
-    }
-
-    /** Decoder confirming `NSCoding`. */
-    public required convenience init?(coder aDecoder: NSCoder) {
-        self.init(aDecoder.decodeObject() as! [TriggerClause])
-    }
-
-    /** Encoder confirming `NSCoding`. */
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.clauses)
     }
 
     /** Add a clause to And clauses.
 
      - Parameter clause: Clause to be added to and clauses.
      */
-    @discardableResult
-    open func add(_ clause: TriggerClause) -> Self {
+    public mutating func add(_ clause: TriggerClause) -> Void {
         self.clauses.append(clause)
-        return self
     }
 
     /** Get And clause for trigger as a Dictionary instance
@@ -408,11 +326,11 @@ open class AndClauseInTrigger: NSObject, TriggerClause, BaseAnd {
 
 }
 
-/** Class represents Or clause for trigger methods. */
-open class OrClauseInTrigger: NSObject, TriggerClause, BaseOr {
+/** Struct represents Or clause for trigger methods. */
+public struct OrClauseInTrigger: TriggerClause, BaseOr {
 
     /** Clauses conjuncted with Or. */
-    open internal(set) var clauses: [TriggerClause]
+    public internal(set) var clauses: [TriggerClause]
 
     /** Initialize with clauses array.
 
@@ -426,28 +344,16 @@ open class OrClauseInTrigger: NSObject, TriggerClause, BaseOr {
 
      - Parameter clauses: Clause array for Or clauses
      */
-    public convenience init(_ clause: TriggerClause...) {
+    public init(_ clause: TriggerClause...) {
         self.init(clause)
-    }
-
-    /** Decoder confirming `NSCoding`. */
-    public required convenience init?(coder aDecoder: NSCoder) {
-        self.init(aDecoder.decodeObject() as! [TriggerClause])
-    }
-
-    /** Encoder confirming `NSCoding`. */
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.clauses)
     }
 
     /** Add a clause to Or clauses.
 
      - Parameter clause: Clause to be added to or clauses.
      */
-    @discardableResult
-    open func add(_ clause: TriggerClause) -> Self {
+    public mutating func add(_ clause: TriggerClause) -> Void {
         self.clauses.append(clause)
-        return self
     }
 
     /** Get Or clause for trigger as a Dictionary instance

--- a/ThingIFSDK/ThingIFSDK/TriggerClause.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggerClause.swift
@@ -16,7 +16,19 @@ public protocol TriggerClause: BaseClause {
 internal extension TriggerClause {
 
     internal func makeDictionary() -> [String : Any] {
-        fatalError("should implement makeDictionary()")
+        if type(of: self) == EqualsClauseInTrigger.self {
+            return (self as! EqualsClauseInTrigger).makeDictionary()
+        } else if type(of: self) == NotEqualsClauseInTrigger.self {
+            return (self as! NotEqualsClauseInTrigger).makeDictionary()
+        } else if type(of: self) == RangeClauseInTrigger.self {
+            return (self as! RangeClauseInTrigger).makeDictionary()
+        } else if type(of: self) == AndClauseInTrigger.self {
+            return (self as! AndClauseInTrigger).makeDictionary()
+        } else if type(of: self) == OrClauseInTrigger.self {
+            return (self as! OrClauseInTrigger).makeDictionary()
+        } else {
+            fatalError("unexpected class")
+        }
     }
 }
 

--- a/ThingIFSDK/ThingIFSDKTests/AndClauseInQueryTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/AndClauseInQueryTests.swift
@@ -279,7 +279,7 @@ class AndClauseInQueryTests: SmallTestBase {
     }
 
     func testAnd() {
-        let actual = AndClauseInQuery(
+        var actual = AndClauseInQuery(
           EqualsClauseInQuery("f", intValue: 1),
           NotEqualsClauseInQuery(EqualsClauseInQuery("f", boolValue: true)),
           RangeClauseInQuery.greaterThan("f", limit: 1))
@@ -287,7 +287,8 @@ class AndClauseInQueryTests: SmallTestBase {
         XCTAssertEqual(3, actual.clauses.count)
 
         actual.add(
-          AndClauseInQuery(EqualsClauseInQuery("f", stringValue: "str"))).add(
+          AndClauseInQuery(EqualsClauseInQuery("f", stringValue: "str")))
+        actual.add(
           OrClauseInQuery(EqualsClauseInQuery("f", stringValue: "str")))
 
         XCTAssertEqual(5, actual.clauses.count)

--- a/ThingIFSDK/ThingIFSDKTests/AndClauseInTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/AndClauseInTriggerTests.swift
@@ -149,21 +149,6 @@ class AndClauseInTriggerTests: SmallTestBase {
               expected,
               actual.makeDictionary(),
               "label \(index)")
-
-            let data: NSMutableData = NSMutableData(capacity: 1024)!;
-            let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-            actual.encode(with: coder);
-            coder.finishEncoding();
-
-            let decoder: NSKeyedUnarchiver =
-              NSKeyedUnarchiver(forReadingWith: data as Data);
-            let deserialized = AndClauseInTrigger(coder: decoder)!;
-            decoder.finishDecoding();
-
-            XCTAssertEqual(actual.clauses.count, deserialized.clauses.count)
-            assertEqualsDictionary(
-              actual.makeDictionary(),
-              deserialized.makeDictionary())
         }
     }
 
@@ -355,26 +340,11 @@ class AndClauseInTriggerTests: SmallTestBase {
               expected,
               actual.makeDictionary(),
               "label \(index)")
-
-            let data: NSMutableData = NSMutableData(capacity: 1024)!;
-            let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-            actual.encode(with: coder);
-            coder.finishEncoding();
-
-            let decoder: NSKeyedUnarchiver =
-              NSKeyedUnarchiver(forReadingWith: data as Data);
-            let deserialized = AndClauseInTrigger(coder: decoder)!;
-            decoder.finishDecoding();
-
-            XCTAssertEqual(actual.clauses.count, deserialized.clauses.count)
-            assertEqualsDictionary(
-              actual.makeDictionary(),
-              deserialized.makeDictionary())
         }
     }
 
     func testAnd() {
-        let actual = AndClauseInTrigger(
+        var actual = AndClauseInTrigger(
           EqualsClauseInTrigger("alias", field: "f", intValue: 1),
           NotEqualsClauseInTrigger(EqualsClauseInTrigger(
                                      "alias",
@@ -388,7 +358,8 @@ class AndClauseInTriggerTests: SmallTestBase {
           AndClauseInTrigger(EqualsClauseInTrigger(
                                "alias",
                                field: "f",
-                               stringValue: "str"))).add(
+                               stringValue: "str")))
+        actual.add(
           OrClauseInTrigger(EqualsClauseInTrigger(
                               "alias",
                               field: "f",
@@ -427,21 +398,5 @@ class AndClauseInTriggerTests: SmallTestBase {
               ]
             ]
           ], actual.makeDictionary())
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = AndClauseInTrigger(coder: decoder)!;
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.clauses.count, deserialized.clauses.count)
-        assertEqualsDictionary(
-          actual.makeDictionary(),
-          deserialized.makeDictionary())
-
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/EqualsClauseInTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/EqualsClauseInTriggerTests.swift
@@ -32,19 +32,6 @@ class EqualClauseInTriggerTests: SmallTestBase {
         XCTAssertEqual("alias", actualDict["alias"] as! String)
         XCTAssertEqual("f", actualDict["field"] as! String)
         XCTAssertEqual(1, actualDict["value"] as! Int)
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = EqualsClauseInTrigger(coder: decoder)!;
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.field, deserialized.field)
-        XCTAssertEqual(actual.value as! Int, deserialized.value as! Int)
     }
 
     func testEqualBoolTrue() {
@@ -60,19 +47,6 @@ class EqualClauseInTriggerTests: SmallTestBase {
         XCTAssertEqual("alias", actualDict["alias"] as! String)
         XCTAssertEqual("f", actualDict["field"] as! String)
         XCTAssertEqual(true, actualDict["value"] as! Bool)
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = EqualsClauseInTrigger(coder: decoder)!;
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.field, deserialized.field)
-        XCTAssertEqual(actual.value as! Bool, deserialized.value as! Bool)
     }
 
     func testEqualBoolFalse() {
@@ -91,19 +65,6 @@ class EqualClauseInTriggerTests: SmallTestBase {
         XCTAssertEqual("alias", actualDict["alias"] as! String)
         XCTAssertEqual("f", actualDict["field"] as! String)
         XCTAssertEqual(false, actualDict["value"] as! Bool)
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = EqualsClauseInTrigger(coder: decoder)!;
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.field, deserialized.field)
-        XCTAssertEqual(actual.value as! Bool, deserialized.value as! Bool)
     }
 
     func testEqualString() {
@@ -122,19 +83,6 @@ class EqualClauseInTriggerTests: SmallTestBase {
         XCTAssertEqual("alias", actualDict["alias"] as! String)
         XCTAssertEqual("f", actualDict["field"] as! String)
         XCTAssertEqual("string", actualDict["value"] as! String)
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = EqualsClauseInTrigger(coder: decoder)!;
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.field, deserialized.field)
-        XCTAssertEqual(actual.value as! String, deserialized.value as! String)
     }
 
 }

--- a/ThingIFSDK/ThingIFSDKTests/NotEqualsClauseInTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/NotEqualsClauseInTriggerTests.swift
@@ -64,30 +64,6 @@ class NotEqualsClauseInTriggerTests: SmallTestBase {
                   "value": expected.value
                 ]
               ], actual.makeDictionary(), label)
-
-            let data: NSMutableData = NSMutableData(capacity: 1024)!;
-            let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-            actual.encode(with: coder);
-            coder.finishEncoding();
-
-            let decoder: NSKeyedUnarchiver =
-              NSKeyedUnarchiver(forReadingWith: data as Data);
-            let deserialized = NotEqualsClauseInTrigger(coder: decoder)!;
-            decoder.finishDecoding();
-
-            XCTAssertEqual(
-              actual.equals.field,
-              deserialized.equals.field,
-              label)
-            assertEqualsAny(
-              actual.equals.value,
-              deserialized.equals.value,
-              label)
-            assertEqualsDictionary(
-              actual.makeDictionary(),
-              deserialized.makeDictionary(),
-              label)
-
         }
     }
 

--- a/ThingIFSDK/ThingIFSDKTests/OrClauseInQueryTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OrClauseInQueryTests.swift
@@ -279,7 +279,7 @@ class OrClauseInQueryTests: SmallTestBase {
     }
 
     func testOr() {
-        let actual = OrClauseInQuery(
+        var actual = OrClauseInQuery(
           EqualsClauseInQuery("f", intValue: 1),
           NotEqualsClauseInQuery(EqualsClauseInQuery("f", boolValue: true)),
           RangeClauseInQuery.greaterThan("f", limit: 1))
@@ -287,7 +287,8 @@ class OrClauseInQueryTests: SmallTestBase {
         XCTAssertEqual(3, actual.clauses.count)
 
         actual.add(
-          AndClauseInQuery(EqualsClauseInQuery("f", stringValue: "str"))).add(
+          AndClauseInQuery(EqualsClauseInQuery("f", stringValue: "str")))
+        actual.add(
           OrClauseInQuery(EqualsClauseInQuery("f", stringValue: "str")))
 
         XCTAssertEqual(5, actual.clauses.count)

--- a/ThingIFSDK/ThingIFSDKTests/OrClauseInTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/OrClauseInTriggerTests.swift
@@ -149,21 +149,6 @@ class OrClauseInTriggerTests: SmallTestBase {
               expected,
               actual.makeDictionary(),
               "label \(index)")
-
-            let data: NSMutableData = NSMutableData(capacity: 1024)!;
-            let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-            actual.encode(with: coder);
-            coder.finishEncoding();
-
-            let decoder: NSKeyedUnarchiver =
-              NSKeyedUnarchiver(forReadingWith: data as Data);
-            let deserialized = OrClauseInTrigger(coder: decoder)!;
-            decoder.finishDecoding();
-
-            XCTAssertEqual(actual.clauses.count, deserialized.clauses.count)
-            assertEqualsDictionary(
-              actual.makeDictionary(),
-              deserialized.makeDictionary())
         }
     }
 
@@ -355,26 +340,11 @@ class OrClauseInTriggerTests: SmallTestBase {
               expected,
               actual.makeDictionary(),
               "label \(index)")
-
-            let data: NSMutableData = NSMutableData(capacity: 1024)!;
-            let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-            actual.encode(with: coder);
-            coder.finishEncoding();
-
-            let decoder: NSKeyedUnarchiver =
-              NSKeyedUnarchiver(forReadingWith: data as Data);
-            let deserialized = OrClauseInTrigger(coder: decoder)!;
-            decoder.finishDecoding();
-
-            XCTAssertEqual(actual.clauses.count, deserialized.clauses.count)
-            assertEqualsDictionary(
-              actual.makeDictionary(),
-              deserialized.makeDictionary())
         }
     }
 
     func testOr() {
-        let actual = OrClauseInTrigger(
+        var actual = OrClauseInTrigger(
           EqualsClauseInTrigger("alias", field: "f", intValue: 1),
           NotEqualsClauseInTrigger(EqualsClauseInTrigger(
                                      "alias",
@@ -388,7 +358,8 @@ class OrClauseInTriggerTests: SmallTestBase {
           AndClauseInTrigger(EqualsClauseInTrigger(
                                "alias",
                                field: "f",
-                               stringValue: "str"))).add(
+                               stringValue: "str")))
+        actual.add(
           OrClauseInTrigger(EqualsClauseInTrigger(
                               "alias",
                               field: "f",
@@ -427,21 +398,5 @@ class OrClauseInTriggerTests: SmallTestBase {
               ]
             ]
           ], actual.makeDictionary())
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = OrClauseInTrigger(coder: decoder)!;
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.clauses.count, deserialized.clauses.count)
-        assertEqualsDictionary(
-          actual.makeDictionary(),
-          deserialized.makeDictionary())
-
     }
 }

--- a/ThingIFSDK/ThingIFSDKTests/RangeClauseInTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/RangeClauseInTriggerTests.swift
@@ -126,29 +126,6 @@ class RangeClauseInTriggerTests: SmallTestBase {
             dict["upperLimit"] = expected.upper?.limit
             dict["upperIncluded"] = expected.upper?.included
             assertEqualsDictionary(dict, actual.makeDictionary(), label)
-
-            let data: NSMutableData = NSMutableData(capacity: 1024)!;
-            let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-            actual.encode(with: coder);
-            coder.finishEncoding();
-
-            let decoder: NSKeyedUnarchiver =
-              NSKeyedUnarchiver(forReadingWith: data as Data);
-            let deserialized = RangeClauseInTrigger(coder: decoder)!;
-            decoder.finishDecoding();
-
-            XCTAssertEqual(actual.alias, deserialized.alias, label)
-            XCTAssertEqual(actual.field, deserialized.field, label)
-            XCTAssertEqual(actual.lowerLimit, deserialized.lowerLimit, label)
-            XCTAssertEqual(
-              actual.lowerIncluded,
-              deserialized.lowerIncluded,
-              label)
-            XCTAssertEqual(actual.upperLimit, deserialized.upperLimit, label)
-            XCTAssertEqual(
-              actual.upperIncluded,
-              deserialized.upperIncluded,
-              label)
         }
 
     }
@@ -269,34 +246,6 @@ class RangeClauseInTriggerTests: SmallTestBase {
             dict["upperLimit"] = expected.upper?.limit
             dict["upperIncluded"] = expected.upper?.included
             assertEqualsDictionary(dict, actual.makeDictionary(), label)
-
-            let data: NSMutableData = NSMutableData(capacity: 1024)!;
-            let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-            actual.encode(with: coder);
-            coder.finishEncoding();
-
-            let decoder: NSKeyedUnarchiver =
-              NSKeyedUnarchiver(forReadingWith: data as Data);
-            let deserialized = RangeClauseInTrigger(coder: decoder)!;
-            decoder.finishDecoding();
-
-            XCTAssertEqual(actual.alias, deserialized.alias, label)
-            XCTAssertEqual(actual.field, deserialized.field, label)
-            assertEqualsWithAccuracyOrNil(
-              actual.lowerLimit as? Double,
-              deserialized.lowerLimit as? Double,
-              accuracy: 0.001, label)
-            XCTAssertEqual(actual.lowerIncluded,
-                           deserialized.lowerIncluded,
-                           label)
-            assertEqualsWithAccuracyOrNil(
-              actual.upperLimit as? Double,
-              deserialized.upperLimit as? Double,
-              accuracy: 0.001, label)
-            XCTAssertEqual(
-              actual.upperIncluded,
-              deserialized.upperIncluded,
-              label)
         }
 
     }

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+TriggerClause.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+TriggerClause.swift
@@ -28,7 +28,7 @@ extension XCTestCase {
             return
         }
 
-        if type(of: expected!) !== type(of: actual!) {
+        if type(of: expected!) != type(of: actual!) {
             let errorMessage = message ??
               "Type mismatch: (\(Mirror(reflecting: expected!).subjectType), \(Mirror(reflecting: actual!).subjectType))"
             XCTFail(
@@ -36,35 +36,35 @@ extension XCTestCase {
             return
         }
 
-        if type(of: expected!) === EqualsClauseInTrigger.self {
+        if type(of: expected!) == EqualsClauseInTrigger.self {
             assertEqualsEqualsClauseInTrigger(
               expected as! EqualsClauseInTrigger,
               actual as! EqualsClauseInTrigger,
               message,
               file,
               line)
-        } else if type(of: expected!) === NotEqualsClauseInTrigger.self {
+        } else if type(of: expected!) == NotEqualsClauseInTrigger.self {
             assertEqualsNotEqualsClauseInTrigger(
               expected as! NotEqualsClauseInTrigger,
               actual as! NotEqualsClauseInTrigger,
               message,
               file,
               line)
-        } else if type(of: expected!) === RangeClauseInTrigger.self {
+        } else if type(of: expected!) == RangeClauseInTrigger.self {
             assertEqualsRangeClauseInTrigger(
               expected as! RangeClauseInTrigger,
               actual as! RangeClauseInTrigger,
               message,
               file,
               line)
-        } else if type(of: expected!) === AndClauseInTrigger.self {
+        } else if type(of: expected!) == AndClauseInTrigger.self {
             assertEqualsAndClauseInTrigger(
               expected as! AndClauseInTrigger,
               actual as! AndClauseInTrigger,
               message,
               file,
               line)
-        } else if type(of: expected!) === OrClauseInTrigger.self {
+        } else if type(of: expected!) == OrClauseInTrigger.self {
             assertEqualsOrClauseInTrigger(
               expected as! OrClauseInTrigger,
               actual as! OrClauseInTrigger,

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -265,7 +265,7 @@ extension XCTestCase {
             return
         }
 
-        if type(of: expected!) !== type(of: actual!) {
+        if type(of: expected!) != type(of: actual!) {
             let errorMessage = message ??
               "Type mismatch: (\(Mirror(reflecting: expected!).subjectType), \(Mirror(reflecting: actual!).subjectType))"
             XCTFail(
@@ -273,35 +273,35 @@ extension XCTestCase {
             return
         }
 
-        if type(of: expected!) === EqualsClauseInQuery.self {
+        if type(of: expected!) == EqualsClauseInQuery.self {
             assertEqualsEqualsClauseInQuery(
               expected as! EqualsClauseInQuery,
               actual as! EqualsClauseInQuery,
               message,
               file,
               line)
-        } else if type(of: expected!) === NotEqualsClauseInQuery.self {
+        } else if type(of: expected!) == NotEqualsClauseInQuery.self {
             assertEqualsNotEqualsClauseInQuery(
               expected as! NotEqualsClauseInQuery,
               actual as! NotEqualsClauseInQuery,
               message,
               file,
               line)
-        } else if type(of: expected!) === RangeClauseInQuery.self {
+        } else if type(of: expected!) == RangeClauseInQuery.self {
             assertEqualsRangeClauseInQuery(
               expected as! RangeClauseInQuery,
               actual as! RangeClauseInQuery,
               message,
               file,
               line)
-        } else if type(of: expected!) === AndClauseInQuery.self {
+        } else if type(of: expected!) == AndClauseInQuery.self {
             assertEqualsAndClauseInQuery(
               expected as! AndClauseInQuery,
               actual as! AndClauseInQuery,
               message,
               file,
               line)
-        } else if type(of: expected!) === OrClauseInQuery.self {
+        } else if type(of: expected!) == OrClauseInQuery.self {
             assertEqualsOrClauseInQuery(
               expected as! OrClauseInQuery,
               actual as! OrClauseInQuery,


### PR DESCRIPTION
* Clauses for trigger and clauses for query become struct.
* Remove return value form `BaseAnd.and()`
  * Struct returns value type so we can not use chaining.
* Add `mutating` keyword to `BaseAnd.and()`.
* Fix small tests and its utilities.

Related PR: #296