### PR TITLE
Refactor makeDictionary in clauses

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		B6AC4A1A1D991CE1001A80DE /* TriggeredCommandForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AC4A191D991CE1001A80DE /* TriggeredCommandForm.swift */; };
 		B6AC4A1C1D991DF2001A80DE /* TriggerOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AC4A1B1D991DF2001A80DE /* TriggerOptions.swift */; };
 		B6AFD02C1E680D9C0066B4AD /* XCTest+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AFD02B1E680D9C0066B4AD /* XCTest+Equatable.swift */; };
+		B6AFD0311E69542B0066B4AD /* Dictionarable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AFD0301E69542B0066B4AD /* Dictionarable.swift */; };
 		B6B0A67A1E63EAA100133788 /* CommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B0A6791E63EAA100133788 /* CommandTests.swift */; };
 		B6B0A67E1E640D1000133788 /* KiiAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B0A67D1E640D1000133788 /* KiiAppTests.swift */; };
 		B6B0A6801E64170600133788 /* ServerCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B0A67F1E64170600133788 /* ServerCodeTests.swift */; };
@@ -226,6 +227,7 @@
 		B6AC4A191D991CE1001A80DE /* TriggeredCommandForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TriggeredCommandForm.swift; sourceTree = "<group>"; };
 		B6AC4A1B1D991DF2001A80DE /* TriggerOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TriggerOptions.swift; sourceTree = "<group>"; };
 		B6AFD02B1E680D9C0066B4AD /* XCTest+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTest+Equatable.swift"; sourceTree = "<group>"; };
+		B6AFD0301E69542B0066B4AD /* Dictionarable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionarable.swift; sourceTree = "<group>"; };
 		B6B0A6791E63EAA100133788 /* CommandTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandTests.swift; sourceTree = "<group>"; };
 		B6B0A67D1E640D1000133788 /* KiiAppTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KiiAppTests.swift; sourceTree = "<group>"; };
 		B6B0A67F1E64170600133788 /* ServerCodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerCodeTests.swift; sourceTree = "<group>"; };
@@ -422,6 +424,7 @@
 			children = (
 				7D36B6621BD4D03100D9B821 /* Logger.swift */,
 				747EB4B91C858BFC00E30C31 /* SDKVersion.swift */,
+				B6AFD0301E69542B0066B4AD /* Dictionarable.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -656,6 +659,7 @@
 				B6F64E1B1E35EA1C00824B4A /* QueryClause.swift in Sources */,
 				7D36B6811BD4D03100D9B821 /* OperationObserver.swift in Sources */,
 				B6F64E171E35E24100824B4A /* BaseClause.swift in Sources */,
+				B6AFD0311E69542B0066B4AD /* Dictionarable.swift in Sources */,
 				7D36B66F1BD4D03100D9B821 /* IoTRequestOperation.swift in Sources */,
 				D5521C761CCDFE7600037C9F /* ServerCode.swift in Sources */,
 				A56B0A431C5B43B100E653EF /* TriggeredServerCodeResult.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/TriggerClause.swift
+++ b/ThingIFSDK/ThingIFSDK/TriggerClause.swift
@@ -13,25 +13,6 @@ public protocol TriggerClause: BaseClause {
 
 }
 
-internal extension TriggerClause {
-
-    internal func makeDictionary() -> [String : Any] {
-        if type(of: self) == EqualsClauseInTrigger.self {
-            return (self as! EqualsClauseInTrigger).makeDictionary()
-        } else if type(of: self) == NotEqualsClauseInTrigger.self {
-            return (self as! NotEqualsClauseInTrigger).makeDictionary()
-        } else if type(of: self) == RangeClauseInTrigger.self {
-            return (self as! RangeClauseInTrigger).makeDictionary()
-        } else if type(of: self) == AndClauseInTrigger.self {
-            return (self as! AndClauseInTrigger).makeDictionary()
-        } else if type(of: self) == OrClauseInTrigger.self {
-            return (self as! OrClauseInTrigger).makeDictionary()
-        } else {
-            fatalError("unexpected class")
-        }
-    }
-}
-
 /** Struct represents Equals clause for trigger methods. */
 public struct EqualsClauseInTrigger: TriggerClause, BaseEquals {
 
@@ -78,7 +59,9 @@ public struct EqualsClauseInTrigger: TriggerClause, BaseEquals {
     public init(_ alias: String, field: String, boolValue: Bool) {
         self.init(alias, field: field, value: boolValue as AnyObject)
     }
+}
 
+extension EqualsClauseInTrigger: Dictionarable {
     /** Get Equals clause for trigger as a Dictionary instance
 
      - Returns: A Dictionary instance.
@@ -104,7 +87,9 @@ public struct NotEqualsClauseInTrigger: TriggerClause, BaseNotEquals {
     public init(_ equals: EqualsClauseInTrigger) {
         self.equals = equals
     }
+}
 
+extension NotEqualsClauseInTrigger: Dictionarable {
     /** Get Not Equals clause for trigger as a Dictionary instance
 
      - Returns: A Dictionary instance.
@@ -276,7 +261,9 @@ public struct RangeClauseInTrigger: TriggerClause, BaseRange {
           field: field,
           upper: (limit, true))
     }
+}
 
+extension RangeClauseInTrigger: Dictionarable {
     /** Get Range clause for trigger as a Dictionary instance
 
      - Returns: A Dictionary instance.
@@ -287,10 +274,10 @@ public struct RangeClauseInTrigger: TriggerClause, BaseRange {
           "alias": alias,
           "field": self.field
         ]
-        retval["upperLimit"] = self.upper?.limit
-        retval["upperIncluded"] = self.upper?.included
-        retval["lowerLimit"] = self.lower?.limit
-        retval["lowerIncluded"] = self.lower?.included
+        retval["upperLimit"] = self.upperLimit
+        retval["upperIncluded"] = self.upperIncluded
+        retval["lowerLimit"] = self.lowerLimit
+        retval["lowerIncluded"] = self.lowerIncluded
         return retval
     }
 
@@ -325,15 +312,19 @@ public struct AndClauseInTrigger: TriggerClause, BaseAnd {
     public mutating func add(_ clause: TriggerClause) -> Void {
         self.clauses.append(clause)
     }
+}
 
+extension AndClauseInTrigger: Dictionarable {
     /** Get And clause for trigger as a Dictionary instance
 
      - Returns: A Dictionary instance.
      */
     internal func makeDictionary() -> [ String : Any ] {
-        var clauses: [[String : Any]] = []
-        self.clauses.forEach { clauses.append($0.makeDictionary()) }
-        return ["type": "and", "clauses": clauses] as [String : Any]
+        return [
+          "type": "and",
+          "clauses":
+            self.clauses.map {($0 as! Dictionarable).makeDictionary()}
+        ] as [String : Any]
     }
 
 }
@@ -367,15 +358,19 @@ public struct OrClauseInTrigger: TriggerClause, BaseOr {
     public mutating func add(_ clause: TriggerClause) -> Void {
         self.clauses.append(clause)
     }
+}
 
+extension OrClauseInTrigger: Dictionarable {
     /** Get Or clause for trigger as a Dictionary instance
 
      - Returns: A Dictionary instance.
      */
     internal func makeDictionary() -> [ String : Any ] {
-        var clauses: [[String : Any]] = []
-        self.clauses.forEach { clauses.append($0.makeDictionary()) }
-        return ["type": "or", "clauses": clauses] as [String : Any]
+        return [
+          "type": "or",
+          "clauses":
+            self.clauses.map {($0 as! Dictionarable).makeDictionary()}
+        ] as [String : Any]
     }
 
 }

--- a/ThingIFSDK/ThingIFSDK/Utils/Dictionarable.swift
+++ b/ThingIFSDK/ThingIFSDK/Utils/Dictionarable.swift
@@ -1,0 +1,15 @@
+//
+//  Dictionarable.swift
+//  ThingIFSDK
+//
+//  Created on 2017/03/03.
+//  Copyright (c) 2017 Kii. All rights reserved.
+//
+
+import Foundation
+
+internal protocol Dictionarable {
+
+    func makeDictionary() -> [String : Any]
+
+}


### PR DESCRIPTION
I implemented `makeDictionary()` methods for each clause structures. I also implemented `makeDictionary()` on `QueryClause` and `TriggerClause` but it is not good way. The code is below:

```swift
internal extension QueryClause {

    internal func makeDictionary() -> [String : Any] {
        if type(of: self) == EqualsClauseInQuery.self {
            return (self as! EqualsClauseInQuery).makeDictionary()
        } else if type(of: self) == NotEqualsClauseInQuery.self {
            return (self as! NotEqualsClauseInQuery).makeDictionary()
        } else if type(of: self) == RangeClauseInQuery.self {
            return (self as! RangeClauseInQuery).makeDictionary()
        } else if type(of: self) == AndClauseInQuery.self {
            return (self as! AndClauseInQuery).makeDictionary()
        } else if type(of: self) == OrClauseInQuery.self {
            return (self as! OrClauseInQuery).makeDictionary()
        } else {
            fatalError("unexpected class")
        }
    }
}
```

Obviously this is not good :( 

To remove that method, I introduced `Dictionarable` protocol.`Dictionarable` protocol is internal. All clauses implements `Dictionarable` protocol by extension. As as result, we can use `makeDictionary()` as `Dictionarable` protocol

Related PR: #296 
