### PR TITLE
Fix uninstallPush method

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
@@ -74,7 +74,10 @@ extension ThingIFAPI {
         )
     {
         guard let installationID = installationID ?? self.installationID else {
-            completionHandler(ThingIFError.unsupportedError)
+            completionHandler(
+              ThingIFError.invalidArgument(
+                message:
+                  "installationID is nil and self.installationID also nil."))
             return
         }
         let requestURL = "\(baseURL)/api/apps/\(appID)/installations/\(installationID)"

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
@@ -66,7 +66,7 @@ extension ThingIFAPI {
 
      - Parameter installationID: installation ID returned from
        installPush(). If null is specified, value of the
-       installationID property is used.
+       `installationID` property is used.
      */
     open func uninstallPush(
         _ installationID: String? = nil,
@@ -77,7 +77,7 @@ extension ThingIFAPI {
             completionHandler(
               ThingIFError.invalidArgument(
                 message:
-                  "installationID is nil and self.installationID also nil."))
+                  "Both of installationID and self.installationID are nil."))
             return
         }
         let requestURL = "\(baseURL)/api/apps/\(appID)/installations/\(installationID)"

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
@@ -69,12 +69,15 @@ extension ThingIFAPI {
        installationID property is used.
      */
     open func uninstallPush(
-        _ installationID:String?,
+        _ installationID: String? = nil,
         completionHandler: @escaping (ThingIFError?)-> Void
         )
     {
-        let idParam = installationID != nil ? installationID : self.installationID
-        let requestURL = "\(baseURL)/api/apps/\(appID)/installations/\(idParam!)"
+        guard let installationID = installationID ?? self.installationID else {
+            completionHandler(ThingIFError.unsupportedError)
+            return
+        }
+        let requestURL = "\(baseURL)/api/apps/\(appID)/installations/\(installationID)"
 
         self.operationQueue.addHttpRequestOperation(
             .delete,

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Push.swift
@@ -84,17 +84,16 @@ extension ThingIFAPI {
             url: requestURL,
             requestHeader:
             self.defaultHeader,
-            requestBody: nil,
             failureBeforeExecutionHandler: { completionHandler($0) }) {
-                response, error in
+            response, error in
 
-                if error == nil{
-                    self.installationID = nil
-                }
-                self.saveToUserDefault()
-                DispatchQueue.main.async {
-                    completionHandler( error)
-                }
+            if error == nil && self.installationID == installationID {
+                self.installationID = nil
+            }
+            self.saveToUserDefault()
+            DispatchQueue.main.async {
+                completionHandler( error)
+            }
         }
 
     }

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPushUninstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPushUninstallationTests.swift
@@ -238,13 +238,16 @@ class ThingIFAPIPushUninstallationTests: SmallTestBase {
         checkSavedIoTAPI(setting)
     }
 
-    func testUnsupportedError() {
+    func testInvalidArgumentError() {
         let setting = TestSetting()
 
         setting.api.uninstallPush() {
             error in
 
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(
+                message: "installationID is nil and self.installationID also nil."),
+              error)
         }
     }
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPushUninstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPushUninstallationTests.swift
@@ -246,7 +246,7 @@ class ThingIFAPIPushUninstallationTests: SmallTestBase {
 
             XCTAssertEqual(
               ThingIFError.invalidArgument(
-                message: "installationID is nil and self.installationID also nil."),
+                message: "Both of installationID and self.installationID are nil."),
               error)
         }
     }

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPushUninstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPushUninstallationTests.swift
@@ -111,7 +111,7 @@ class ThingIFAPIPushUninstallationTests: SmallTestBase {
         
         setting.api.uninstallPush(installID) { (error) -> Void in
             XCTAssertTrue(error==nil,"should not error")
-            XCTAssertNil(setting.api.installationID,"Should be nil")
+            XCTAssertEqual("dummyInstallationID", setting.api.installationID)
             expectation.fulfill()
         }
         self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in


### PR DESCRIPTION
* Add nil default parameter for `installationID`
* Fix a condition to set nil to `self.installationID`.
  * `self.installationID` used to become nil only if `uninstallPush` succeed, but I think this is wrong. `uninstallPush` receives `installationID` as its argument, if received `installationID` is different from `self.installationID`, we do not set nil to `self.installationID`. Now `self.installationID` becomes nil if `uninstallPush` succeed and received `installationID` is same as `self.installationID`.
* Add and fix small tests

Related PR: #296