### PR TITLE
Add test for Action struct

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		B645506C1E78ECC600D8FACF /* GatewayAPILoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B645506B1E78ECC600D8FACF /* GatewayAPILoginTests.swift */; };
 		B645506E1E79087F00D8FACF /* GatewayAPIOnboardGatewayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B645506D1E79087F00D8FACF /* GatewayAPIOnboardGatewayTests.swift */; };
 		B64550701E79467600D8FACF /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = B645506F1E79467600D8FACF /* Action.swift */; };
+		B64550721E7A4BCD00D8FACF /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64550711E7A4BCC00D8FACF /* ActionTests.swift */; };
 		B66729351E724D7B007E3019 /* Serializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66729341E724D7B007E3019 /* Serializable.swift */; };
 		B66729371E72A0BA007E3019 /* ThingIFAPIPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66729361E72A0BA007E3019 /* ThingIFAPIPersistenceTests.swift */; };
 		B673C0051CF81CEC00AEF519 /* TestSetting.plist in Resources */ = {isa = PBXBuildFile; fileRef = B673C0041CF81CEC00AEF519 /* TestSetting.plist */; };
@@ -230,6 +231,7 @@
 		B645506B1E78ECC600D8FACF /* GatewayAPILoginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPILoginTests.swift; sourceTree = "<group>"; };
 		B645506D1E79087F00D8FACF /* GatewayAPIOnboardGatewayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPIOnboardGatewayTests.swift; sourceTree = "<group>"; };
 		B645506F1E79467600D8FACF /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
+		B64550711E7A4BCC00D8FACF /* ActionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionTests.swift; sourceTree = "<group>"; };
 		B66729341E724D7B007E3019 /* Serializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serializable.swift; sourceTree = "<group>"; };
 		B66729361E72A0BA007E3019 /* ThingIFAPIPersistenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThingIFAPIPersistenceTests.swift; sourceTree = "<group>"; };
 		B673C0041CF81CEC00AEF519 /* TestSetting.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TestSetting.plist; sourceTree = "<group>"; };
@@ -533,6 +535,7 @@
 				B6A3DA1C1E77C05B001662D0 /* ThingIFAPIOnboardEndNodeTests.swift */,
 				B645506B1E78ECC600D8FACF /* GatewayAPILoginTests.swift */,
 				B645506D1E79087F00D8FACF /* GatewayAPIOnboardGatewayTests.swift */,
+				B64550711E7A4BCC00D8FACF /* ActionTests.swift */,
 			);
 			path = ThingIFSDKTests;
 			sourceTree = "<group>";
@@ -821,6 +824,7 @@
 				B6C33F101E4977C700DF2BF5 /* XCTest+Utils.swift in Sources */,
 				B6BE38A21E601F3200FD9976 /* CommandFormTests.swift in Sources */,
 				B6A86CAE1E6D66E100F9C41B /* TestSetting.swift in Sources */,
+				B64550721E7A4BCD00D8FACF /* ActionTests.swift in Sources */,
 				2262F14B1E49899300080DF6 /* ActionResultTests.swift in Sources */,
 				B6AFD02C1E680D9C0066B4AD /* XCTest+Equatable.swift in Sources */,
 				B6BE38981E5FE6B500FD9976 /* StandaloneThingTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/AliasAction.swift
+++ b/ThingIFSDK/ThingIFSDK/AliasAction.swift
@@ -29,4 +29,15 @@ public struct AliasAction {
         self.alias = alias
         self.actions = actions
     }
+
+    /** Initializer of AliasAction instance.
+
+     - Parameter alias: Name of an alias.
+     - Parameter actions: Actions of this alias.
+     */
+    public init(_ alias: String, actions: Action...) {
+        self.alias = alias
+        self.actions = actions
+    }
+
 }

--- a/ThingIFSDK/ThingIFSDK/AliasAction.swift
+++ b/ThingIFSDK/ThingIFSDK/AliasAction.swift
@@ -22,7 +22,7 @@ public struct AliasAction {
     /** Initializer of AliasAction instance.
 
      - Parameter alias: Name of an alias.
-     - Parameter actions: Actions of this alias. must not be empty.
+     - Parameter actions: Array of `Action` instances. must not be empty.
      */
 
     public init(_ alias: String, actions: [Action]) {
@@ -33,7 +33,8 @@ public struct AliasAction {
     /** Initializer of AliasAction instance.
 
      - Parameter alias: Name of an alias.
-     - Parameter actions: Actions of this alias.
+     - Parameter actions: Variable number of `Action` instance. must
+       equal or be more than one
      */
     public init(_ alias: String, actions: Action...) {
         self.alias = alias

--- a/ThingIFSDK/ThingIFSDKTests/ActionTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ActionTests.swift
@@ -1,0 +1,30 @@
+//
+//  ActionTests.swift
+//  ThingIFSDK
+//
+//  Created on 2017/03/16.
+//  Copyright (c) 2017 Kii. All rights reserved.
+//
+
+import XCTest
+
+@testable import ThingIFSDK
+
+class ActionTests: SmallTestBase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testValue() {
+        let actual = Action("name", value: "value")
+
+        XCTAssertEqual("name", actual.name)
+        XCTAssertEqual("value", actual.value as? String)
+    }
+
+}

--- a/ThingIFSDK/ThingIFSDKTests/AliasActionTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/AliasActionTests.swift
@@ -20,13 +20,35 @@ class AliasActionTests: SmallTestBase {
     }
 
     func testValues() {
-        let target = AliasAction("dummy", action: ["key": "value"])
+        let action = Action("key", value: "value")
+        let target = AliasAction("dummy", actions: action)
 
         XCTAssertNotNil(target)
         XCTAssertEqual(target.alias, "dummy")
-        XCTAssertNotNil(target.action)
-        XCTAssertEqual(target.action.count, 1)
-        XCTAssertEqual(target.action["key"] as! String, "value")
+        XCTAssertEqual([action], target.actions)
+    }
+
+    func testValuesWithArray() {
+        let actions = [
+          Action("key1", value: "value1"),
+          Action("key2", value: "value2")
+        ]
+        let target = AliasAction("dummy", actions: actions)
+
+        XCTAssertNotNil(target)
+        XCTAssertEqual(target.alias, "dummy")
+        XCTAssertEqual(actions, target.actions)
+    }
+
+    func testValuesWithVariableNumberOfArgument() {
+        let action1 = Action("key1", value: "value1")
+        let action2 = Action("key2", value: "value2")
+        let action3 = Action("key3", value: "value3")
+        let target = AliasAction("dummy", actions: action1, action2, action3)
+
+        XCTAssertNotNil(target)
+        XCTAssertEqual(target.alias, "dummy")
+        XCTAssertEqual([action1, action2, action3], target.actions)
     }
 
 }

--- a/ThingIFSDK/ThingIFSDKTests/CommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/CommandFormTests.swift
@@ -23,7 +23,9 @@ class CommandFormTests: SmallTestBase {
         let actions = [
           AliasAction(
             "alias",
-            action: [ "action1" : [ "arg1" : "value1", "arg2": "value2" ] ]
+            actions: Action(
+              "action1",
+              value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
         let commandForm = CommandForm(actions)
@@ -37,7 +39,9 @@ class CommandFormTests: SmallTestBase {
         let actions = [
           AliasAction(
             "alias",
-            action: [ "action1" : [ "arg1" : "value1", "arg2": "value2" ] ]
+            actions: Action(
+              "action1",
+              value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
         let commandForm = CommandForm(actions, title: "title")
@@ -51,7 +55,9 @@ class CommandFormTests: SmallTestBase {
         let actions = [
           AliasAction(
             "alias",
-            action: [ "action1" : [ "arg1" : "value1", "arg2": "value2" ] ]
+            actions: Action(
+              "action1",
+              value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
         let commandForm = CommandForm(actions,
@@ -67,7 +73,9 @@ class CommandFormTests: SmallTestBase {
         let actions = [
           AliasAction(
             "alias",
-            action: [ "action1" : [ "arg1" : "value1", "arg2": "value2" ] ]
+            actions: Action(
+              "action1",
+              value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
         let metadata = [ "key1" : "value1", "key2" : "value2" ]
@@ -85,7 +93,9 @@ class CommandFormTests: SmallTestBase {
         let actions = [
           AliasAction(
             "alias",
-            action: [ "action1" : [ "arg1" : "value1", "arg2": "value2" ] ]
+            actions: Action(
+              "action1",
+              value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
         let commandForm = CommandForm(actions,
@@ -102,7 +112,9 @@ class CommandFormTests: SmallTestBase {
         let actions = [
           AliasAction(
             "alias",
-            action: [ "action1" : [ "arg1" : "value1", "arg2": "value2" ] ]
+            actions: Action(
+              "action1",
+              value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
         let metadata: [String : Any] = [ "key1" : "value1", "key2" : "value2" ]
@@ -122,7 +134,9 @@ class CommandFormTests: SmallTestBase {
         let actions = [
           AliasAction(
             "alias",
-            action: [ "action1" : [ "arg1" : "value1", "arg2": "value2" ] ]
+            actions: Action(
+              "action1",
+              value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
         let metadata: [String : Any] = [ "key1" : "value1", "key2" : "value2" ]
@@ -142,7 +156,9 @@ class CommandFormTests: SmallTestBase {
         let actions = [
           AliasAction(
             "alias",
-            action: [ "action1" : [ "arg1" : "value1", "arg2": "value2" ] ]
+            actions: Action(
+              "action1",
+              value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
         let metadata: [String : Any] = [ "key1" : "value1", "key2" : "value2" ]

--- a/ThingIFSDK/ThingIFSDKTests/CommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/CommandTests.swift
@@ -21,7 +21,8 @@ class CommandTests: SmallTestBase {
     func testOptinalNonNil() {
         let targetID = TypedID(TypedID.Types.thing, id: "target")
         let issuerID = TypedID(TypedID.Types.thing, id: "issuer")
-        let aliasActions = [AliasAction("alias", action: ["key" : "value"])]
+        let aliasActions =
+          [AliasAction("alias", actions: Action("key", value: "value"))]
         let aliasActionResults = [
           AliasActionResult(
             "alias",
@@ -63,7 +64,8 @@ class CommandTests: SmallTestBase {
     func testOptinalNil() {
         let targetID = TypedID(TypedID.Types.thing, id: "target")
         let issuerID = TypedID(TypedID.Types.thing, id: "issuer")
-        let aliasActions = [AliasAction("alias", action: ["key" : "value"])]
+        let aliasActions =
+          [AliasAction("alias", actions: Action("key", value: "value"))]
 
         let actual = Command(
           "commandID",
@@ -86,11 +88,13 @@ class CommandTests: SmallTestBase {
 
     func testGetAction() {
 
-        let actionA = AliasAction("alias", action: ["key1" : "value1"])
+        let actionA = AliasAction(
+          "alias",
+          actions: Action("key1", value: "value1"))
         let actionDifferentAliasFromA =
-          AliasAction("different", action: ["key2" : "value2"])
+          AliasAction("different", actions: Action("key2", value: "value2"))
         let aliasActionsameAliasAsA =
-          AliasAction("alias", action: ["key3" : "value3"])
+          AliasAction("alias", actions: Action("key3", value: "value3"))
 
         let actual = Command(
           "commandID",
@@ -127,7 +131,8 @@ class CommandTests: SmallTestBase {
           "commandID",
           targetID: TypedID(TypedID.Types.thing, id: "target"),
           issuerID: TypedID(TypedID.Types.thing, id: "issuer"),
-          aliasActions: [AliasAction("alias", action: ["key1" : "value1"])],
+          aliasActions:
+            [AliasAction("alias", actions: Action("key1", value: "value1"))],
           aliasActionResults: [
             aliasActionResultA,
             aliasActionResultDifferentAliasFromA,

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
@@ -449,3 +449,10 @@ extension KiiApp: Equatable, CustomStringConvertible {
           + "siteName=\(self.siteName)"
     }
 }
+
+extension Action: Equatable {
+
+    public static func == (left: Action, right: Action) -> Bool {
+        return left.name == right.name && isSameAny(left.value, right.value)
+    }
+}

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
@@ -247,9 +247,7 @@ extension AliasActionResult: Equatable {
 extension AliasAction: Equatable {
 
     public static func == (left: AliasAction, right: AliasAction) -> Bool {
-        return left.alias == right.alias &&
-          NSDictionary(dictionary: left.action) ==
-            NSDictionary(dictionary: right.action)
+        return left.alias == right.alias && left.actions == right.actions
     }
 
 }


### PR DESCRIPTION
In #376, We rename `AliasAction.action` to `AliasAction.actions`. We also change type of its property to `Action` which is newly introduced struct.

In this PR

* Add test for `Action`
* Fix test concerned with `AliasAction`.

Related PR: #296 