### PR TITLE
Add onboarded checks.

### DIFF
--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIOnboardWithThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIOnboardWithThingIDTests.swift
@@ -75,6 +75,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
           nil)
 
         iotSession = MockSession.self
+        XCTAssertFalse(api.onboarded)
         api.onboardWith(
           thingID: "th.0267251d9d60-1858-5e11-3dc3-00f3f0b5",
           thingPassword: "dummyPassword") { ( target, error) -> Void in
@@ -102,6 +103,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
         let api = setting.api
 
         api.target = setting.target
+        XCTAssertTrue(api.onboarded)
         api.onboardWith(
           thingID: "dummyThingID",
           thingPassword: "dummyPassword") { (target, error) -> Void in
@@ -112,6 +114,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
         self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
             XCTAssertNil(error)
         }
+        XCTAssertTrue(api.onboarded)
     }
 
     func testOnboardWithThingIDAndOptionsSuccess() throws {
@@ -172,6 +175,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
            nil)
         iotSession = MockSession.self
 
+        XCTAssertFalse(setting.api.onboarded)
         setting.api.onboardWith(
           thingID: thingID,
           thingPassword: password,
@@ -188,6 +192,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
             XCTAssertNil(error)
         }
 
+        XCTAssertTrue(setting.api.onboarded)
         XCTAssertEqual(
           setting.api,
           try ThingIFAPI.loadWithStoredInstance(setting.api.tag))
@@ -247,6 +252,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
           nil)
         iotSession = MockSession.self
 
+        XCTAssertFalse(setting.api.onboarded)
         setting.api.onboardWith(
           thingID: thingID,
           thingPassword: password,
@@ -263,6 +269,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
         self.waitForExpectations(timeout: 20.0) { (error) -> Void in
             XCTAssertNil(error)
         }
+        XCTAssertFalse(setting.api.onboarded)
     }
 
     func testOnboardWithThingIDAndOptions404Error() throws {
@@ -319,6 +326,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
           error: nil)
         iotSession = MockSession.self
 
+        XCTAssertFalse(setting.api.onboarded)
         setting.api.onboardWith(
           thingID: thingID,
           thingPassword: password,
@@ -335,6 +343,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
         self.waitForExpectations(timeout: 20.0) { (error) -> Void in
             XCTAssertNil(error)
         }
+        XCTAssertFalse(setting.api.onboarded)
     }
 
     func testOnboardWithThingIDAndOptions500Error() throws {
@@ -391,6 +400,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
           nil)
         iotSession = MockSession.self
 
+        XCTAssertFalse(setting.api.onboarded)
         setting.api.onboardWith(
           thingID: thingID,
           thingPassword: password,
@@ -407,6 +417,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
         self.waitForExpectations(timeout: 20.0) { (error) -> Void in
             XCTAssertNil(error)
         }
+        XCTAssertFalse(setting.api.onboarded)
     }
 
     func testOnboardWithThingIDAndOptionsTwiceTest() throws {
@@ -431,6 +442,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
           nil)
         iotSession = MockSession.self
 
+        XCTAssertFalse(setting.api.onboarded)
         setting.api.onboardWith(
           thingID: thingID,
           thingPassword: password,
@@ -442,6 +454,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
             XCTAssertEqual(target!.accessToken, accessToken)
             expectation.fulfill()
         }
+        XCTAssertTrue(setting.api.onboarded)
 
         self.waitForExpectations(timeout: 20.0) { (error) -> Void in
             XCTAssertNil(error)
@@ -460,6 +473,7 @@ class ThingIFAPIOnboardWithThingIDTests: SmallTestBase {
             XCTAssertEqual(ThingIFError.alreadyOnboarded, error)
         }
 
+        XCTAssertTrue(setting.api.onboarded)
         XCTAssertEqual(
           setting.api,
           try ThingIFAPI.loadWithStoredInstance(setting.api.tag))

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIOnboardWithVendorThingIDTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIOnboardWithVendorThingIDTests.swift
@@ -81,6 +81,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
 
         iotSession = MockSession.self
 
+        XCTAssertFalse(api.onboarded)
         api.onboardWith(
           vendorThingID: vendorThingID,
           thingPassword: thingPassword,
@@ -104,6 +105,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
             XCTAssertNil(error)
         }
 
+        XCTAssertTrue(api.onboarded)
         XCTAssertEqual(
           setting.api,
           try ThingIFAPI.loadWithStoredInstance(setting.api.tag))
@@ -173,7 +175,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
         }
         iotSession = MockSession.self
 
-        // verify request
+        XCTAssertFalse(api.onboarded)
         api.onboardWith(
           vendorThingID:vendorThingID,
           thingPassword: thingPassword,
@@ -197,6 +199,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
             XCTAssertNil(error)
         }
 
+        XCTAssertTrue(api.onboarded)
         XCTAssertEqual(api, try ThingIFAPI.loadWithStoredInstance(api.tag))
     }
 
@@ -272,6 +275,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
         }
         iotSession = MockSession.self
 
+        XCTAssertFalse(setting.api.onboarded)
         setting.api.onboardWith(
           vendorThingID: vendorThingID,
           thingPassword: password,
@@ -287,6 +291,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
         self.waitForExpectations(timeout: 20.0) { (error) -> Void in
             XCTAssertNil(error)
         }
+        XCTAssertTrue(setting.api.onboarded)
     }
 
     func testOnboardWithVendorThingIDAndOptions403Error() throws {
@@ -352,6 +357,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
           nil)
         iotSession = MockSession.self
 
+        XCTAssertFalse(setting.api.onboarded)
         setting.api.onboardWith(
           vendorThingID: vendorThingID,
           thingPassword: password,
@@ -367,6 +373,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
         self.waitForExpectations(timeout: 20.0) { (error) -> Void in
             XCTAssertNil(error)
         }
+        XCTAssertFalse(setting.api.onboarded)
     }
 
     func testOnboardWithVendorThingIDAndOptions404Error() throws {
@@ -432,6 +439,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
           nil)
         iotSession = MockSession.self
 
+        XCTAssertFalse(setting.api.onboarded)
         setting.api.onboardWith(
           vendorThingID: vendorThingID,
           thingPassword: password,
@@ -447,6 +455,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
         self.waitForExpectations(timeout: 20.0) { (error) -> Void in
             XCTAssertNil(error)
         }
+        XCTAssertFalse(setting.api.onboarded)
     }
 
     func testOnboardWithVendorThingIDAndOptions500Error()
@@ -513,6 +522,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
           nil)
         iotSession = MockSession.self
 
+        XCTAssertFalse(setting.api.onboarded)
         setting.api.onboardWith(
           vendorThingID: vendorThingID,
           thingPassword: password,
@@ -528,6 +538,7 @@ class ThingIFAPIOnboardWithVendorThingIDTests: SmallTestBase {
         self.waitForExpectations(timeout: 20.0) { (error) -> Void in
             XCTAssertNil(error)
         }
+        XCTAssertFalse(setting.api.onboarded)
     }
 
 }


### PR DESCRIPTION
To test `ThingIFAPI.onboarded` property, I added test code to onboard tests.

Related PR: #296