### PR TITLE
Fix AliasAction.

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		B63FC8B51CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63FC8B41CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift */; };
 		B645506C1E78ECC600D8FACF /* GatewayAPILoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B645506B1E78ECC600D8FACF /* GatewayAPILoginTests.swift */; };
 		B645506E1E79087F00D8FACF /* GatewayAPIOnboardGatewayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B645506D1E79087F00D8FACF /* GatewayAPIOnboardGatewayTests.swift */; };
+		B64550701E79467600D8FACF /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = B645506F1E79467600D8FACF /* Action.swift */; };
 		B66729351E724D7B007E3019 /* Serializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66729341E724D7B007E3019 /* Serializable.swift */; };
 		B66729371E72A0BA007E3019 /* ThingIFAPIPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66729361E72A0BA007E3019 /* ThingIFAPIPersistenceTests.swift */; };
 		B673C0051CF81CEC00AEF519 /* TestSetting.plist in Resources */ = {isa = PBXBuildFile; fileRef = B673C0041CF81CEC00AEF519 /* TestSetting.plist */; };
@@ -228,6 +229,7 @@
 		B63FC8B41CEEDCD50042C747 /* PostNewTriggerForSchedulePredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostNewTriggerForSchedulePredicateTests.swift; sourceTree = "<group>"; };
 		B645506B1E78ECC600D8FACF /* GatewayAPILoginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPILoginTests.swift; sourceTree = "<group>"; };
 		B645506D1E79087F00D8FACF /* GatewayAPIOnboardGatewayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPIOnboardGatewayTests.swift; sourceTree = "<group>"; };
+		B645506F1E79467600D8FACF /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		B66729341E724D7B007E3019 /* Serializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serializable.swift; sourceTree = "<group>"; };
 		B66729361E72A0BA007E3019 /* ThingIFAPIPersistenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThingIFAPIPersistenceTests.swift; sourceTree = "<group>"; };
 		B673C0041CF81CEC00AEF519 /* TestSetting.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TestSetting.plist; sourceTree = "<group>"; };
@@ -412,6 +414,7 @@
 				B6A047281E3EFD6500D85A1E /* GroupedHistoryStatesQuery.swift */,
 				B6A0472A1E3F048700D85A1E /* GroupedHistoryStates.swift */,
 				B6A86CB31E71507D00F9C41B /* ThingIFAPI+Persistence.swift */,
+				B645506F1E79467600D8FACF /* Action.swift */,
 			);
 			path = ThingIFSDK;
 			sourceTree = "<group>";
@@ -732,6 +735,7 @@
 				7D36B6801BD4D03100D9B821 /* OperationErrors.swift in Sources */,
 				D5636AFB1CE1E9E000760564 /* ScheduleOncePredicate.swift in Sources */,
 				7D36B68B1BD4D03100D9B821 /* Logger.swift in Sources */,
+				B64550701E79467600D8FACF /* Action.swift in Sources */,
 				B6AC4A1A1D991CE1001A80DE /* TriggeredCommandForm.swift in Sources */,
 				7D36B6BC1BD4D43700D9B821 /* ThingIFAPI+GetState.swift in Sources */,
 				7D36B6BD1BD4D43700D9B821 /* ThingIFAPI+OnBoard.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/Action.swift
+++ b/ThingIFSDK/ThingIFSDK/Action.swift
@@ -22,8 +22,8 @@ public struct Action {
     /** Initializer of Action instance.
 
      - Parameter name: Name of an action
-     - Parameter value: Value of an action. This must be number, bool,
-       string or json compatible array or dictionary
+     - Parameter value: Value of an action. Type must be any of
+       number, bool, string or json compatible array/dictionary
      */
     public init(_ name: String, value: Any) {
         self.name = name

--- a/ThingIFSDK/ThingIFSDK/Action.swift
+++ b/ThingIFSDK/ThingIFSDK/Action.swift
@@ -1,0 +1,32 @@
+//
+//  Action.swift
+//  ThingIFSDK
+//
+//  Created on 2017/03/15.
+//  Copyright (c) 2017 Kii. All rights reserved.
+//
+
+import Foundation
+
+/** Action of a command. */
+public struct Action {
+
+    // MARK: - Properties
+
+    /** Name of an action. */
+    public let name: String
+    /** Value of an action. */
+    public let value: Any
+
+    // MARK: - Initializing Action instance.
+    /** Initializer of Action instance.
+
+     - Parameter name: Name of an action
+     - Parameter value: Value of an action. This must be number, bool,
+       string or json compatible array or dictionary
+     */
+    public init(_ name: String, value: Any) {
+        self.name = name
+        self.value = value
+    }
+}

--- a/ThingIFSDK/ThingIFSDK/AliasAction.swift
+++ b/ThingIFSDK/ThingIFSDK/AliasAction.swift
@@ -16,16 +16,20 @@ public struct AliasAction {
     /** Name of an alias. */
     public let alias: String
     /** Action of this alias. */
-    public let action: [String : Any]
+    public let actions: [(name: String, value: Any)]
 
     // MARK: - Initializing CommandForm instance.
     /** Initializer of AliasAction instance.
 
      - Parameter alias: Name of an alias.
-     - Parameter action: Action of this alias. This should be able to convert to JSON.
+     - Parameter actions: Actions of this alias.
+       - name: name of an action
+       - value: value of an action. This must be number, bool, string
+         or json compatible array or dictionary
      */
-    public init(_ alias: String, action: [String : Any]) {
+
+    public init(_ alias: String, actions: [(name: String, value: Any)]) {
         self.alias = alias
-        self.action = action
+        self.actions = actions
     }
 }

--- a/ThingIFSDK/ThingIFSDK/AliasAction.swift
+++ b/ThingIFSDK/ThingIFSDK/AliasAction.swift
@@ -16,19 +16,16 @@ public struct AliasAction {
     /** Name of an alias. */
     public let alias: String
     /** Action of this alias. */
-    public let actions: [(name: String, value: Any)]
+    public let actions: [Action]
 
     // MARK: - Initializing CommandForm instance.
     /** Initializer of AliasAction instance.
 
      - Parameter alias: Name of an alias.
-     - Parameter actions: Actions of this alias.
-       - name: name of an action
-       - value: value of an action. This must be number, bool, string
-         or json compatible array or dictionary
+     - Parameter actions: Actions of this alias. must not be empty.
      */
 
-    public init(_ alias: String, actions: [(name: String, value: Any)]) {
+    public init(_ alias: String, actions: [Action]) {
         self.alias = alias
         self.actions = actions
     }


### PR DESCRIPTION
***This is API change PR.***

From [this specification](https://docs.google.com/document/edit?hgd=1&id=1TLZvjKvwSQ_C66XcC7haef5-PtO639y2fjhQIlOBCYE#heading=h.1k2ktfg9t87a), an action of post new command request is like following:

```json
     { 
       "lampAlias":[
         {"turnPower":true},
         {"setBrightness":3000}
       ]
     }
```

We designed `AliasAction` as a struct representing the json, however, `AliasAction` can not represent the json.

We defined `action` as a dictionary but actual action is an array of object. To solve this issue, I changed `action` property from dictionary to array of tuple.

We can create a struct to represent the action but tuple might be more easy to write applications.

If we try to write an array of action with class, it may be like following:

```swift
let actions = [Action("turnPower", value: true), Action("setBrightness", value: 3000)]
```

but if we adopt tuple, it becomes following:
```swift
let action = [("turnPower", true), ("setBrightness", 3000)]
```

Related PR: #296 