### PR TITLE
implement and test ThingIFAPI.query(HistoryStateQuery).

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		226EA0D41CD0D883002C1821 /* TargetThing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226EA0D31CD0D883002C1821 /* TargetThing.swift */; };
 		229418FD1E827C9E009CF87A /* GetGatewayIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229418FC1E827C9E009CF87A /* GetGatewayIDTests.swift */; };
 		229665AF1E84E1E500E860D3 /* GatewayAPIListPendingEndNodesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229665AE1E84E1E500E860D3 /* GatewayAPIListPendingEndNodesTests.swift */; };
+		22AFCCBD1E8A524500C4DB61 /* ThingIFAPIQueryUngroupedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AFCCBC1E8A524500C4DB61 /* ThingIFAPIQueryUngroupedTests.swift */; };
 		22DC5E9B1E77B04100519807 /* ThingIFAPIAggregateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DC5E9A1E77B04100519807 /* ThingIFAPIAggregateTests.swift */; };
 		22DD30FF1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DD30FE1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift */; };
 		22E486341CC4E1C000269A1E /* GatewayAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E486331CC4E1C000269A1E /* GatewayAPI.swift */; };
@@ -207,6 +208,7 @@
 		226EA0D31CD0D883002C1821 /* TargetThing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TargetThing.swift; sourceTree = "<group>"; };
 		229418FC1E827C9E009CF87A /* GetGatewayIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetGatewayIDTests.swift; sourceTree = "<group>"; };
 		229665AE1E84E1E500E860D3 /* GatewayAPIListPendingEndNodesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPIListPendingEndNodesTests.swift; sourceTree = "<group>"; };
+		22AFCCBC1E8A524500C4DB61 /* ThingIFAPIQueryUngroupedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThingIFAPIQueryUngroupedTests.swift; sourceTree = "<group>"; };
 		22DC5E9A1E77B04100519807 /* ThingIFAPIAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThingIFAPIAggregateTests.swift; sourceTree = "<group>"; };
 		22DD30FE1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPIListOnboardedEndNodesTests.swift; sourceTree = "<group>"; };
 		22E486331CC4E1C000269A1E /* GatewayAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPI.swift; sourceTree = "<group>"; };
@@ -605,6 +607,7 @@
 				B69ADF361E8A2F9600BC48A1 /* ThingIFAPIPatchServerCodeTriggerTests.swift */,
 				B69ADF381E8A41FD00BC48A1 /* ThingIFAPIListTriggeredServerCodeResultsTests.swift */,
 				B69ADF3A1E8A5B9100BC48A1 /* ThingIFAPIDeleteTriggerTests.swift */,
+				22AFCCBC1E8A524500C4DB61 /* ThingIFAPIQueryUngroupedTests.swift */,
 			);
 			path = ThingIFSDKTests;
 			sourceTree = "<group>";
@@ -927,6 +930,7 @@
 				B6A3DA191E769C38001662D0 /* GatewayAPITestBase.swift in Sources */,
 				229665AF1E84E1E500E860D3 /* GatewayAPIListPendingEndNodesTests.swift in Sources */,
 				B6E58D751E8269CF004C1873 /* ThingIFAPIListCommandsTests.swift in Sources */,
+				22AFCCBD1E8A524500C4DB61 /* ThingIFAPIQueryUngroupedTests.swift in Sources */,
 				B6C33F0F1E4977C700DF2BF5 /* TestHelpers.swift in Sources */,
 				B6B0A67A1E63EAA100133788 /* CommandTests.swift in Sources */,
 				B6C33F141E49ABB300DF2BF5 /* NotEqualsClauseInQueryTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/HistoryStatesQuery.swift
+++ b/ThingIFSDK/ThingIFSDK/HistoryStatesQuery.swift
@@ -14,7 +14,7 @@ public struct HistoryStatesQuery {
     /** Alias to be queried history. */
     public let alias: String
     /** Query clause. */
-    public let clause: QueryClause?
+    public let clause: QueryClause
     /** firmware version. */
     public let firmwareVersion: String?
     /** Best effor limit to retrieve results. */
@@ -26,8 +26,7 @@ public struct HistoryStatesQuery {
     /** Initializer of HistoryStatesQuery
 
      - Parameter alias: Alias for a query.
-     - Parameter clause: Clause to narrow down history states. If nil
-       or ommited, all history states are target to be retrived.
+     - Parameter clause: Clause to narrow down history states.
      - Parameter firmwareVersion: Firmware version for a query.
      - Parameter bestEffortLimit: bestEffortLimit: Limit the maximum
        number of results in a response. If omitted, default limitis
@@ -38,7 +37,7 @@ public struct HistoryStatesQuery {
      */
     public init(
       _ alias: String,
-      clause: QueryClause? = nil,
+      clause: QueryClause,
       firmwareVersion: String? = nil,
       bestEffortLimit: Int? = nil,
       nextPaginationKey: String? = nil)
@@ -50,4 +49,22 @@ public struct HistoryStatesQuery {
         self.nextPaginationKey = nextPaginationKey
     }
 
+}
+
+extension HistoryStatesQuery : ToJsonObject {
+
+    internal func makeJsonObject() -> [String : Any]{
+        var json : [String : Any] = [:]
+        if self.firmwareVersion != nil {
+            json["firmwareVersion"] = self.firmwareVersion
+        }
+        if self.bestEffortLimit != nil {
+            json["bestEffortLimit"] = self.bestEffortLimit
+        }
+        if self.nextPaginationKey != nil {
+            json["paginationKey"] = self.nextPaginationKey
+        }
+        json["query"] = ["clause" : (self.clause as? ToJsonObject)?.makeJsonObject()]
+        return json
+    }
 }

--- a/ThingIFSDK/ThingIFSDK/HistoryStatesQuery.swift
+++ b/ThingIFSDK/ThingIFSDK/HistoryStatesQuery.swift
@@ -54,17 +54,10 @@ public struct HistoryStatesQuery {
 extension HistoryStatesQuery : ToJsonObject {
 
     internal func makeJsonObject() -> [String : Any]{
-        var json : [String : Any] = [:]
-        if self.firmwareVersion != nil {
-            json["firmwareVersion"] = self.firmwareVersion
-        }
-        if self.bestEffortLimit != nil {
-            json["bestEffortLimit"] = self.bestEffortLimit
-        }
-        if self.nextPaginationKey != nil {
-            json["paginationKey"] = self.nextPaginationKey
-        }
-        json["query"] = ["clause" : (self.clause as? ToJsonObject)?.makeJsonObject()]
+        var json : [String : Any] = ["query" : ["clause" : (self.clause as? ToJsonObject)?.makeJsonObject()]]
+        json["firmwareVersion"] = self.firmwareVersion
+        json["bestEffortLimit"] = self.bestEffortLimit
+        json["paginationKey"] = self.nextPaginationKey
         return json
     }
 }

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Query.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Query.swift
@@ -10,6 +10,8 @@ import Foundation
 
 extension ThingIFAPI {
 
+    // MARK: Qeury state history.
+
     /** Query history states with trait alias.
 
      - Parameter query: Instance of `HistoryStatesQuery`.

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -133,28 +133,6 @@ open class ThingIFAPI: Equatable {
 
     // MARK: Qeury state history.
 
-    /** Query history states with trait alias.
-
-     - Parameter query: Instance of `HistoryStatesQuery`. If nil or
-       omitted, query all history states
-     - Parameter completionHandler: A closure to be executed once
-       finished. The closure takes 3 arguments:
-       - 1st one is array of history states. If there is no objects to
-         be queried, the array is empty.
-       - 2nd one is a pagination key. It represents information to
-         retrieve further page. You can use pagination key to retrieve
-         next page by setting nextPaginationKey. if there is no
-         further page, pagination key is nil.
-       - 3rd one is an instance of ThingIFError when failed.
-     */
-    open func query(
-      _ query: HistoryStatesQuery? = nil,
-      completionHandler: @escaping (
-        [HistoryState]?, String?, ThingIFError?) -> Void) -> Void
-    {
-        // TODO: implement me.
-    }
-
     /** Group history state
 
      - Parameter query: `GroupedHistoryStatesQuery` instance.timeRange

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -131,8 +131,6 @@ open class ThingIFAPI: Equatable {
         _enableTrigger(triggerID, enable: enable, completionHandler: completionHandler)
     }
 
-    // MARK: Qeury state history.
-
     /** Group history state
 
      - Parameter query: `GroupedHistoryStatesQuery` instance.timeRange

--- a/ThingIFSDK/ThingIFSDKTests/HistoryStatesQueryTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/HistoryStatesQueryTests.swift
@@ -38,10 +38,11 @@ class HistoryStatesQueryTests: SmallTestBase {
     }
 
     func testOptinalNil() {
-        let actual = HistoryStatesQuery("alias")
+        let clause = EqualsClauseInQuery("f", intValue: 1)
+        let actual = HistoryStatesQuery("alias", clause: clause)
 
         XCTAssertEqual("alias", actual.alias)
-        XCTAssertNil(actual.clause)
+        XCTAssertEqual(clause, actual.clause as! EqualsClauseInQuery)
         XCTAssertNil(actual.firmwareVersion)
         XCTAssertNil(actual.bestEffortLimit)
         XCTAssertNil(actual.nextPaginationKey)

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIAggregateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIAggregateTests.swift
@@ -51,40 +51,40 @@ class ThingIFAPIAggregateTests: SmallTestBase {
                 ],
                 request.allHTTPHeaderFields!)
 
-            let expectedBody: [ String : Any] = [
-                "query": [
-                    "clause": [
-                        "type": "and",
-                        "clauses": [
-                            [
-                                "type": "eq",
-                                "field": clause.field,
-                                "value": clause.value
-                            ],
-                            [
-                                "type": "withinTimeRange",
-                                "lowerLimit": timeRange.from.timeIntervalSince1970InMillis,
-                                "upperLimit": timeRange.to.timeIntervalSince1970InMillis
-                            ]
-                        ]
-                    ],
-                    "grouped": true,
-                    "aggregations": [
-                        [
-                            "type": aggregation.function.rawValue.uppercased(),
-                            "putAggregationInto": aggregation.function.rawValue.lowercased(),
-                            "field": aggregation.field,
-                            "fieldType": aggregation.fieldType.rawValue
-                        ]
-                    ]
-                ]
-            ]
-            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
-            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
             //verify body
             XCTAssertEqual(
-                expectedBodyStr,
-                String.init(data: request.httpBody!, encoding: .utf8)
+                [
+                    "query": [
+                        "clause": [
+                            "type": "and",
+                            "clauses": [
+                                [
+                                    "type": "eq",
+                                    "field": clause.field,
+                                    "value": clause.value
+                                ],
+                                [
+                                    "type": "withinTimeRange",
+                                    "lowerLimit": timeRange.from.timeIntervalSince1970InMillis,
+                                    "upperLimit": timeRange.to.timeIntervalSince1970InMillis
+                                ]
+                            ]
+                        ],
+                        "grouped": true,
+                        "aggregations": [
+                            [
+                                "type": aggregation.function.rawValue.uppercased(),
+                                "putAggregationInto": aggregation.function.rawValue.lowercased(),
+                                "field": aggregation.field,
+                                "fieldType": aggregation.fieldType.rawValue
+                            ]
+                        ]
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary
             )
         }
 
@@ -169,30 +169,30 @@ class ThingIFAPIAggregateTests: SmallTestBase {
                 ],
                 request.allHTTPHeaderFields!)
 
-            let expectedBody: [ String : Any] = [
-                "query": [
-                    "clause": [
-                        "type": "withinTimeRange",
-                        "lowerLimit": timeRange.from.timeIntervalSince1970InMillis,
-                        "upperLimit": timeRange.to.timeIntervalSince1970InMillis
-                    ],
-                    "grouped": true,
-                    "aggregations": [
-                        [
-                            "type": aggregation.function.rawValue.uppercased(),
-                            "putAggregationInto": aggregation.function.rawValue.lowercased(),
-                            "field": aggregation.field,
-                            "fieldType": aggregation.fieldType.rawValue
-                        ]
-                    ]
-                ]
-            ]
-            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
-            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
             //verify body
             XCTAssertEqual(
-                expectedBodyStr,
-                String.init(data: request.httpBody!, encoding: .utf8)
+                [
+                    "query": [
+                        "clause": [
+                            "type": "withinTimeRange",
+                            "lowerLimit": timeRange.from.timeIntervalSince1970InMillis,
+                            "upperLimit": timeRange.to.timeIntervalSince1970InMillis
+                        ],
+                        "grouped": true,
+                        "aggregations": [
+                            [
+                                "type": aggregation.function.rawValue.uppercased(),
+                                "putAggregationInto": aggregation.function.rawValue.lowercased(),
+                                "field": aggregation.field,
+                                "fieldType": aggregation.fieldType.rawValue
+                            ]
+                        ]
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary
             )
         }
 
@@ -274,30 +274,30 @@ class ThingIFAPIAggregateTests: SmallTestBase {
                 ],
                 request.allHTTPHeaderFields!)
 
-            let expectedBody: [ String : Any] = [
-                "query": [
-                    "clause": [
-                        "type": "withinTimeRange",
-                        "lowerLimit": timeRange.from.timeIntervalSince1970InMillis,
-                        "upperLimit": timeRange.to.timeIntervalSince1970InMillis
-                    ],
-                    "grouped": true,
-                    "aggregations": [
-                        [
-                            "type": aggregation.function.rawValue.uppercased(),
-                            "putAggregationInto": aggregation.function.rawValue.lowercased(),
-                            "field": aggregation.field,
-                            "fieldType": aggregation.fieldType.rawValue
-                        ]
-                    ]
-                ]
-            ]
-            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
-            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
             //verify body
             XCTAssertEqual(
-                expectedBodyStr,
-                String.init(data: request.httpBody!, encoding: .utf8)
+                [
+                    "query": [
+                        "clause": [
+                            "type": "withinTimeRange",
+                            "lowerLimit": timeRange.from.timeIntervalSince1970InMillis,
+                            "upperLimit": timeRange.to.timeIntervalSince1970InMillis
+                        ],
+                        "grouped": true,
+                        "aggregations": [
+                            [
+                                "type": aggregation.function.rawValue.uppercased(),
+                                "putAggregationInto": aggregation.function.rawValue.lowercased(),
+                                "field": aggregation.field,
+                                "fieldType": aggregation.fieldType.rawValue
+                            ]
+                        ]
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary
             )
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIQueryUngroupedTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIQueryUngroupedTests.swift
@@ -62,24 +62,23 @@ class ThingIFAPIQueryUngroupedTests: SmallTestBase {
                 request.allHTTPHeaderFields!)
 
             //verify body
-            let expectedBody: [ String : Any] = [
-                "query": [
-                    "clause": [
-                        "type": "eq",
-                        "field": clause.field,
-                        "value": clause.value
-                    ]
-                ],
-                "firmwareVersion" : "V1",
-                "bestEffortLimit" : 5,
-                "paginationKey" : "100/2"
-            ]
-            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
-            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
-            //verify body
             XCTAssertEqual(
-                expectedBodyStr,
-                String.init(data: request.httpBody!, encoding: .utf8)
+                [
+                    "query": [
+                        "clause": [
+                            "type": "eq",
+                            "field": clause.field,
+                            "value": clause.value
+                        ]
+                    ],
+                    "firmwareVersion" : "V1",
+                    "bestEffortLimit" : 5,
+                    "paginationKey" : "100/2"
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary
             )
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIQueryUngroupedTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIQueryUngroupedTests.swift
@@ -1,0 +1,636 @@
+//
+//  ThingIFAPIQueryUngroupedTests.swift
+//  ThingIFSDK
+//
+//  Copyright (c) 2017 Kii. All rights reserved.
+//
+
+import XCTest
+@testable import ThingIFSDK
+
+class ThingIFAPIQueryUngroupedTests: SmallTestBase {
+
+    override func setUp() {
+        super.setUp()
+    }
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testSuccess() throws {
+        let expectation = self.expectation(description: "testSuccess")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = HistoryStatesQuery(alias, clause: clause)
+        let historyState = HistoryState(
+            ["power" : true, "currentTemperature" : 25],
+            createdAt: Date(timeIntervalSince1970: 50))
+        let nextPaginationKey = "100/2"
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+
+            let expectedBody: [ String : Any] = [
+                "query": [
+                    "clause": [
+                        "type": "eq",
+                        "field": clause.field,
+                        "value": clause.value
+                    ]
+                ]
+            ]
+            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
+            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
+            //verify body
+            XCTAssertEqual(
+                expectedBodyStr,
+                String.init(data: request.httpBody!, encoding: .utf8)
+            )
+        }
+
+        // mock response
+        let responseBody : [String: Any] = [
+            "results" : [
+                historyState.makeJsonObject()
+            ],
+            "nextPaginationKey": nextPaginationKey
+        ]
+        sharedMockSession.mockResponse = (
+            try JSONSerialization.data(withJSONObject: responseBody, options: JSONSerialization.WritingOptions(rawValue: 0)),
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [HistoryState]?, paginationKey:String?, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(results)
+            XCTAssertEqual(1, results!.count)
+            let result: HistoryState = results![0]
+            XCTAssertEqual(historyState, result)
+            XCTAssertEqual(nextPaginationKey, paginationKey)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testSuccessResultsEmpty() throws {
+        let expectation = self.expectation(description: "testSuccessResultsEmpty")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = HistoryStatesQuery(alias, clause: clause)
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+
+            let expectedBody: [ String : Any] = [
+                "query": [
+                    "clause": [
+                        "type": "eq",
+                        "field": clause.field,
+                        "value": clause.value
+                    ]
+                ]
+            ]
+            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
+            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
+            //verify body
+            XCTAssertEqual(
+                expectedBodyStr,
+                String.init(data: request.httpBody!, encoding: .utf8)
+            )
+        }
+
+        // mock response
+        let responseBody : [String: Any] = [
+            "results" : [ ]
+        ]
+        sharedMockSession.mockResponse = (
+            try JSONSerialization.data(withJSONObject: responseBody, options: JSONSerialization.WritingOptions(rawValue: 0)),
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [HistoryState]?, paginationKey:String?, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(results)
+            XCTAssertEqual(0, results!.count)
+            XCTAssertNil(paginationKey)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testSuccessNoStateInServer() throws {
+        let expectation = self.expectation(description: "testSuccessNoStateInServer")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = HistoryStatesQuery(alias, clause: clause)
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+
+            let expectedBody: [ String : Any] = [
+                "query": [
+                    "clause": [
+                        "type": "eq",
+                        "field": clause.field,
+                        "value": clause.value
+                    ]
+                ]
+            ]
+            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
+            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
+            //verify body
+            XCTAssertEqual(
+                expectedBodyStr,
+                String.init(data: request.httpBody!, encoding: .utf8)
+            )
+        }
+
+        // mock response
+        let responseBody : [String: Any] = [
+            "errorCode" : "STATE_HISTORY_NOT_AVAILABLE",
+            "message" : "Time series bucket does not exist"
+        ]
+        sharedMockSession.mockResponse = (
+            try JSONSerialization.data(withJSONObject: responseBody, options: JSONSerialization.WritingOptions(rawValue: 0)),
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 409,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [HistoryState]?, paginationKey:String?, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(results)
+            XCTAssertEqual(0, results!.count)
+            XCTAssertNil(paginationKey)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testErrorResponse400() throws {
+        let expectation = self.expectation(description: "testErrorResponse400")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = HistoryStatesQuery(alias, clause: clause)
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+
+            let expectedBody: [ String : Any] = [
+                "query": [
+                    "clause": [
+                        "type": "eq",
+                        "field": clause.field,
+                        "value": clause.value
+                    ]
+                ]
+            ]
+            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
+            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
+            //verify body
+            XCTAssertEqual(
+                expectedBodyStr,
+                String.init(data: request.httpBody!, encoding: .utf8)
+            )
+        }
+
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 400,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [HistoryState]?, paginationKey:String?, error) in
+            XCTAssertNil(results)
+            XCTAssertNil(paginationKey)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(400, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testErrorResponse403() throws {
+        let expectation = self.expectation(description: "testErrorResponse403")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = HistoryStatesQuery(alias, clause: clause)
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+
+            let expectedBody: [ String : Any] = [
+                "query": [
+                    "clause": [
+                        "type": "eq",
+                        "field": clause.field,
+                        "value": clause.value
+                    ]
+                ]
+            ]
+            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
+            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
+            //verify body
+            XCTAssertEqual(
+                expectedBodyStr,
+                String.init(data: request.httpBody!, encoding: .utf8)
+            )
+        }
+
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 403,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [HistoryState]?, paginationKey:String?, error) in
+            XCTAssertNil(results)
+            XCTAssertNil(paginationKey)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(403, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testErrorResponse404() throws {
+        let expectation = self.expectation(description: "testErrorResponse404")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = HistoryStatesQuery(alias, clause: clause)
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+
+            let expectedBody: [ String : Any] = [
+                "query": [
+                    "clause": [
+                        "type": "eq",
+                        "field": clause.field,
+                        "value": clause.value
+                    ]
+                ]
+            ]
+            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
+            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
+            //verify body
+            XCTAssertEqual(
+                expectedBodyStr,
+                String.init(data: request.httpBody!, encoding: .utf8)
+            )
+        }
+
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [HistoryState]?, paginationKey:String?, error) in
+            XCTAssertNil(results)
+            XCTAssertNil(paginationKey)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(404, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testErrorResponse409() throws {
+        let expectation = self.expectation(description: "testErrorResponse409")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = HistoryStatesQuery(alias, clause: clause)
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+
+            let expectedBody: [ String : Any] = [
+                "query": [
+                    "clause": [
+                        "type": "eq",
+                        "field": clause.field,
+                        "value": clause.value
+                    ]
+                ]
+            ]
+            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
+            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
+            //verify body
+            XCTAssertEqual(
+                expectedBodyStr,
+                String.init(data: request.httpBody!, encoding: .utf8)
+            )
+        }
+
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 409,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [HistoryState]?, paginationKey:String?, error) in
+            XCTAssertNil(results)
+            XCTAssertNil(paginationKey)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(409, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testErrorResponse503() throws {
+        let expectation = self.expectation(description: "testErrorResponse503")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = HistoryStatesQuery(alias, clause: clause)
+
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+
+            let expectedBody: [ String : Any] = [
+                "query": [
+                    "clause": [
+                        "type": "eq",
+                        "field": clause.field,
+                        "value": clause.value
+                    ]
+                ]
+            ]
+            let data: Data = try JSONSerialization.data(withJSONObject: expectedBody, options: JSONSerialization.WritingOptions(rawValue: 0))
+            let expectedBodyStr: String = String.init(data: data, encoding: .utf8)!
+            //verify body
+            XCTAssertEqual(
+                expectedBodyStr,
+                String.init(data: request.httpBody!, encoding: .utf8)
+            )
+        }
+
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 503,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [HistoryState]?, paginationKey:String?, error) in
+            XCTAssertNil(results)
+            XCTAssertNil(paginationKey)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(503, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testErrorNoTarget() throws {
+        let expectation = self.expectation(description: "testErrorNoTarget")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = HistoryStatesQuery(alias, clause: clause)
+
+        setting.api.query(query) {
+            (results: [HistoryState]?, paginationKey:String?, error) in
+            XCTAssertNil(results)
+            XCTAssertNil(paginationKey)
+            XCTAssertEqual(ThingIFError.targetNotAvailable, error)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+}


### PR DESCRIPTION
ThingIFAPI.query(HistoryStateQuery)の実装を行いテストを追加しました。レビューをお願いします。

HisotryStateQuery.clauseがAndroid側では省略不可となっていました。奈良さんと相談の上Android側に合わせて省略不可へ修正しました。