### PR TITLE
Refactor creating Trigger from response.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -407,7 +407,7 @@ extension ThingIFAPI {
           failureBeforeExecutionHandler: { completionHandler(nil, nil, $0) }) {
             response, error -> Void in
 
-            var json: [String : Any]?
+            let json: [String : Any]?
             if let response = response {
                 // NOTE: Server does not contains target id but
                 // Trigger requires it so I add it. We should discuss
@@ -489,7 +489,7 @@ fileprivate func convertTrigger(
   targetID: String,
   error: ThingIFError? = nil) -> (Trigger?, ThingIFError?)
 {
-    var json: [String : Any]?
+    let json: [String : Any]?
     if let response = response {
         // NOTE: Server does not contains target id but
         // Trigger requires it so I add it. We should discuss

--- a/ThingIFSDK/ThingIFSDK/Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/Trigger.swift
@@ -151,20 +151,27 @@ public enum EventSource: String {
 extension Trigger: FromJsonObject {
 
     internal init(_ jsonObject: [String : Any]) throws {
-        guard let triggerID = jsonObject["triggerID"] as? String,
-              let predicateDict = jsonObject["predicate"] as? [String : Any],
-              let disabled = jsonObject["disabled"] as? Bool else {
+        guard let serverResponse =
+                jsonObject["serverResponse"] as? [String : Any] else {
+            throw ThingIFError.jsonParseError
+        }
+        let targetID = try TypedID(jsonObject["target"] as? String)
+
+
+        guard let triggerID = serverResponse["triggerID"] as? String,
+              let predicateDict =
+                serverResponse["predicate"] as? [String : Any],
+              let disabled = serverResponse["disabled"] as? Bool else {
             throw ThingIFError.jsonParseError
         }
 
-        let targetID = try TypedID(jsonObject["target"] as? String)
         let predicate = try makePredicate(predicateDict)
 
-        let title = jsonObject["title"] as? String
-        let description = jsonObject["description"] as? String
-        let metadata = jsonObject["metadata"] as? [String : Any]
+        let title = serverResponse["title"] as? String
+        let description = serverResponse["description"] as? String
+        let metadata = serverResponse["metadata"] as? [String : Any]
 
-        if let command = jsonObject["command"] as? [String : Any] {
+        if let command = serverResponse["command"] as? [String : Any] {
             self.init(
               triggerID,
               targetID: targetID,
@@ -174,7 +181,8 @@ extension Trigger: FromJsonObject {
               title: title,
               triggerDescription: description,
               metadata: metadata)
-        } else if let serverCode = jsonObject["serverCode"] as? [String : Any] {
+        } else if let serverCode = serverResponse["serverCode"]
+                    as? [String : Any] {
             self.init(
               triggerID,
               targetID: targetID,

--- a/ThingIFSDK/ThingIFSDK/Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/Trigger.swift
@@ -157,7 +157,6 @@ extension Trigger: FromJsonObject {
         }
         let targetID = try TypedID(jsonObject["target"] as? String)
 
-
         guard let triggerID = serverResponse["triggerID"] as? String,
               let predicateDict =
                 serverResponse["predicate"] as? [String : Any],


### PR DESCRIPTION
`Trigger` requires target id but the server response does not contains the target id. As as result, we put target id to the response dictionary.

I think this is wrong way because if response dictionary has a property which name is same as we put, we overwrite the property.

Instead of this way, I create new dictionary which contains server response and target id. As a result, we does not overwrite same name property.

Related PR: #296 