### PR TITLE
implement and test ThingIFAPI.query(Grouped).

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		229418FD1E827C9E009CF87A /* GetGatewayIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229418FC1E827C9E009CF87A /* GetGatewayIDTests.swift */; };
 		229665AF1E84E1E500E860D3 /* GatewayAPIListPendingEndNodesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229665AE1E84E1E500E860D3 /* GatewayAPIListPendingEndNodesTests.swift */; };
 		22AFCCBD1E8A524500C4DB61 /* ThingIFAPIQueryUngroupedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AFCCBC1E8A524500C4DB61 /* ThingIFAPIQueryUngroupedTests.swift */; };
+		22C27B641E8B807D00AA2E0B /* ThingIFAPIQueryGroupedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C27B631E8B807D00AA2E0B /* ThingIFAPIQueryGroupedTests.swift */; };
 		22DC5E9B1E77B04100519807 /* ThingIFAPIAggregateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DC5E9A1E77B04100519807 /* ThingIFAPIAggregateTests.swift */; };
 		22DD30FF1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DD30FE1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift */; };
 		22E486341CC4E1C000269A1E /* GatewayAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E486331CC4E1C000269A1E /* GatewayAPI.swift */; };
@@ -215,6 +216,7 @@
 		229418FC1E827C9E009CF87A /* GetGatewayIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetGatewayIDTests.swift; sourceTree = "<group>"; };
 		229665AE1E84E1E500E860D3 /* GatewayAPIListPendingEndNodesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPIListPendingEndNodesTests.swift; sourceTree = "<group>"; };
 		22AFCCBC1E8A524500C4DB61 /* ThingIFAPIQueryUngroupedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThingIFAPIQueryUngroupedTests.swift; sourceTree = "<group>"; };
+		22C27B631E8B807D00AA2E0B /* ThingIFAPIQueryGroupedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThingIFAPIQueryGroupedTests.swift; sourceTree = "<group>"; };
 		22DC5E9A1E77B04100519807 /* ThingIFAPIAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThingIFAPIAggregateTests.swift; sourceTree = "<group>"; };
 		22DD30FE1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPIListOnboardedEndNodesTests.swift; sourceTree = "<group>"; };
 		22E486331CC4E1C000269A1E /* GatewayAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPI.swift; sourceTree = "<group>"; };
@@ -626,6 +628,7 @@
 				B69ADF3A1E8A5B9100BC48A1 /* ThingIFAPIDeleteTriggerTests.swift */,
 				B69ADF3C1E8A626700BC48A1 /* ThingIFAPIEnableTriggerTests.swift */,
 				22AFCCBC1E8A524500C4DB61 /* ThingIFAPIQueryUngroupedTests.swift */,
+				22C27B631E8B807D00AA2E0B /* ThingIFAPIQueryGroupedTests.swift */,
 			);
 			path = ThingIFSDKTests;
 			sourceTree = "<group>";
@@ -884,6 +887,7 @@
 				22DD30FF1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift in Sources */,
 				B6AFD0331E695A4A0066B4AD /* AllClauseTests.swift in Sources */,
 				B6C2DB4D1E5AC962008DBA83 /* SchedulePredicateTests.swift in Sources */,
+				22C27B641E8B807D00AA2E0B /* ThingIFAPIQueryGroupedTests.swift in Sources */,
 				22DC5E9B1E77B04100519807 /* ThingIFAPIAggregateTests.swift in Sources */,
 				B6A3DA171E7698FD001662D0 /* GatewayAPIPersistenceTests.swift in Sources */,
 				D5D170071E8B934D005EE037 /* PushInstallationTests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDK/GroupedHistoryStates.swift
+++ b/ThingIFSDK/ThingIFSDK/GroupedHistoryStates.swift
@@ -31,3 +31,13 @@ public struct GroupedHistoryStates {
     }
 
 }
+
+extension GroupedHistoryStates : FromJsonObject {
+
+    internal init(_ jsonObject: [String : Any]) throws {
+        self.init(
+            try TimeRange(jsonObject["range"] as! [String : Any]),
+            objects: try (jsonObject["objects"] as! [[String : Any]]).map {try HistoryState($0)}
+        )
+    }
+}

--- a/ThingIFSDK/ThingIFSDK/GroupedHistoryStatesQuery.swift
+++ b/ThingIFSDK/ThingIFSDK/GroupedHistoryStatesQuery.swift
@@ -20,6 +20,7 @@ public struct GroupedHistoryStatesQuery {
     /** Firmware version of a query. */
     public let firmwareVersion: String?
 
+    fileprivate var aggregation: Aggregation? = nil
 
     // MARK: - Initializing GroupedHistoryStatesQuery instance.
     /** Initializer of GroupedHistoryStatesQuery
@@ -45,6 +46,11 @@ public struct GroupedHistoryStatesQuery {
 }
 
 extension GroupedHistoryStatesQuery : ToJsonObject {
+
+    internal mutating func setAggregation(_ aggregation: Aggregation?) {
+        self.aggregation = aggregation
+    }
+
     internal func makeJsonObject() -> [String : Any]{
 
         let timeRangeClause = TimeRangeClauseInQuery(self.timeRange)
@@ -56,6 +62,13 @@ extension GroupedHistoryStatesQuery : ToJsonObject {
             clause = timeRangeClause.makeJsonObject()
         }
 
-        return [ "clause": clause, "grouped": true ]
+        var query : [ String: Any ] = ["clause": clause, "grouped": true ]
+        if self.aggregation != nil {
+            query["aggregations"] = [ self.aggregation!.makeJsonObject() ]
+        }
+
+        var json : [String : Any] = [ "query" : query ]
+        json["firmwareVersion"] = self.firmwareVersion
+        return json
     }
 }

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -85,23 +85,6 @@ open class ThingIFAPI: Equatable {
         _uninstallPush(installationID, completionHandler: completionHandler)
     }
 
-    /** Group history state
-
-     - Parameter query: `GroupedHistoryStatesQuery` instance.timeRange
-       in query should less than 60 data grouping intervals.
-     - Parameter completionHandler: A closure to be executed once
-       finished. The closure takes 2 arguments:
-       - 1st one is `GroupedHistoryStates` array.
-       - 2nd one is an instance of ThingIFError when failed.
-     */
-    open func query(
-      _ query: GroupedHistoryStatesQuery,
-      completionHandler: @escaping (
-        [GroupedHistoryStates]?, ThingIFError?) -> Void) -> Void
-    {
-        // TODO: implement me.
-    }
-
     public static func == (left: ThingIFAPI, right: ThingIFAPI) -> Bool {
         return left.appID == right.appID &&
           left.appKey == right.appKey &&

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIAggregateTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIAggregateTests.swift
@@ -23,7 +23,7 @@ class ThingIFAPIAggregateTests: SmallTestBase {
         let alias = "dummyAlias"
         let timeRange = TimeRange(Date(timeIntervalSince1970: 1), to: Date(timeIntervalSince1970: 1))
         let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
-        let query = GroupedHistoryStatesQuery(alias, timeRange: timeRange, clause: clause)
+        let query = GroupedHistoryStatesQuery(alias, timeRange: timeRange, clause: clause, firmwareVersion: "V1")
         let aggregation = try Aggregation.makeMaxAggregation(
             "dummyField",
             fieldType: Aggregation.FieldType.integer)
@@ -79,7 +79,8 @@ class ThingIFAPIAggregateTests: SmallTestBase {
                                 "fieldType": aggregation.fieldType.rawValue
                             ]
                         ]
-                    ]
+                    ],
+                    "firmwareVersion" : "V1"
                 ],
                 try JSONSerialization.jsonObject(
                     with: request.httpBody!,

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIQueryGroupedTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIQueryGroupedTests.swift
@@ -1,0 +1,647 @@
+//
+//  ThingIFAPIQueryGroupedTests.swift
+//  ThingIFSDK
+//
+//  Copyright (c) 2017 Kii. All rights reserved.
+//
+
+import XCTest
+@testable import ThingIFSDK
+
+class ThingIFAPIQueryGroupedTests: SmallTestBase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testSuccess() throws {
+        let expectation = self.expectation(description: "testSuccess")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let clause : EqualsClauseInQuery = EqualsClauseInQuery("dummyField", intValue: 10)
+        let query = GroupedHistoryStatesQuery(
+            alias,
+            timeRange: TimeRange(
+                Date(timeIntervalSince1970InMillis: 50),
+                to: Date(timeIntervalSince1970InMillis: 50)),
+            clause: clause,
+            firmwareVersion: "V1"
+        )
+        let states = [
+            HistoryState(
+                ["power" : true, "currentTemperature" : 25],
+                createdAt: Date(timeIntervalSince1970: 50)),
+            HistoryState(
+                ["power" : false, "currentTemperature" : 32],
+                createdAt: Date(timeIntervalSince1970: 10)),
+            HistoryState(
+                ["power" : true, "currentTemperature" : 10],
+                createdAt: Date(timeIntervalSince1970: 2000))
+        ]
+        let groupedStates = [
+            GroupedHistoryStates(
+                TimeRange(
+                    Date(timeIntervalSince1970InMillis:1),
+                    to: Date(timeIntervalSince1970InMillis:100)),
+                objects: states)
+        ]
+        
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+            
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+            
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+            
+            //verify body
+            XCTAssertEqual(
+                [
+                    "query": [
+                        "clause": [
+                            "type": "and",
+                            "clauses" : [
+                                clause.makeJsonObject(),
+                                TimeRangeClauseInQuery(query.timeRange).makeJsonObject()
+                            ]
+                        ],
+                        "grouped" : true
+                    ],
+                    "firmwareVersion" : "V1"
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary)
+        }
+        
+        // mock response
+        let responseBody : [String: Any] = [
+            "groupedResults" : groupedStates.map { $0.makeJsonObject() }
+        ]
+        sharedMockSession.mockResponse = (
+            try JSONSerialization.data(withJSONObject: responseBody, options: JSONSerialization.WritingOptions(rawValue: 0)),
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+        
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [GroupedHistoryStates]?, error) in
+            XCTAssertNil(error)
+            XCTAssertEqual(groupedStates, results!)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testSuccessResultsEmpty() throws {
+        let expectation = self.expectation(description: "testSuccessResultsEmpty")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let query = GroupedHistoryStatesQuery(
+            alias,
+            timeRange: TimeRange(
+                Date(timeIntervalSince1970InMillis: 50),
+                to: Date(timeIntervalSince1970InMillis: 50))
+        )
+    
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+            
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+            
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+            
+            //verify body
+            XCTAssertEqual(
+                [
+                    "query": [
+                        "clause": TimeRangeClauseInQuery(query.timeRange).makeJsonObject(),
+                        "grouped" : true
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary)
+        }
+        
+        // mock response
+        let responseBody : [String: Any] = [
+            "groupedResults" : [ ]
+        ]
+        sharedMockSession.mockResponse = (
+            try JSONSerialization.data(withJSONObject: responseBody, options: JSONSerialization.WritingOptions(rawValue: 0)),
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+        
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [GroupedHistoryStates]?, error) in
+            XCTAssertNil(error)
+            XCTAssertEqual([], results!)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testSuccessNoStateInServer() throws {
+        let expectation = self.expectation(description: "testSuccessNoStateInServer")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let query = GroupedHistoryStatesQuery(
+            alias,
+            timeRange: TimeRange(
+                Date(timeIntervalSince1970InMillis: 50),
+                to: Date(timeIntervalSince1970InMillis: 50))
+        )
+        
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+            
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+            
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+            
+            //verify body
+            XCTAssertEqual(
+                [
+                    "query": [
+                        "clause": TimeRangeClauseInQuery(query.timeRange).makeJsonObject(),
+                        "grouped" : true
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary)
+        }
+        
+        // mock response
+        let responseBody : [String: Any] = [
+            "errorCode" : "STATE_HISTORY_NOT_AVAILABLE",
+            "message" : "Time series bucket does not exist"
+        ]
+        sharedMockSession.mockResponse = (
+            try JSONSerialization.data(withJSONObject: responseBody, options: JSONSerialization.WritingOptions(rawValue: 0)),
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 409,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+        
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [GroupedHistoryStates]?, error) in
+            XCTAssertNil(error)
+            XCTAssertEqual([], results!)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testErrorResponse400() throws {
+        let expectation = self.expectation(description: "testErrorResponse400")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let query = GroupedHistoryStatesQuery(
+            alias,
+            timeRange: TimeRange(
+                Date(timeIntervalSince1970InMillis: 50),
+                to: Date(timeIntervalSince1970InMillis: 50))
+        )
+        
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+            
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+            
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+            
+            //verify body
+            XCTAssertEqual(
+                [
+                    "query": [
+                        "clause": TimeRangeClauseInQuery(query.timeRange).makeJsonObject(),
+                        "grouped" : true
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary)
+        }
+        
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 400,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+        
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [GroupedHistoryStates]?, error) in
+            XCTAssertNil(results)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(400, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testErrorResponse403() throws {
+        let expectation = self.expectation(description: "testErrorResponse403")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let query = GroupedHistoryStatesQuery(
+            alias,
+            timeRange: TimeRange(
+                Date(timeIntervalSince1970InMillis: 50),
+                to: Date(timeIntervalSince1970InMillis: 50))
+        )
+        
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+            
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+            
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+            
+            //verify body
+            XCTAssertEqual(
+                [
+                    "query": [
+                        "clause": TimeRangeClauseInQuery(query.timeRange).makeJsonObject(),
+                        "grouped" : true
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary)
+        }
+        
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 403,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+        
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [GroupedHistoryStates]?, error) in
+            XCTAssertNil(results)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(403, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testErrorResponse404() throws {
+        let expectation = self.expectation(description: "testErrorResponse404")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let query = GroupedHistoryStatesQuery(
+            alias,
+            timeRange: TimeRange(
+                Date(timeIntervalSince1970InMillis: 50),
+                to: Date(timeIntervalSince1970InMillis: 50))
+        )
+        
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+            
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+            
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+            
+            //verify body
+            XCTAssertEqual(
+                [
+                    "query": [
+                        "clause": TimeRangeClauseInQuery(query.timeRange).makeJsonObject(),
+                        "grouped" : true
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary)
+        }
+        
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+        
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [GroupedHistoryStates]?, error) in
+            XCTAssertNil(results)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(404, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testErrorResponse409() throws {
+        let expectation = self.expectation(description: "testErrorResponse409")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let query = GroupedHistoryStatesQuery(
+            alias,
+            timeRange: TimeRange(
+                Date(timeIntervalSince1970InMillis: 50),
+                to: Date(timeIntervalSince1970InMillis: 50))
+        )
+        
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+            
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+            
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+            
+            //verify body
+            XCTAssertEqual(
+                [
+                    "query": [
+                        "clause": TimeRangeClauseInQuery(query.timeRange).makeJsonObject(),
+                        "grouped" : true
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary)
+        }
+        
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 409,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+        
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [GroupedHistoryStates]?, error) in
+            XCTAssertNil(results)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(409, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testErrorResponse503() throws {
+        let expectation = self.expectation(description: "testErrorResponse503")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let query = GroupedHistoryStatesQuery(
+            alias,
+            timeRange: TimeRange(
+                Date(timeIntervalSince1970InMillis: 50),
+                to: Date(timeIntervalSince1970InMillis: 50))
+        )
+        
+        // verify request
+        sharedMockSession.requestVerifier = makeRequestVerifier() {(request) in
+            XCTAssertEqual(request.httpMethod, "POST")
+            
+            // verify path
+            XCTAssertEqual(
+                request.url!.absoluteString,
+                "\(setting.api.baseURL)/thing-if/apps/\(setting.app.appID)/targets/\(setting.target.typedID.toString())/states/aliases/\(alias)/query")
+            
+            //verify header
+            XCTAssertEqual(
+                [
+                    "X-Kii-AppID": setting.app.appID,
+                    "X-Kii-AppKey": setting.app.appKey,
+                    "X-Kii-SDK" : SDKVersion.sharedInstance.kiiSDKHeader,
+                    "Authorization": "Bearer \(setting.owner.accessToken)",
+                    "Content-Type": MediaType.mediaTypeTraitStateQueryRequest.rawValue
+                ],
+                request.allHTTPHeaderFields!)
+            
+            //verify body
+            XCTAssertEqual(
+                [
+                    "query": [
+                        "clause": TimeRangeClauseInQuery(query.timeRange).makeJsonObject(),
+                        "grouped" : true
+                    ]
+                ],
+                try JSONSerialization.jsonObject(
+                    with: request.httpBody!,
+                    options: JSONSerialization.ReadingOptions.allowFragments)
+                    as? NSDictionary)
+        }
+        
+        // mock response
+        sharedMockSession.mockResponse = (
+            nil,
+            HTTPURLResponse(
+                url: URL(string:setting.app.baseURL)!,
+                statusCode: 503,
+                httpVersion: nil,
+                headerFields: nil),
+            nil)
+        iotSession = MockSession.self
+        
+        setting.api.target = setting.target
+        setting.api.query(query) {
+            (results: [GroupedHistoryStates]?, error) in
+            XCTAssertNil(results)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(503, errorCode: "", errorMessage: "")),
+                error)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testErrorNoTarget() throws {
+        let expectation = self.expectation(description: "testErrorNoTarget")
+        let setting = TestSetting()
+        let alias = "dummyAlias"
+        let query = GroupedHistoryStatesQuery(
+            alias,
+            timeRange: TimeRange(
+                Date(timeIntervalSince1970InMillis: 50),
+                to: Date(timeIntervalSince1970InMillis: 50))
+        )
+        
+        setting.api.query(query) {
+            (results: [GroupedHistoryStates]?, error) in
+            XCTAssertNil(results)
+            XCTAssertEqual(ThingIFError.targetNotAvailable, error)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 20.0) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+}

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
@@ -72,10 +72,17 @@ struct EndNodeWrapper: EquatableWrapper {
 
 }
 
-extension TimeRange: Equatable {
+extension TimeRange: Equatable, ToJsonObject {
 
     public static func == (left: TimeRange, right: TimeRange) -> Bool {
         return left.from == right.from && left.to == right.to
+    }
+
+    public func makeJsonObject() -> [String : Any] {
+        return [
+            "from" : self.from.timeIntervalSince1970InMillis,
+            "to" : self.to.timeIntervalSince1970InMillis
+        ]
     }
 }
 
@@ -487,6 +494,22 @@ extension HistoryState : Equatable, ToJsonObject {
         var ret = self.state
         ret["_created"] = self.createdAt.timeIntervalSince1970InMillis
         return ret
+    }
+}
+
+extension GroupedHistoryStates : Equatable, ToJsonObject {
+
+    public static func == (left: GroupedHistoryStates, right: GroupedHistoryStates) -> Bool {
+        return
+            left.timeRange == right.timeRange &&
+            left.objects == right.objects
+    }
+
+    public func makeJsonObject() -> [String : Any] {
+        return [
+            "range" : self.timeRange.makeJsonObject(),
+            "objects" : self.objects.map { $0.makeJsonObject() }
+        ]
     }
 }
 


### PR DESCRIPTION
ThingIFAPI.query(Grouped)を実装しテストを追加しました。レビューをお願いします。

GroupedHistoryStatesQueryのmekJsonObject内でJsonの生成を完結させるため、aggregate側も修正していますので注意してください。