### PR TITLE
Implement ThingIFAPI.getFirmwareVersion

### DIFF
--- a/ThingIFSDK/ThingIFSDK/IoTOperations/IoTRequestOperation.swift
+++ b/ThingIFSDK/ThingIFSDK/IoTOperations/IoTRequestOperation.swift
@@ -241,8 +241,6 @@ class IoTRequestOperation<T>: GroupOperation {
                 let httpResponse = responseOptional as! HTTPURLResponse
                 let statusCode = httpResponse.statusCode
                 var responseBody : NSDictionary?
-                var errorCode = ""
-                var errorMessage = ""
                 kiiDebugLog("Response Status Code : \(statusCode)")
 
                 if statusCode < 200 || statusCode >= 300 {
@@ -254,13 +252,10 @@ class IoTRequestOperation<T>: GroupOperation {
                         }
                     }
                     kiiDebugLog("Response Error : \(responseBody)")
-                    if responseBody != nil
-                        && responseBody!["errorCode"] != nil
-                        && responseBody!["message"] != nil {
-                        errorCode = responseBody!["errorCode"] as! String
-                        errorMessage = responseBody!["message"] as! String
-                    }
-                    let errorResponse = ErrorResponse(statusCode, errorCode: errorCode, errorMessage: errorMessage)
+                    let errorResponse = ErrorResponse(
+                      statusCode,
+                      errorCode: (responseBody?["errorCode"] as? String) ?? "",
+                      errorMessage: (responseBody?["message"] as? String) ?? "")
                     let iotCloudError = ThingIFError.errorResponse(required: errorResponse)
                     completionHandler(nil, iotCloudError)
                 }else {

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
@@ -90,7 +90,7 @@ extension ThingIFAPI {
         }
     }
 
-    /** Get firmeware version.
+    /** Get firmware version.
 
      This method gets firmware version for `target` thing.
 
@@ -98,7 +98,7 @@ extension ThingIFAPI {
        getting has finished The closure takes 2 arguments. First one
        is firmware version. Second one is ThingIFError.
      */
-    open func getFirmewareVerson(
+    open func getFirmwareVersion(
       _ completionHandler: @escaping (String?, ThingIFError?) -> Void) -> Void
     {
         guard let target = self.target else {
@@ -108,7 +108,7 @@ extension ThingIFAPI {
 
         self.operationQueue.addHttpRequestOperation(
           .get,
-          url: "\(self.baseURL)/thing-if/apps/\(self.appID)/things/\(target.typedID.id)/vendor-thing-id",
+          url: "\(self.baseURL)/thing-if/apps/\(self.appID)/things/\(target.typedID.id)/firmware-version",
           requestHeader: self.defaultHeader,
           failureBeforeExecutionHandler: { completionHandler(nil, $0) }) {
             response, error -> Void in

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
@@ -90,4 +90,19 @@ extension ThingIFAPI {
         }
     }
 
+
+    /** Get firmeware version.
+
+     This method gets firmware version for `target` thing.
+
+     - Parameter completionHandler: A closure to be executed once on
+       getting has finished The closure takes 2 arguments. First one
+       is firmware version. Second one is ThingIFError.
+     */
+    open func getFirmewareVerson(
+      _ completionHandler: @escaping (String?, ThingIFError?) -> Void) -> Void
+    {
+        // TODO: implement me.
+    }
+
 }

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -398,20 +398,6 @@ open class ThingIFAPI: Equatable {
         // TODO: implement me.
     }
 
-    /** Get firmeware version.
-
-     This method gets firmware version for `target` thing.
-
-     - Parameter completionHandler: A closure to be executed once on
-       getting has finished The closure takes 2 arguments. First one
-       is firmware version. Second one is ThingIFError.
-     */
-    open func getFirmewareVerson(
-      _ completionHandler: @escaping (String?, ThingIFError?) -> Void) -> Void
-    {
-        // TODO: implement me.
-    }
-
     /** Update thing type.
 
      This method updates thing type for `target` thing.

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -501,4 +501,236 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
             XCTAssertNil(error, "execution timeout")
         }
     }
+
+    func  testGetFirmwareVersionError401() throws {
+        let expectation =
+          self.expectation(description: "testGetFirmwareVersionSuccess")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(setting.target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)"
+              ],
+              request.allHTTPHeaderFields!)
+            XCTAssertNil(request.httpBody)
+        }
+
+        // mock response
+
+        // TODO: When server response fixed, change to
+        // FIRMWARE_VERSION_NOT_FOUND.
+        sharedMockSession.mockResponse = (
+          nil,
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 401,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.getFirmwareVersion() { firmwareVersion, error -> Void in
+            XCTAssertNil(firmwareVersion)
+            XCTAssertEqual(
+              ThingIFError.errorResponse(
+                required: ErrorResponse(401, errorCode: "", errorMessage: "")),
+              error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
+
+    func  testGetFirmwareVersionError403() throws {
+        let expectation =
+          self.expectation(description: "testGetFirmwareVersionSuccess")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(setting.target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)"
+              ],
+              request.allHTTPHeaderFields!)
+            XCTAssertNil(request.httpBody)
+        }
+
+        // mock response
+
+        // TODO: When server response fixed, change to
+        // FIRMWARE_VERSION_NOT_FOUND.
+        sharedMockSession.mockResponse = (
+          nil,
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 403,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.getFirmwareVersion() { firmwareVersion, error -> Void in
+            XCTAssertNil(firmwareVersion)
+            XCTAssertEqual(
+              ThingIFError.errorResponse(
+                required: ErrorResponse(403, errorCode: "", errorMessage: "")),
+              error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
+
+    func  testGetFirmwareVersionError404() throws {
+        let expectation =
+          self.expectation(description: "testGetFirmwareVersionSuccess")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(setting.target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)"
+              ],
+              request.allHTTPHeaderFields!)
+            XCTAssertNil(request.httpBody)
+        }
+
+        // mock response
+
+        // TODO: When server response fixed, change to
+        // FIRMWARE_VERSION_NOT_FOUND.
+        sharedMockSession.mockResponse = (
+          nil,
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.getFirmwareVersion() { firmwareVersion, error -> Void in
+            XCTAssertNil(firmwareVersion)
+            XCTAssertEqual(
+              ThingIFError.errorResponse(
+                required: ErrorResponse(404, errorCode: "", errorMessage: "")),
+              error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
+
+    func  testGetFirmwareVersionError503() throws {
+        let expectation =
+          self.expectation(description: "testGetFirmwareVersionSuccess")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(setting.target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)"
+              ],
+              request.allHTTPHeaderFields!)
+            XCTAssertNil(request.httpBody)
+        }
+
+        // mock response
+
+        // TODO: When server response fixed, change to
+        // FIRMWARE_VERSION_NOT_FOUND.
+        sharedMockSession.mockResponse = (
+          nil,
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 503,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.getFirmwareVersion() { firmwareVersion, error -> Void in
+            XCTAssertNil(firmwareVersion)
+            XCTAssertEqual(
+              ThingIFError.errorResponse(
+                required: ErrorResponse(503, errorCode: "", errorMessage: "")),
+              error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
 }

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -444,4 +444,61 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
             XCTAssertNil(error, "execution timeout")
         }
     }
+
+    func  testGetFirmwareVersionSuccessNil() throws {
+        let expectation =
+          self.expectation(description: "testGetFirmwareVersionSuccess")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(setting.target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)"
+              ],
+              request.allHTTPHeaderFields!)
+            XCTAssertNil(request.httpBody)
+        }
+
+        // mock response
+
+        // TODO: When server response fixed, change to
+        // FIRMWARE_VERSION_NOT_FOUND.
+        sharedMockSession.mockResponse = (
+          try JSONSerialization.data(
+            withJSONObject: ["errorCode" : "THING_WITHOUT_THING_TYPE"],
+            options: .prettyPrinted),
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.getFirmwareVersion() { firmwareVersion, error -> Void in
+            XCTAssertNil(error)
+            XCTAssertNil(firmwareVersion)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
 }

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -389,4 +389,59 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
             XCTAssertNil(error, "execution timeout")
         }
     }
+
+    func  testGetFirmwareVersionSuccess() throws {
+        let expectation =
+          self.expectation(description: "testGetFirmwareVersionSuccess")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(setting.target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)"
+              ],
+              request.allHTTPHeaderFields!)
+            XCTAssertNil(request.httpBody)
+        }
+
+        // mock response
+        let expectedFirmwareVersion = "V1"
+        sharedMockSession.mockResponse = (
+          try JSONSerialization.data(
+            withJSONObject: ["firmwareVersion": expectedFirmwareVersion],
+            options: .prettyPrinted),
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.getFirmwareVersion() { firmwareVersion, error -> Void in
+            XCTAssertNil(error)
+            XCTAssertEqual(firmwareVersion, expectedFirmwareVersion)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
 }


### PR DESCRIPTION
* Move `ThingIFAPI.getFirmwareVersion` from ThingIFAPI.swift to ThingIFAPI+ThingInfomation.swift
* Fix `IoTRequestOperation`
  * Accept only `errorCode` or `errorMessage` response.
* Add small tests

This is new API for v1.0 so we do not have old test.

Related PR: #296