### PR TITLE
Trigger series classes become struct

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ServerCode.swift
+++ b/ThingIFSDK/ThingIFSDK/ServerCode.swift
@@ -7,31 +7,17 @@
 //
 
 import Foundation
-open class ServerCode : NSObject, NSCoding {
-    // MARK: - Implements NSCoding protocol
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.endpoint, forKey: "endpoint")
-        aCoder.encode(self.executorAccessToken, forKey: "executorAccessToken")
-        aCoder.encode(self.targetAppID, forKey: "targetAppID")
-        aCoder.encode(self.parameters, forKey: "parameters")
-    }
+public struct ServerCode {
 
-    // MARK: - Implements NSCoding protocol
-    public required init?(coder aDecoder: NSCoder) {
-        self.endpoint = aDecoder.decodeObject(forKey: "endpoint") as! String
-        self.executorAccessToken = aDecoder.decodeObject(forKey: "executorAccessToken") as? String
-        self.targetAppID = aDecoder.decodeObject(forKey: "targetAppID") as? String
-        self.parameters = aDecoder.decodeObject(forKey: "parameters") as? [String : Any]
-    }
-
+    // MARK: Properties
     /** Endpoint to call on servercode */
-    open let endpoint: String
+    public let endpoint: String
     /** This token will be used to call the external appID endpoint */
-    open let executorAccessToken: String?
+    public let executorAccessToken: String?
     /** If provided, servercode endpoint will be called for this appid. Otherwise same appID of trigger is used */
-    open let targetAppID: String?
+    public let targetAppID: String?
     /** Parameters to pass to the servercode function */
-    open let parameters: [String : Any]?
+    public let parameters: [String : Any]?
 
     /** Init TriggeredServerCodeResult with necessary attributes
 
@@ -40,7 +26,7 @@ open class ServerCode : NSObject, NSCoding {
      - Parameter targetAppID: If provided, servercode endpoint will be called for this appid. Otherwise same appID of trigger is used
      - Parameter parameters: Parameters to pass to the servercode function
      */
-    internal init(
+    public init(
       _ endpoint: String,
       executorAccessToken: String? = nil,
       targetAppID: String? = nil,

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -398,6 +398,8 @@ extension ThingIFAPI {
         completionHandler: @escaping (_ triggers:[Trigger]?, _ paginationKey:String?, _ error: ThingIFError?)-> Void
         )
     {
+        fatalError("TODO: implement me")
+        /*
         guard let target = self.target else {
             completionHandler(nil, nil, ThingIFError.targetNotAvailable)
             return
@@ -436,6 +438,7 @@ extension ThingIFAPI {
         })
         let operation = IoTRequestOperation(request: request)
         operationQueue.addOperation(operation)
+        */
     }
 
     func _getTrigger(
@@ -443,6 +446,8 @@ extension ThingIFAPI {
         completionHandler: @escaping (Trigger?, ThingIFError?)-> Void
         )
     {
+        fatalError("TODO: implement me")
+        /*
         guard let target = self.target else {
             completionHandler(nil, ThingIFError.targetNotAvailable)
             return
@@ -466,5 +471,6 @@ extension ThingIFAPI {
 
         let operation = IoTRequestOperation(request: request)
         operationQueue.addOperation(operation)
+        */
     }
 }

--- a/ThingIFSDK/ThingIFSDK/Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/Trigger.swift
@@ -6,37 +6,9 @@
 import Foundation
 
 /** Class represents Trigger */
-open class Trigger: Equatable, NSCoding {
+public struct Trigger {
 
-    // MARK: - Implements NSCoding protocol
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.triggerID, forKey: "triggerID")
-        aCoder.encode(self.targetID, forKey: "targetID")
-        aCoder.encode(self.predicate, forKey: "predicate")
-        aCoder.encode(self.command, forKey: "command")
-        aCoder.encode(self.serverCode, forKey: "serverCode")
-        aCoder.encode(self.enabled, forKey: "enabled")
-        aCoder.encode(self.title, forKey: "title")
-        aCoder.encode(self.triggerDescription, forKey: "triggerDescription")
-        aCoder.encode(self.metadata, forKey: "metadata")
-        
-    }
-
-    // MARK: - Implements NSCoding protocol
-    public required init(coder aDecoder: NSCoder) {
-        self.triggerID = aDecoder.decodeObject(forKey: "triggerID") as! String
-        self.targetID = aDecoder.decodeObject(forKey: "targetID") as! TypedID
-        self.enabled = aDecoder.decodeBool(forKey: "enabled")
-        self.predicate = aDecoder.decodeObject(forKey: "predicate") as! Predicate
-        self.command = aDecoder.decodeObject(forKey: "command") as? Command
-        self.serverCode = aDecoder.decodeObject(forKey: "serverCode") as? ServerCode
-        self.title = aDecoder.decodeObject(forKey: "title") as? String
-        self.triggerDescription = aDecoder.decodeObject(forKey: "triggerDescription") as? String
-        self.metadata = aDecoder.decodeObject(forKey: "metadata") as? Dictionary<String, Any>
-        // TODO: add aditional decoder
-    }
-    
-    var triggersWhat: TriggersWhat? {
+    public var triggersWhat: TriggersWhat? {
         get {
             if self.command != nil {
                 return TriggersWhat.command
@@ -48,79 +20,30 @@ open class Trigger: Equatable, NSCoding {
         }
     }
 
-    class func triggerWithNSDict(_ targetID: TypedID, triggerDict: NSDictionary) -> Trigger?{
-        fatalError("TODO: implement me")
-        /*
-        let triggerID = triggerDict["triggerID"] as? String
-        let disabled = triggerDict["disabled"] as? Bool
-        var predicate: Predicate?
-        var command: Command?
-        var serverCode: ServerCode?
-        var trigger: Trigger?
-
-        if let commandDict = triggerDict["command"] as? NSDictionary {
-            command = Command.commandWithNSDictionary(commandDict)
-        }
-        if let serverCodeDict = triggerDict["serverCode"] as? NSDictionary {
-            serverCode = ServerCode.serverCodeWithNSDictionary(serverCodeDict)
-        }
-
-        if let predicateDict = triggerDict["predicate"] as? NSDictionary{
-            if let eventSourceString = predicateDict["eventSource"] as? String{
-                if let eventSource = EventSource(rawValue: eventSourceString){
-                    switch eventSource {
-                    case EventSource.states:
-                        fatalError("We should reimplement this.")
-                        // predicate = StatePredicate.statePredicateWithNSDict(predicateDict)
-                        break
-                    case EventSource.schedule:
-                        predicate = SchedulePredicate(predicateDict["schedule"] as! String)
-                        break
-                    case EventSource.scheduleOnce:
-                        if let scheduleAtMilis = (predicateDict["scheduleAt"] as? NSNumber)?.doubleValue {
-                            predicate = ScheduleOncePredicate(Date(timeIntervalSince1970: scheduleAtMilis/1000))
-                        }
-                        break
-                    }
-                }
-            }
-        }
-
-        let title = triggerDict["title"] as? String
-        let triggerDescription = triggerDict["description"] as? String
-        let metadata = triggerDict["metadata"] as? Dictionary<String, Any>
-
-        if triggerID != nil && predicate != nil && command != nil && disabled != nil{
-            trigger = Trigger(triggerID: triggerID!, targetID: targetID, enabled: !(disabled!), predicate: predicate!, command: command!, title: title, triggerDescription: triggerDescription, metadata: metadata)
-        }
-        if triggerID != nil && predicate != nil && serverCode != nil && disabled != nil{
-            trigger = Trigger(triggerID: triggerID!, targetID: targetID, enabled: !(disabled!), predicate: predicate!, serverCode: serverCode!, title: title, triggerDescription: triggerDescription, metadata: metadata)
-        }
-        
-        return trigger
-        */
-    }
-
     /** ID of the Trigger */
-    open let triggerID: String
+    public let triggerID: String
     /** ID of the Trigger target */
-    open let targetID: TypedID
+    public let targetID: TypedID
     /** Flag indicate whether the Trigger is enabled */
-    open let enabled: Bool
+    public let enabled: Bool
     /** Predicate of the Trigger */
-    open let predicate: Predicate
+    public let predicate: Predicate
     /** Command to be fired */
-    open let command: Command?
+    public let command: Command?
     /** ServerCode to be fired */
-    open let serverCode: ServerCode?
+    public let serverCode: ServerCode?
     /** Title of the Trigger */
-    open let title: String?
+    public let title: String?
     /** Description of the Trigger */
-    open let triggerDescription: String?
+    public let triggerDescription: String?
     /** Metadata of the Trigger */
-    open let metadata: Dictionary<String, Any>?
+    public let metadata: Dictionary<String, Any>?
 
     /** Init Trigger with Command
+
+     Developers rarely use this initializer. If you want to recreate
+     same instance from stored data or transmitted data, you can use
+     this method.
 
     - Parameter triggerID: ID of trigger
     - Parameter targetID: ID of trigger target
@@ -128,7 +51,16 @@ open class Trigger: Equatable, NSCoding {
     - Parameter predicate: Predicate instance
     - Parameter command: Command instance
     */
-    internal init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, command: Command, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, Any>? = nil) {
+    public init(
+      _ triggerID: String,
+      targetID: TypedID,
+      enabled: Bool,
+      predicate: Predicate,
+      command: Command,
+      title: String? = nil,
+      triggerDescription: String? = nil,
+      metadata: Dictionary<String, Any>? = nil)
+    {
         self.triggerID = triggerID
         self.targetID = targetID
         self.enabled = enabled
@@ -139,15 +71,29 @@ open class Trigger: Equatable, NSCoding {
         self.triggerDescription = triggerDescription
         self.metadata = metadata
     }
+
     /** Init Trigger with Server code
-     
+
+     Developers rarely use this initializer. If you want to recreate
+     same instance from stored data or transmitted data, you can use
+     this method.
+
      - Parameter triggerID: ID of trigger
      - Parameter targetID: ID of trigger target
      - Parameter enabled: True to enable trigger
      - Parameter predicate: Predicate instance
      - Parameter serverCode: ServerCode instance
      */
-    internal init(triggerID: String, targetID: TypedID, enabled: Bool, predicate: Predicate, serverCode: ServerCode, title: String? = nil, triggerDescription: String? = nil, metadata: Dictionary<String, Any>? = nil) {
+    public init(
+      _ triggerID: String,
+      targetID: TypedID,
+      enabled: Bool,
+      predicate: Predicate,
+      serverCode: ServerCode,
+      title: String? = nil,
+      triggerDescription: String? = nil,
+      metadata: Dictionary<String, Any>? = nil)
+    {
         self.triggerID = triggerID
         self.targetID = targetID
         self.enabled = enabled
@@ -157,20 +103,6 @@ open class Trigger: Equatable, NSCoding {
         self.title = title
         self.triggerDescription = triggerDescription
         self.metadata = metadata
-    }
-
-    open func isEqual(_ object: Any?) -> Bool {
-        guard let aTrigger = object as? Trigger else{
-            return false
-        }
-
-        return self.enabled == aTrigger.enabled &&
-            self.command == aTrigger.command &&
-            self.serverCode == aTrigger.serverCode
-    }
-
-    public static func == (left: Trigger, right: Trigger) -> Bool {
-        return left.isEqual(right)
     }
 
 }

--- a/ThingIFSDK/ThingIFSDK/Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/Trigger.swift
@@ -50,11 +50,11 @@ public struct Trigger {
     - Parameter enabled: True to enable trigger
     - Parameter predicate: Predicate instance
     - Parameter command: Command instance
-    - Parameter title: Title of a command. This should be equal or
+    - Parameter title: Title of a trigger. This should be equal or
       less than 50 characters.
-    - Parameter triggerDescription: Description of a comand. This should be
-      equal or less than 200 characters.
-    - Parameter metadata: Meta data of a command.
+    - Parameter triggerDescription: Description of a trigger. This
+      should be equal or less than 200 characters.
+    - Parameter metadata: Meta data of a trigger.
     */
     public init(
       _ triggerID: String,
@@ -88,11 +88,11 @@ public struct Trigger {
      - Parameter enabled: True to enable trigger
      - Parameter predicate: Predicate instance
      - Parameter serverCode: ServerCode instance
-     - Parameter title: Title of a command. This should be equal or
+     - Parameter title: Title of a trigger. This should be equal or
        less than 50 characters.
-     - Parameter triggerDescription: Description of a comand. This should be
-       equal or less than 200 characters.
-     - Parameter metadata: Meta data of a command.
+     - Parameter triggerDescription: Description of a trigger. This
+       should be equal or less than 200 characters.
+     - Parameter metadata: Meta data of a trigger.
      */
     public init(
       _ triggerID: String,

--- a/ThingIFSDK/ThingIFSDK/Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/Trigger.swift
@@ -50,6 +50,11 @@ public struct Trigger {
     - Parameter enabled: True to enable trigger
     - Parameter predicate: Predicate instance
     - Parameter command: Command instance
+    - Parameter title: Title of a command. This should be equal or
+      less than 50 characters.
+    - Parameter triggerDescription: Description of a comand. This should be
+      equal or less than 200 characters.
+    - Parameter metadata: Meta data of a command.
     */
     public init(
       _ triggerID: String,
@@ -83,6 +88,11 @@ public struct Trigger {
      - Parameter enabled: True to enable trigger
      - Parameter predicate: Predicate instance
      - Parameter serverCode: ServerCode instance
+     - Parameter title: Title of a command. This should be equal or
+       less than 50 characters.
+     - Parameter triggerDescription: Description of a comand. This should be
+       equal or less than 200 characters.
+     - Parameter metadata: Meta data of a command.
      */
     public init(
       _ triggerID: String,

--- a/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggeredServerCodeResult.swift
@@ -90,49 +90,33 @@ public class TriggeredServerCodeResult {
 
 }
 
-open class ServerError: NSObject, NSCoding {
-    
-    // MARK: - Implements NSCoding protocol
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.errorMessage, forKey: "errorMessage")
-        aCoder.encode(self.errorCode, forKey: "errorCode")
-        aCoder.encode(self.detailMessage, forKey: "detailMessage")
-    }
-    
-    // MARK: - Implements NSCoding protocol
-    public required init(coder aDecoder: NSCoder) {
-        self.errorMessage = aDecoder.decodeObject(forKey: "errorMessage") as? String
-        self.errorCode = aDecoder.decodeObject(forKey: "errorCode") as? String
-        self.detailMessage = aDecoder.decodeObject(forKey: "detailMessage") as? String
-    }
-    
-    open let errorMessage: String?
-    open let errorCode: String?
-    open let detailMessage: String?
-    
-    init(errorMessage: String?, errorCode: String?, detailMessage: String?) {
+public struct ServerError {
+
+    /** Error message. */
+    public let errorMessage: String?
+    /** Error code. */
+    public let errorCode: String?
+    /** Detail message. */
+    public let detailMessage: String?
+
+    /** Initialize `ServerError`.
+
+     Developers rarely use this initializer. If you want to recreate
+     same instance from stored data or transmitted data, you can use
+     this method.
+
+     - Parameter errorMessage: Error message.
+     - Parameter errorCode: Error can.
+     - Parameter detailMessage: Detail message.
+     */
+    public init(
+      _ errorMessage: String?,
+      errorCode: String?,
+      detailMessage: String?)
+    {
         self.errorMessage = errorMessage
         self.errorCode = errorCode
         self.detailMessage = detailMessage
-    }
-    
-    open override func isEqual(_ object: Any?) -> Bool {
-        guard let aResult = object as? ServerError else{
-            return false
-        }
-        return self.errorMessage == aResult.errorMessage && self.errorCode == aResult.errorCode && self.detailMessage == aResult.detailMessage
-    }
-    
-    class func errorWithNSDict(_ errorDict: NSDictionary) -> ServerError?{
-        let errorMessage = errorDict["errorMessage"] as? String
-        let details = errorDict["details"] as? NSDictionary
-        var errorCode: String?
-        var detailMessage: String?
-        if details != nil {
-            errorCode = details!["errorCode"] as? String
-            detailMessage = details!["message"] as? String
-        }
-        return ServerError(errorMessage: errorMessage, errorCode: errorCode, detailMessage: detailMessage)
     }
 
 }

--- a/ThingIFSDK/ThingIFSDKTests/ServerCodeTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ServerCodeTests.swift
@@ -30,23 +30,6 @@ class ServerCodeTests: SmallTestBase {
         XCTAssertEqual("executorAccessToken", actual.executorAccessToken)
         XCTAssertEqual("targetAppID", actual.targetAppID)
         assertEqualsDictionary(["key" : "value"], actual.parameters)
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = ServerCode(coder: decoder)!
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.endpoint, deserialized.endpoint)
-        XCTAssertEqual(
-          actual.executorAccessToken,
-          deserialized.executorAccessToken)
-        XCTAssertEqual(actual.targetAppID, deserialized.targetAppID)
-        assertEqualsDictionary(actual.parameters, deserialized.parameters)
     }
 
     func testOptionalNil() {
@@ -56,23 +39,6 @@ class ServerCodeTests: SmallTestBase {
         XCTAssertNil(actual.executorAccessToken)
         XCTAssertNil(actual.targetAppID)
         XCTAssertNil(actual.parameters)
-
-        let data: NSMutableData = NSMutableData(capacity: 1024)!;
-        let coder: NSKeyedArchiver = NSKeyedArchiver(forWritingWith: data);
-        actual.encode(with: coder);
-        coder.finishEncoding();
-
-        let decoder: NSKeyedUnarchiver =
-          NSKeyedUnarchiver(forReadingWith: data as Data);
-        let deserialized = ServerCode(coder: decoder)!
-        decoder.finishDecoding();
-
-        XCTAssertEqual(actual.endpoint, deserialized.endpoint)
-        XCTAssertEqual(
-          actual.executorAccessToken,
-          deserialized.executorAccessToken)
-        XCTAssertEqual(actual.targetAppID, deserialized.targetAppID)
-        assertEqualsDictionary(actual.parameters, deserialized.parameters)
     }
 
 }


### PR DESCRIPTION
* `Trigger` becomes struct
  * Remove a redundant method
  * Remove `Equatable` and `NSCoding` protocol
  * make initializers public
* `ServerCode` becomes struct.
  * Remove `NSCoding`.
* `ServerError` becomes struct.
  * Remove `NSCoding`.
  * Make an initializer public.
  * Remove class method `errorWithNSDict`. This is not used.

Related PR: #296 