### PR TITLE
Implement ThingIFAPI.update for firmware version method

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
@@ -132,4 +132,42 @@ extension ThingIFAPI {
         }
     }
 
+    /** Update firmware version.
+
+     This method updates firmware version for `target` thing.
+
+     - Parameter firmwareVersion: firmwareVersion to be updated.
+     - Parameter completionHandler: A closure to be executed once on
+       updating has finished The closure takes 1 argument. The
+       argument is ThingIFError.
+     */
+    open func update(
+      firmwareVersion: String,
+      completionHandler: @escaping (ThingIFError?)-> Void) -> Void
+    {
+        guard let target = self.target else {
+            completionHandler(ThingIFError.targetNotAvailable)
+            return;
+        }
+        if firmwareVersion.isEmpty {
+            completionHandler(ThingIFError.unsupportedError)
+            return;
+        }
+
+        self.operationQueue.addHttpRequestOperation(
+          .put,
+          url: "\(self.baseURL)/api/apps/\(self.appID)/things/\(target.typedID.id)/firmware-version",
+          requestHeader:
+            self.defaultHeader +
+            [
+              "Content-Type":
+                MediaType.mediaTypeThingFirmwareVersionUpdateRequest.rawValue
+            ],
+          requestBody: ["firmwareVersion": firmwareVersion],
+          failureBeforeExecutionHandler: { completionHandler($0) }) {
+            response, error -> Void in
+            DispatchQueue.main.async { completionHandler(error) }
+        }
+    }
+
 }

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
@@ -156,7 +156,7 @@ extension ThingIFAPI {
 
         self.operationQueue.addHttpRequestOperation(
           .put,
-          url: "\(self.baseURL)/api/apps/\(self.appID)/things/\(target.typedID.id)/firmware-version",
+          url: "\(self.baseURL)/thing-if/apps/\(self.appID)/things/\(target.typedID.id)/firmware-version",
           requestHeader:
             self.defaultHeader +
             [

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -382,22 +382,6 @@ open class ThingIFAPI: Equatable {
         _listTriggeredServerCodeResults(triggerID, bestEffortLimit:bestEffortLimit, paginationKey:paginationKey, completionHandler: completionHandler)
     }
 
-    /** Update firmware version.
-
-     This method updates firmware version for `target` thing.
-
-     - Parameter firmwareVersion: firmwareVersion to be updated.
-     - Parameter completionHandler: A closure to be executed once on
-       updating has finished The closure takes 1 argument. The
-       argument is ThingIFError.
-     */
-    open func update(
-      firmwareVersion: String,
-      completionHandler: @escaping (ThingIFError?)-> Void) -> Void
-    {
-        // TODO: implement me.
-    }
-
     /** Update thing type.
 
      This method updates thing type for `target` thing.

--- a/ThingIFSDK/ThingIFSDK/Utils/MediaType.swift
+++ b/ThingIFSDK/ThingIFSDK/Utils/MediaType.swift
@@ -15,4 +15,5 @@ internal enum MediaType : String {
     case mediaTypeOnboardingEndnodeWithGatewayThingIdRequest = "application/vnd.kii.OnboardingEndNodeWithGatewayThingID+json"
     case mediaTypeTraitStateQueryRequest = "application/vnd.kii.TraitStateQueryRequest+json"
     case mediaTypeVendorThingIDUpdateRequest = "application/vnd.kii.VendorThingIDUpdateRequest+json"
+    case mediaTypeThingFirmwareVersionUpdateRequest = "application/vnd.kii.ThingFirmwareVersionUpdateRequest+json"
 }

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -447,7 +447,7 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
 
     func  testGetFirmwareVersionSuccessNil() throws {
         let expectation =
-          self.expectation(description: "testGetFirmwareVersionSuccess")
+          self.expectation(description: "testGetFirmwareVersionSuccessNil")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -504,7 +504,7 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
 
     func  testGetFirmwareVersionError401() throws {
         let expectation =
-          self.expectation(description: "testGetFirmwareVersionSuccess")
+          self.expectation(description: "testGetFirmwareVersionError401")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -562,7 +562,7 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
 
     func  testGetFirmwareVersionError403() throws {
         let expectation =
-          self.expectation(description: "testGetFirmwareVersionSuccess")
+          self.expectation(description: "testGetFirmwareVersionError403")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -620,7 +620,7 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
 
     func  testGetFirmwareVersionError404() throws {
         let expectation =
-          self.expectation(description: "testGetFirmwareVersionSuccess")
+          self.expectation(description: "testGetFirmwareVersionError404")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -678,7 +678,7 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
 
     func  testGetFirmwareVersionError503() throws {
         let expectation =
-          self.expectation(description: "testGetFirmwareVersionSuccess")
+          self.expectation(description: "testGetFirmwareVersionError503")
         let setting = TestSetting()
         let api = setting.api
         let target = setting.target
@@ -726,6 +726,69 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
               ThingIFError.errorResponse(
                 required: ErrorResponse(503, errorCode: "", errorMessage: "")),
               error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
+
+    func testUpdateFirmwareVersionSuccess() {
+        let expectation =
+          self.expectation(description: "testUpdateFirmwareVersionSuccess")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+        let firmwareVersion = "V1"
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/api/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)",
+                "Content-Type":
+                  "application/vnd.kii.ThingFirmwareVersionUpdateRequest+json"
+              ],
+              request.allHTTPHeaderFields!)
+
+            //verify body
+            XCTAssertEqual(
+              ["firmwareVersion": firmwareVersion],
+              try JSONSerialization.jsonObject(
+                with: request.httpBody!,
+                options: JSONSerialization.ReadingOptions.allowFragments)
+                as? NSDictionary
+            )
+        }
+
+        // mock response
+        sharedMockSession.mockResponse = (
+          nil,
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 204,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.update(firmwareVersion: firmwareVersion) { error -> Void in
+            XCTAssertNil(error)
             expectation.fulfill()
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -832,4 +832,202 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
             XCTAssertNil(error, "execution timeout")
         }
     }
+
+    func testUpdateFirmwareVersionError403() {
+        let expectation =
+          self.expectation(description: "testUpdateFirmwareVersionError403")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+        let firmwareVersion = "V1"
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/api/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)",
+                "Content-Type":
+                  "application/vnd.kii.ThingFirmwareVersionUpdateRequest+json"
+              ],
+              request.allHTTPHeaderFields!)
+
+            //verify body
+            XCTAssertEqual(
+              ["firmwareVersion": firmwareVersion],
+              try JSONSerialization.jsonObject(
+                with: request.httpBody!,
+                options: JSONSerialization.ReadingOptions.allowFragments)
+                as? NSDictionary
+            )
+        }
+
+        // mock response
+        sharedMockSession.mockResponse = (
+          nil,
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 403,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.update(firmwareVersion: firmwareVersion) { error -> Void in
+            XCTAssertEqual(
+              ThingIFError.errorResponse(
+                required: ErrorResponse(403, errorCode: "", errorMessage: "")),
+              error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
+
+    func testUpdateFirmwareVersionError404() {
+        let expectation =
+          self.expectation(description: "testUpdateFirmwareVersionError404")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+        let firmwareVersion = "V1"
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/api/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)",
+                "Content-Type":
+                  "application/vnd.kii.ThingFirmwareVersionUpdateRequest+json"
+              ],
+              request.allHTTPHeaderFields!)
+
+            //verify body
+            XCTAssertEqual(
+              ["firmwareVersion": firmwareVersion],
+              try JSONSerialization.jsonObject(
+                with: request.httpBody!,
+                options: JSONSerialization.ReadingOptions.allowFragments)
+                as? NSDictionary
+            )
+        }
+
+        // mock response
+        sharedMockSession.mockResponse = (
+          nil,
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.update(firmwareVersion: firmwareVersion) { error -> Void in
+            XCTAssertEqual(
+              ThingIFError.errorResponse(
+                required: ErrorResponse(404, errorCode: "", errorMessage: "")),
+              error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
+
+    func testUpdateFirmwareVersionError503() {
+        let expectation =
+          self.expectation(description: "testUpdateFirmwareVersionError503")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+        let firmwareVersion = "V1"
+
+        // perform onboarding
+        api.target = target
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() { request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+
+            // verify path
+            XCTAssertEqual(
+              "\(setting.api.baseURL)/api/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
+              request.url!.absoluteString)
+
+            //verify header
+            XCTAssertEqual(
+              [
+                "X-Kii-AppID": setting.app.appID,
+                "X-Kii-AppKey": setting.app.appKey,
+                "X-Kii-SDK": SDKVersion.sharedInstance.kiiSDKHeader,
+                "Authorization": "Bearer \(setting.owner.accessToken)",
+                "Content-Type":
+                  "application/vnd.kii.ThingFirmwareVersionUpdateRequest+json"
+              ],
+              request.allHTTPHeaderFields!)
+
+            //verify body
+            XCTAssertEqual(
+              ["firmwareVersion": firmwareVersion],
+              try JSONSerialization.jsonObject(
+                with: request.httpBody!,
+                options: JSONSerialization.ReadingOptions.allowFragments)
+                as? NSDictionary
+            )
+        }
+
+        // mock response
+        sharedMockSession.mockResponse = (
+          nil,
+          HTTPURLResponse(
+            url: URL(string:setting.app.baseURL)!,
+            statusCode: 503,
+            httpVersion: nil,
+            headerFields: nil),
+          nil)
+        iotSession = MockSession.self
+
+        setting.api.update(firmwareVersion: firmwareVersion) { error -> Void in
+            XCTAssertEqual(
+              ThingIFError.errorResponse(
+                required: ErrorResponse(503, errorCode: "", errorMessage: "")),
+              error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
 }

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -796,4 +796,40 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
             XCTAssertNil(error, "execution timeout")
         }
     }
+
+    func testUpdateFirmwareVersionWithoutTarget() {
+        let expectation = self.expectation(
+          description: "testUpdateFirmwareVersionEmptyFirmwareVersion")
+        let setting = TestSetting()
+        let firmwareVersion = "V1"
+
+        setting.api.update(firmwareVersion: firmwareVersion) { error -> Void in
+            XCTAssertEqual(ThingIFError.targetNotAvailable, error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
+
+    func testUpdateFirmwareVersionEmptyFirmwareVersion() {
+        let expectation = self.expectation(
+          description: "testUpdateFirmwareVersionEmptyFirmwareVersion")
+        let setting = TestSetting()
+        let api = setting.api
+        let target = setting.target
+
+        // perform onboarding
+        api.target = target
+
+        setting.api.update(firmwareVersion: "") { error -> Void in
+            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error, "execution timeout")
+        }
+    }
 }

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -751,7 +751,7 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
 
             // verify path
             XCTAssertEqual(
-              "\(setting.api.baseURL)/api/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
               request.url!.absoluteString)
 
             //verify header
@@ -850,7 +850,7 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
 
             // verify path
             XCTAssertEqual(
-              "\(setting.api.baseURL)/api/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
               request.url!.absoluteString)
 
             //verify header
@@ -916,7 +916,7 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
 
             // verify path
             XCTAssertEqual(
-              "\(setting.api.baseURL)/api/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
               request.url!.absoluteString)
 
             //verify header
@@ -982,7 +982,7 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
 
             // verify path
             XCTAssertEqual(
-              "\(setting.api.baseURL)/api/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
+              "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/things/\(target.typedID.id)/firmware-version",
               request.url!.absoluteString)
 
             //verify header


### PR DESCRIPTION
* Move `ThingIFAPI.update` for firmware version from ThingIFAPI.swift to ThingIFAPI+ThingInformation.swift
* Add small tests

This is new API for v1.0 so there is no old test.

Related PR: #296