### PR TITLE
Change property name actions to aliasActions.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -28,7 +28,7 @@ public struct CommandForm {
 
     // MARK: - Properties
 
-    /// Array of actions with alias.
+    /// Array of AliasAction instances.
     public let aliasActions: [AliasAction]
 
     /// Title of a command.
@@ -45,7 +45,7 @@ public struct CommandForm {
     /**
     Initializer of CommandForm instance.
 
-    - Parameter actions: Array of actions with alias. Must not be empty.
+    - Parameter actions: Array of AliasAction instances. Must not be empty.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.
     - Parameter description: Description of a comand. This should be

--- a/ThingIFSDK/ThingIFSDK/CommandForm.swift
+++ b/ThingIFSDK/ThingIFSDK/CommandForm.swift
@@ -28,8 +28,8 @@ public struct CommandForm {
 
     // MARK: - Properties
 
-    /// Array of actions.
-    public let actions: [AliasAction]
+    /// Array of actions with alias.
+    public let aliasActions: [AliasAction]
 
     /// Title of a command.
     public let title: String?
@@ -45,19 +45,19 @@ public struct CommandForm {
     /**
     Initializer of CommandForm instance.
 
-    - Parameter actions: Array of actions. Must not be empty.
+    - Parameter actions: Array of actions with alias. Must not be empty.
     - Parameter title: Title of a command. This should be equal or
       less than 50 characters.
     - Parameter description: Description of a comand. This should be
       equal or less than 200 characters.
     - Parameter metadata: Meta data of a command.
     */
-    public init(_ actions: [AliasAction],
+    public init(_ aliasActions: [AliasAction],
                 title: String? = nil,
                 commandDescription: String? = nil,
                 metadata: [String : Any]? = nil)
     {
-        self.actions = actions
+        self.aliasActions = aliasActions
         self.title = title;
         self.commandDescription = commandDescription;
         self.metadata = metadata;

--- a/ThingIFSDK/ThingIFSDKTests/CommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/CommandFormTests.swift
@@ -20,7 +20,7 @@ class CommandFormTests: SmallTestBase {
     }
 
     func testInitWithRequiredValue() {
-        let actions = [
+        let aliasActions = [
           AliasAction(
             "alias",
             actions: Action(
@@ -28,15 +28,15 @@ class CommandFormTests: SmallTestBase {
               value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
-        let commandForm = CommandForm(actions)
-        XCTAssertEqual(commandForm.actions, actions)
+        let commandForm = CommandForm(aliasActions)
+        XCTAssertEqual(commandForm.aliasActions, aliasActions)
         XCTAssertNil(commandForm.title)
         XCTAssertNil(commandForm.commandDescription)
         XCTAssertNil(commandForm.metadata)
     }
 
     func testInitWithTitle() {
-        let actions = [
+        let aliasActions = [
           AliasAction(
             "alias",
             actions: Action(
@@ -44,15 +44,15 @@ class CommandFormTests: SmallTestBase {
               value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
-        let commandForm = CommandForm(actions, title: "title")
-        XCTAssertEqual(commandForm.actions, actions)
+        let commandForm = CommandForm(aliasActions, title: "title")
+        XCTAssertEqual(commandForm.aliasActions, aliasActions)
         XCTAssertEqual(commandForm.title, "title")
         XCTAssertNil(commandForm.commandDescription)
         XCTAssertNil(commandForm.metadata)
     }
 
     func testInitWithCommandDescription() {
-        let actions = [
+        let aliasActions = [
           AliasAction(
             "alias",
             actions: Action(
@@ -60,17 +60,17 @@ class CommandFormTests: SmallTestBase {
               value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
-        let commandForm = CommandForm(actions,
+        let commandForm = CommandForm(aliasActions,
                                       commandDescription: "description")
         XCTAssertNotNil(commandForm)
-        XCTAssertEqual(commandForm.actions, actions)
+        XCTAssertEqual(commandForm.aliasActions, aliasActions)
         XCTAssertNil(commandForm.title)
         XCTAssertEqual(commandForm.commandDescription, "description")
         XCTAssertNil(commandForm.metadata)
     }
 
     func testInitWithMetadata() {
-        let actions = [
+        let aliasActions = [
           AliasAction(
             "alias",
             actions: Action(
@@ -79,10 +79,10 @@ class CommandFormTests: SmallTestBase {
           )
         ]
         let metadata = [ "key1" : "value1", "key2" : "value2" ]
-        let commandForm = CommandForm(actions,
+        let commandForm = CommandForm(aliasActions,
                                       metadata: metadata)
         XCTAssertNotNil(commandForm)
-        XCTAssertEqual(commandForm.actions, actions)
+        XCTAssertEqual(commandForm.aliasActions, aliasActions)
         XCTAssertNil(commandForm.title)
         XCTAssertEqual(
           commandForm.metadata as! [String : String],
@@ -90,7 +90,7 @@ class CommandFormTests: SmallTestBase {
     }
 
     func testInitWithTitleAndDescription() {
-        let actions = [
+        let aliasActions = [
           AliasAction(
             "alias",
             actions: Action(
@@ -98,18 +98,18 @@ class CommandFormTests: SmallTestBase {
               value: ["arg1" : "value1", "arg2": "value2"])
           )
         ]
-        let commandForm = CommandForm(actions,
+        let commandForm = CommandForm(aliasActions,
                                       title: "title",
                                       commandDescription: "description")
         XCTAssertNotNil(commandForm)
-        XCTAssertEqual(commandForm.actions, actions)
+        XCTAssertEqual(commandForm.aliasActions, aliasActions)
         XCTAssertEqual(commandForm.title, "title")
         XCTAssertEqual(commandForm.commandDescription, "description")
         XCTAssertNil(commandForm.metadata)
     }
 
     func testInitWithTitleAndMetadata() {
-        let actions = [
+        let aliasActions = [
           AliasAction(
             "alias",
             actions: Action(
@@ -118,11 +118,11 @@ class CommandFormTests: SmallTestBase {
           )
         ]
         let metadata: [String : Any] = [ "key1" : "value1", "key2" : "value2" ]
-        let commandForm = CommandForm(actions,
+        let commandForm = CommandForm(aliasActions,
                                       title: "title",
                                       metadata: metadata)
         XCTAssertNotNil(commandForm)
-        XCTAssertEqual(commandForm.actions, actions)
+        XCTAssertEqual(commandForm.aliasActions, aliasActions)
         XCTAssertEqual(commandForm.title, "title")
         XCTAssertNil(commandForm.commandDescription)
         XCTAssertEqual(
@@ -131,7 +131,7 @@ class CommandFormTests: SmallTestBase {
     }
 
     func testInitWithDescriptionAndMetadata() {
-        let actions = [
+        let aliasActions = [
           AliasAction(
             "alias",
             actions: Action(
@@ -140,11 +140,11 @@ class CommandFormTests: SmallTestBase {
           )
         ]
         let metadata: [String : Any] = [ "key1" : "value1", "key2" : "value2" ]
-        let commandForm = CommandForm(actions,
+        let commandForm = CommandForm(aliasActions,
                                       commandDescription: "description",
                                       metadata: metadata)
         XCTAssertNotNil(commandForm)
-        XCTAssertEqual(commandForm.actions, actions)
+        XCTAssertEqual(commandForm.aliasActions, aliasActions)
         XCTAssertNil(commandForm.title)
         XCTAssertEqual(commandForm.commandDescription, "description")
         XCTAssertEqual(
@@ -153,7 +153,7 @@ class CommandFormTests: SmallTestBase {
     }
 
     func testInitWithAllFields() {
-        let actions = [
+        let aliasActions = [
           AliasAction(
             "alias",
             actions: Action(
@@ -162,12 +162,12 @@ class CommandFormTests: SmallTestBase {
           )
         ]
         let metadata: [String : Any] = [ "key1" : "value1", "key2" : "value2" ]
-        let commandForm = CommandForm(actions,
+        let commandForm = CommandForm(aliasActions,
                                       title: "title",
                                       commandDescription: "description",
                                       metadata: metadata)
         XCTAssertNotNil(commandForm)
-        XCTAssertEqual(commandForm.actions, actions)
+        XCTAssertEqual(commandForm.aliasActions, aliasActions)
         XCTAssertEqual(commandForm.title, "title")
         XCTAssertEqual(commandForm.commandDescription, "description")
         XCTAssertEqual(


### PR DESCRIPTION
In #355, We change property name `actions` in `Command` to `aliasActions`.
We should also change property name `actions` in `CommandForm` to `aliasActions`.

Related PR: #296 
