### PR TITLE
Change unsupportedError to invalidArgument

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -249,8 +249,14 @@ open class GatewayAPI {
             return;
         }
 
+        if endNode.thingID.isEmpty {
+            completionHandler(
+              ThingIFError.invalidArgument(message: "thingID is empty."))
+            return;
+        }
         if endNode.thingID.isEmpty || endNode.vendorThingID.isEmpty {
-            completionHandler(ThingIFError.unsupportedError)
+            completionHandler(
+              ThingIFError.invalidArgument(message: "vendorThingID is empty."))
             return;
         }
 

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -62,8 +62,14 @@ open class GatewayAPI {
         password: String,
         completionHandler: @escaping (ThingIFError?)-> Void) -> Void
     {
-        if username.isEmpty || password.isEmpty {
-            completionHandler(ThingIFError.unsupportedError)
+        if username.isEmpty {
+            completionHandler(
+              ThingIFError.invalidArgument(message: "username is empty."))
+            return
+        }
+        if password.isEmpty {
+            completionHandler(
+              ThingIFError.invalidArgument(message: "password is empty."))
             return
         }
 

--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI.swift
@@ -317,8 +317,14 @@ open class GatewayAPI {
             return;
         }
 
-        if endNodeThingID.isEmpty || endNodeVendorThingID.isEmpty {
-            completionHandler(ThingIFError.unsupportedError)
+        if endNodeThingID.isEmpty {
+            completionHandler(
+              ThingIFError.invalidArgument(message: "thingID is empty."))
+            return;
+        }
+        if endNodeVendorThingID.isEmpty {
+            completionHandler(
+              ThingIFError.invalidArgument(message: "vendorThingID is empty."))
             return;
         }
 

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+OnBoard.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+OnBoard.swift
@@ -115,7 +115,10 @@ extension ThingIFAPI {
         }
 
         if endnodePassword.isEmpty {
-            completionHandler(nil, ThingIFError.unsupportedError)
+            completionHandler(
+              nil,
+              ThingIFError.invalidArgument(
+                message: "endnodePassword is empty."))
             return
         }
 

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
@@ -150,7 +150,8 @@ extension ThingIFAPI {
             return;
         }
         if firmwareVersion.isEmpty {
-            completionHandler(ThingIFError.unsupportedError)
+            completionHandler(
+              ThingIFError.invalidArgument(message: "firmwareVersionis empty."))
             return;
         }
 

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
@@ -65,9 +65,15 @@ extension ThingIFAPI {
             completionHandler(ThingIFError.targetNotAvailable)
             return;
         }
-        if vendorThingID.isEmpty || password.isEmpty {
-            completionHandler(ThingIFError.unsupportedError)
-            return;
+        if vendorThingID.isEmpty {
+            completionHandler(ThingIFError.invalidArgument(
+                                message: "vendorThingID is empty."))
+            return
+        }
+        if password.isEmpty {
+            completionHandler(ThingIFError.invalidArgument(
+                                message: "password is empty."))
+            return
         }
 
         self.operationQueue.addHttpRequestOperation(

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+ThingInformation.swift
@@ -235,7 +235,8 @@ extension ThingIFAPI {
             return;
         }
         if thingType.isEmpty {
-            completionHandler(ThingIFError.unsupportedError)
+            completionHandler(
+              ThingIFError.invalidArgument(message: "thingType is empty."))
             return;
         }
 

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Trigger.swift
@@ -183,7 +183,10 @@ extension ThingIFAPI {
         }
 
         if requestBody.isEmpty {
-            completionHandler(nil, ThingIFError.unsupportedError)
+            completionHandler(
+              nil,
+              ThingIFError.invalidArgument(
+                message: "nothing to send as patch trigger"))
             return
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
@@ -92,7 +92,9 @@ class GatewayAPILoginTests: GatewayAPITestBase {
           setting.app,
           gatewayAddress: URL(string: setting.app.baseURL)!)
         gatewayAPI.login("", password: password) { error in
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(message: "username is empty."),
+              error)
             expectation.fulfill()
         }
 
@@ -111,7 +113,9 @@ class GatewayAPILoginTests: GatewayAPITestBase {
           setting.app,
           gatewayAddress: URL(string: setting.app.baseURL)!)
         gatewayAPI.login(username, password: "") { error in
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(message: "password is empty."),
+              error)
             expectation.fulfill()
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPINotifyOnboardingCompletionTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPINotifyOnboardingCompletionTests.swift
@@ -100,7 +100,9 @@ class GatewayAPINotifyOnboardingCompletionTests: GatewayAPITestBase {
         let endNode = EndNode("", vendorThingID: vendorThingID)
 
         api.notifyOnboardingCompletion(endNode, completionHandler: { (error:ThingIFError?) -> Void in
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(message: "thingID is empty."),
+              error)
             expectation.fulfill()
         })
 
@@ -117,7 +119,9 @@ class GatewayAPINotifyOnboardingCompletionTests: GatewayAPITestBase {
         let endNode = EndNode(thingID, vendorThingID: "")
 
         api.notifyOnboardingCompletion(endNode, completionHandler: { (error:ThingIFError?) -> Void in
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(message: "vendorThingID is empty."),
+              error)
             expectation.fulfill()
         })
 

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIReplaceEndNodeTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIReplaceEndNodeTests.swift
@@ -108,7 +108,9 @@ class GatewayAPIReplaceEndNodeTests: GatewayAPITestBase {
             "",
             endNodeVendorThingID: vendorThingID,
             completionHandler: { (error:ThingIFError?) -> Void in
-                XCTAssertEqual(ThingIFError.unsupportedError, error)
+                XCTAssertEqual(
+                  ThingIFError.invalidArgument(message: "thingID is empty."),
+                  error)
                 expectation.fulfill()
             }
         )
@@ -128,7 +130,10 @@ class GatewayAPIReplaceEndNodeTests: GatewayAPITestBase {
             thingID,
             endNodeVendorThingID: "",
             completionHandler: { (error:ThingIFError?) -> Void in
-                XCTAssertEqual(ThingIFError.unsupportedError, error)
+                XCTAssertEqual(
+                  ThingIFError.invalidArgument(
+                    message: "vendorThingID is empty."),
+                  error)
                 expectation.fulfill()
             }
         )

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIOnboardEndNodeTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIOnboardEndNodeTests.swift
@@ -440,7 +440,10 @@ class ThingIFAPIOnboardEndNodeTests: SmallTestBase {
             firmwareVersion: firmwareVersion),
           endnodePassword: password) { (endNode, error) -> Void in
             XCTAssertNil(endNode)
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(
+                message: "endnodePassword is empty."),
+              error)
             expectation.fulfill()
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPatchCommandTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPatchCommandTriggerTests.swift
@@ -604,7 +604,10 @@ class ThingIFAPIPatchCommandTriggerTests: SmallTestBase {
           triggeredCommandForm: nil,
           predicate: nil) { (trigger, error) -> Void in
             XCTAssertNil(trigger)
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(
+                message: "nothing to send as patch trigger"),
+              error)
             expectation.fulfill()
         }
 
@@ -627,7 +630,10 @@ class ThingIFAPIPatchCommandTriggerTests: SmallTestBase {
           predicate: nil,
           options: TriggerOptions()) { (trigger, error) -> Void in
             XCTAssertNil(trigger)
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(
+                message: "nothing to send as patch trigger"),
+              error)
             expectation.fulfill()
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPatchServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPatchServerCodeTriggerTests.swift
@@ -467,7 +467,10 @@ class ThingIFAPIPatchServerCodeTriggerTests: SmallTestBase {
           serverCode: nil,
           predicate: nil) { (trigger, error) -> Void in
             XCTAssertNil(trigger)
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(
+                message: "nothing to send as patch trigger"),
+              error)
             expectation.fulfill()
         }
 
@@ -490,7 +493,10 @@ class ThingIFAPIPatchServerCodeTriggerTests: SmallTestBase {
           predicate: nil,
           options: TriggerOptions()) { (trigger, error) -> Void in
             XCTAssertNil(trigger)
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(
+                message: "nothing to send as patch trigger"),
+              error)
             expectation.fulfill()
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -357,7 +357,10 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
         setting.api.update(
           vendorThingID: newVendorThingID,
           password: newPassword) { error -> Void in
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(
+                message: "vendorThingID is empty."),
+              error)
             expectation.fulfill()
         }
 
@@ -381,7 +384,10 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
         setting.api.update(
           vendorThingID: newVendorThingID,
           password: newPassword) { error -> Void in
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(
+                message: "password is empty."),
+              error)
             expectation.fulfill()
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -1456,7 +1456,9 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
         setting.api.target = target
 
         setting.api.update(thingType: "") { error -> Void in
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(message: "thingType is empty."),
+              error)
             expectation.fulfill()
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIThingInformationTests.swift
@@ -824,7 +824,9 @@ class ThingIFAPIThingInformationTests: SmallTestBase {
         api.target = target
 
         setting.api.update(firmwareVersion: "") { error -> Void in
-            XCTAssertEqual(ThingIFError.unsupportedError, error)
+            XCTAssertEqual(
+              ThingIFError.invalidArgument(message: "firmwareVersionis empty."),
+              error)
             expectation.fulfill()
         }
 


### PR DESCRIPTION
@yongpingchen pointed out that `ThingIFError.invalidArgument` is better than `ThingIFError.unsupportedError` in some case. It is pointed out at https://github.com/KiiPlatform/thing-if-iOSSDK/pull/426#discussion_r109096838.

I agreed with his opinion.

I checked code using `ThingIFError.unsupportedError` and changed it to `ThingIFError.invalidArgument`.

Related PR: #296