### PR TITLE
Add a method to put http request operation to operation queue.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+OnBoard.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+OnBoard.swift
@@ -140,62 +140,49 @@ extension ThingIFAPI {
       vendorThingID: String? = nil,
       completionHandler: @escaping (Target?, ThingIFError?) -> Void) -> Void
     {
-        let data: Data
-        do {
-            data = try JSONSerialization.data(
-              withJSONObject: requestBody,
-              options: JSONSerialization.WritingOptions(rawValue: 0))
-        } catch {
-            kiiSevereLog("ThingIFError.JSON_PARSE_ERROR")
-            completionHandler(nil, ThingIFError.jsonParseError)
-            return
-        }
+        self.operationQueue.addHttpRequestOperation(
+          .post,
+          url: "\(self.baseURL)/thing-if/apps/\(self.appID)/onboardings",
+          requestHeader:
+            self.defaultHeader + ["Content-Type" : mediaType.rawValue],
+          requestBody: requestBody,
+          failureBeforeExecutionHandler: { completionHandler(nil, $0) }) {
+            response, error in
 
-        operationQueue.addOperation(
-          IoTRequestOperation(
-            request: buildDefaultRequest(
-              .post,
-              urlString:
-                "\(self.baseURL)/thing-if/apps/\(self.appID)/onboardings",
-              requestHeaderDict:
-                self.defaultHeader + ["Content-Type" : mediaType.rawValue],
-              requestBodyData: data) { response, error in
-                var target: Target?
-                var error2 = error
-                if error == nil {
-                    do {
-                        /* TODO:
-                         Idealy, server should send vendorThingID as
-                         response of onboarding, and SDK should use
-                         the received vendorThingID. However, current
-                         server implementation does not send
-                         vendorThingID. So we used IDString if it is
-                         vendorThingID, otherwise we set it empty
-                         string. This behavior should be fixed after
-                         server fixed.
-                        */
-                        self.target = try makeTargetThing(
-                          response!,
-                          layoutPosition: layoutPosition ?? .standalone,
-                          vendorThingID: vendorThingID)
-                        self.saveToUserDefault()
-                        target = self.target
-                    } catch (ThingIFError.jsonParseError) {
-                        // This is unexpected case.
-                        // If response body is not unexpected format,
-                        // this error is thrown
-                        kiiSevereLog("unexpected error")
-                        error2 = ThingIFError.jsonParseError
-                    } catch {
-                        // This case must not happen.
-                        kiiSevereLog("must not happen")
-                        error2 = ThingIFError.jsonParseError
-                    }
+            var target: Target?
+            var error2 = error
+            if error == nil {
+                do {
+                    /* TODO:
+                     Idealy, server should send vendorThingID as
+                     response of onboarding, and SDK should use
+                     the received vendorThingID. However, current
+                     server implementation does not send
+                     vendorThingID. So we used IDString if it is
+                     vendorThingID, otherwise we set it empty
+                     string. This behavior should be fixed after
+                     server fixed.
+                     */
+                    self.target = try makeTargetThing(
+                      response!,
+                      layoutPosition: layoutPosition ?? .standalone,
+                      vendorThingID: vendorThingID)
+                    self.saveToUserDefault()
+                    target = self.target
+                } catch (ThingIFError.jsonParseError) {
+                    // This is unexpected case.
+                    // If response body is not unexpected format,
+                    // this error is thrown
+                    kiiSevereLog("unexpected error")
+                    error2 = ThingIFError.jsonParseError
+                } catch {
+                    // This case must not happen.
+                    kiiSevereLog("must not happen")
+                    error2 = ThingIFError.jsonParseError
                 }
-                DispatchQueue.main.async { completionHandler(target, error2) }
             }
-          )
-        )
+            DispatchQueue.main.async { completionHandler(target, error2) }
+        }
     }
 
 }

--- a/ThingIFSDK/ThingIFSDK/Utils/Utilities.swift
+++ b/ThingIFSDK/ThingIFSDK/Utils/Utilities.swift
@@ -22,3 +22,40 @@ internal func +<Key, Value>(
 internal func +=<Key, Value>(left: inout [Key : Value], right: [Key : Value]) {
     right.forEach { left[$0.0] = $0.1 }
 }
+
+internal extension OperationQueue {
+
+    func addHttpRequestOperation(
+      _ method: HTTPMethod,
+      url: String,
+      requestHeader: [String : String],
+      requestBody: [String : Any],
+      failureBeforeExecutionHandler: @escaping (_ error: ThingIFError) -> Void,
+      completionHandler:
+        @escaping (_ response: [String : Any]?,
+                   _ error: ThingIFError?) -> Void) -> Void
+    {
+        let data: Data
+        do {
+            data = try JSONSerialization.data(
+              withJSONObject: requestBody,
+              options: JSONSerialization.WritingOptions(rawValue: 0))
+        } catch let error {
+            kiiSevereLog(error)
+            failureBeforeExecutionHandler(ThingIFError.jsonParseError)
+            return
+        }
+
+        self.addOperation(
+          IoTRequestOperation(
+            request: buildDefaultRequest(
+              method,
+              urlString: url,
+              requestHeaderDict: requestHeader,
+              requestBodyData: data) { response, error in
+                completionHandler(response, error)
+            }
+          )
+        )
+    }
+}


### PR DESCRIPTION
In thing-if iOSSDK, creating http request is a little bit bothersome task. It takes following procedures:

1. Create `Data` object from Dictionary. This requires catching error.
1. Create `IoTRequestOperation` object.
1. Add object created at 2 to `OperationQueue`.

To simply this procedures, I add ad method to execute above 3 tasks.

Related PR: #296 