### PR TITLE
add large tests for ThingIFAPI.query(HisotryStatesQuery).

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		22DD30FF1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DD30FE1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift */; };
 		22DD62EF1E8E3A1200B2507D /* XCTest+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AFD02B1E680D9C0066B4AD /* XCTest+Equatable.swift */; };
 		22DD62F11E8E3E1C00B2507D /* ThingIFAPI+LargeTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DD62F01E8E3E1C00B2507D /* ThingIFAPI+LargeTestUtils.swift */; };
+		22DD62F31E8E4CBF00B2507D /* ThingIFAPIQueryUngroupedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DD62F21E8E4CBF00B2507D /* ThingIFAPIQueryUngroupedTests.swift */; };
 		22E486341CC4E1C000269A1E /* GatewayAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E486331CC4E1C000269A1E /* GatewayAPI.swift */; };
 		22EA81D81E4D83310069B0B8 /* TypedIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EA81D71E4D83310069B0B8 /* TypedIDTests.swift */; };
 		22EA81DA1E4DB1A70069B0B8 /* GroupedHistoryStatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EA81D91E4DB1A70069B0B8 /* GroupedHistoryStatesTests.swift */; };
@@ -224,6 +225,7 @@
 		22DC5E9A1E77B04100519807 /* ThingIFAPIAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThingIFAPIAggregateTests.swift; sourceTree = "<group>"; };
 		22DD30FE1E838D600043AA1A /* GatewayAPIListOnboardedEndNodesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPIListOnboardedEndNodesTests.swift; sourceTree = "<group>"; };
 		22DD62F01E8E3E1C00B2507D /* ThingIFAPI+LargeTestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ThingIFAPI+LargeTestUtils.swift"; sourceTree = "<group>"; };
+		22DD62F21E8E4CBF00B2507D /* ThingIFAPIQueryUngroupedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThingIFAPIQueryUngroupedTests.swift; sourceTree = "<group>"; };
 		22E486331CC4E1C000269A1E /* GatewayAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GatewayAPI.swift; sourceTree = "<group>"; };
 		22EA81D71E4D83310069B0B8 /* TypedIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedIDTests.swift; sourceTree = "<group>"; };
 		22EA81D91E4DB1A70069B0B8 /* GroupedHistoryStatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupedHistoryStatesTests.swift; sourceTree = "<group>"; };
@@ -550,6 +552,7 @@
 				B6A55CD11E8CDB6700AAC733 /* NotOnboardedYetTestsBase.swift */,
 				22CB84C91E8CF9050089450E /* ThingIFAPIAggregateTests.swift */,
 				22DD62F01E8E3E1C00B2507D /* ThingIFAPI+LargeTestUtils.swift */,
+				22DD62F21E8E4CBF00B2507D /* ThingIFAPIQueryUngroupedTests.swift */,
 			);
 			path = ThingIFSDKLargeTests;
 			sourceTree = "<group>";
@@ -886,6 +889,7 @@
 			files = (
 				22DD62F11E8E3E1C00B2507D /* ThingIFAPI+LargeTestUtils.swift in Sources */,
 				B6A55CD21E8CDB6700AAC733 /* NotOnboardedYetTestsBase.swift in Sources */,
+				22DD62F31E8E4CBF00B2507D /* ThingIFAPIQueryUngroupedTests.swift in Sources */,
 				22CB84CA1E8CF9050089450E /* ThingIFAPIAggregateTests.swift in Sources */,
 				22DD62EF1E8E3A1200B2507D /* XCTest+Equatable.swift in Sources */,
 				B6A55CD01E8CC56000AAC733 /* OnboardAPITests.swift in Sources */,

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIQueryUngroupedTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIQueryUngroupedTests.swift
@@ -44,6 +44,7 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             [ "power" : true, "currentTemperature" : 26]
         ]
 
+        // update 4 states
         states.forEach {
             let expectation = self.expectation(description: "updateTargetState")
             onboardedApi.updateTargetState(ALIAS1, state: $0) {
@@ -56,6 +57,7 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             sleep(1)
         }
 
+        // all query
         let query1 = HistoryStatesQuery(
             ALIAS1,
             clause: AllClause())
@@ -65,12 +67,21 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             XCTAssertNil(error)
             XCTAssertNil(nextPaginationKey)
             XCTAssertEqual(4, results!.count)
+            XCTAssertEqual(states[0] as NSDictionary, results![0].state as NSDictionary)
+            XCTAssertNotNil(results![0].createdAt)
+            XCTAssertEqual(states[1] as NSDictionary, results![1].state as NSDictionary)
+            XCTAssertNotNil(results![1].createdAt)
+            XCTAssertEqual(states[2] as NSDictionary, results![2].state as NSDictionary)
+            XCTAssertNotNil(results![2].createdAt)
+            XCTAssertEqual(states[3] as NSDictionary, results![3].state as NSDictionary)
+            XCTAssertNotNil(results![3].createdAt)
             expectation1.fulfill()
         }
         self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
             XCTAssertNil(error)
         }
 
+        // query with empty result returned
         let query2 = HistoryStatesQuery(
             ALIAS1,
             clause: RangeClauseInQuery.greaterThan("currentTemperature", limit: 30),
@@ -87,6 +98,7 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             XCTAssertNil(error)
         }
 
+        // query with bestEffortLimit
         let query3 = HistoryStatesQuery(
             ALIAS1,
             clause: AllClause(),
@@ -98,12 +110,19 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             XCTAssertNil(error)
             XCTAssertEqual("100/3", nextPaginationKey)
             XCTAssertEqual(3, results!.count)
+            XCTAssertEqual(states[0] as NSDictionary, results![0].state as NSDictionary)
+            XCTAssertNotNil(results![0].createdAt)
+            XCTAssertEqual(states[1] as NSDictionary, results![1].state as NSDictionary)
+            XCTAssertNotNil(results![1].createdAt)
+            XCTAssertEqual(states[2] as NSDictionary, results![2].state as NSDictionary)
+            XCTAssertNotNil(results![2].createdAt)
             expectation3.fulfill()
         }
         self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
             XCTAssertNil(error)
         }
 
+        // query with pagination key
         let query4 = HistoryStatesQuery(
             ALIAS1,
             clause: AllClause(),
@@ -114,12 +133,26 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             XCTAssertNil(error)
             XCTAssertNil(nextPaginationKey)
             XCTAssertEqual(1, results!.count)
+            XCTAssertEqual(states[3] as NSDictionary, results![0].state as NSDictionary)
+            XCTAssertNotNil(results![0].createdAt)
             expectation4.fulfill()
         }
         self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
             XCTAssertNil(error)
         }
 
+        // update thing new versio, in v3, ALIAS1 is not defined.
+        let updateExpectation = self.expectation(description: "updateFirmwareVersion")
+        onboardedApi.update(firmwareVersion: "v3") {
+            error in
+            XCTAssertNil(error)
+            updateExpectation.fulfill()
+        }
+        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+
+        // query with older firmwareVersion, in v3, ALIAS1 is not defined.
         let query5 = HistoryStatesQuery(
             ALIAS1,
             clause: AllClause(),
@@ -130,6 +163,14 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             XCTAssertNil(error)
             XCTAssertNil(nextPaginationKey)
             XCTAssertEqual(4, results!.count)
+            XCTAssertEqual(states[0] as NSDictionary, results![0].state as NSDictionary)
+            XCTAssertNotNil(results![0].createdAt)
+            XCTAssertEqual(states[1] as NSDictionary, results![1].state as NSDictionary)
+            XCTAssertNotNil(results![1].createdAt)
+            XCTAssertEqual(states[2] as NSDictionary, results![2].state as NSDictionary)
+            XCTAssertNotNil(results![2].createdAt)
+            XCTAssertEqual(states[3] as NSDictionary, results![3].state as NSDictionary)
+            XCTAssertNotNil(results![3].createdAt)
             expectation5.fulfill()
         }
         self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
@@ -138,7 +179,7 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
     }
 
     func testFailedQueryWithNotDefinedAlias404Error() {
-
+        // update thing new versio, in v3, ALIAS1 is not defined.
         let updateExpectation = self.expectation(description: "updateFirmwareVersion")
         onboardedApi.update(firmwareVersion: "v3") {
             error -> Void in

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIQueryUngroupedTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIQueryUngroupedTests.swift
@@ -1,0 +1,173 @@
+//
+//  ThingIFAPIQueryUngroupedTests.swift
+//  ThingIFSDK
+//
+//  Copyright (c) 2017 Kii. All rights reserved.
+//
+
+import XCTest
+@testable import ThingIFSDK
+
+class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testSuccessQueryEmptyResults() {
+        let query = HistoryStatesQuery(
+            ALIAS1,
+            clause: AllClause())
+
+        let expectation = self.expectation(description: "testSuccessQueryEmptyResults")
+        onboardedApi.query(query) {
+            (results: [HistoryState]?, nextPaginationKey:String?, error) in
+            XCTAssertNil(error)
+            XCTAssertNil(nextPaginationKey)
+            XCTAssertEqual([], results!)
+            expectation.fulfill()
+        }
+        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testSuccessQueryThingUpdateStates() {
+        let states = [
+            [ "power" : true, "currentTemperature" : 23],
+            [ "power" : true, "currentTemperature" : 24],
+            [ "power" : true, "currentTemperature" : 25],
+            [ "power" : true, "currentTemperature" : 26]
+        ]
+
+        states.forEach {
+            let expectation = self.expectation(description: "updateTargetState")
+            onboardedApi.updateTargetState(ALIAS1, state: $0) {
+                (error) in
+                expectation.fulfill()
+            }
+            self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+                XCTAssertNil(error)
+            }
+            sleep(1)
+        }
+
+        let query1 = HistoryStatesQuery(
+            ALIAS1,
+            clause: AllClause())
+        let expectation1 = self.expectation(description: "testSuccessQueryThingUpdateStates1")
+        onboardedApi.query(query1) {
+            (results: [HistoryState]?, nextPaginationKey:String?, error) in
+            XCTAssertNil(error)
+            XCTAssertNil(nextPaginationKey)
+            XCTAssertEqual(4, results!.count)
+            expectation1.fulfill()
+        }
+        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+
+        let query2 = HistoryStatesQuery(
+            ALIAS1,
+            clause: RangeClauseInQuery.greaterThan("currentTemperature", limit: 30),
+            firmwareVersion: "v1")
+        let expectation2 = self.expectation(description: "testSuccessQueryThingUpdateStates2")
+        onboardedApi.query(query2) {
+            (results: [HistoryState]?, nextPaginationKey:String?, error) in
+            XCTAssertNil(error)
+            XCTAssertNil(nextPaginationKey)
+            XCTAssertEqual(0, results!.count)
+            expectation2.fulfill()
+        }
+        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+
+        let query3 = HistoryStatesQuery(
+            ALIAS1,
+            clause: AllClause(),
+            firmwareVersion: "v1",
+            bestEffortLimit: 3)
+        let expectation3 = self.expectation(description: "testSuccessQueryThingUpdateStates3")
+        onboardedApi.query(query3) {
+            (results: [HistoryState]?, nextPaginationKey:String?, error) in
+            XCTAssertNil(error)
+            XCTAssertEqual("100/3", nextPaginationKey)
+            XCTAssertEqual(3, results!.count)
+            expectation3.fulfill()
+        }
+        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+
+        let query4 = HistoryStatesQuery(
+            ALIAS1,
+            clause: AllClause(),
+            nextPaginationKey: "100/3")
+        let expectation4 = self.expectation(description: "testSuccessQueryThingUpdateStates4")
+        onboardedApi.query(query4) {
+            (results: [HistoryState]?, nextPaginationKey:String?, error) in
+            XCTAssertNil(error)
+            XCTAssertNil(nextPaginationKey)
+            XCTAssertEqual(1, results!.count)
+            expectation4.fulfill()
+        }
+        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+
+        let query5 = HistoryStatesQuery(
+            ALIAS1,
+            clause: AllClause(),
+            firmwareVersion: "v1")
+        let expectation5 = self.expectation(description: "testSuccessQueryThingUpdateStates5")
+        onboardedApi.query(query5) {
+            (results: [HistoryState]?, nextPaginationKey:String?, error) in
+            XCTAssertNil(error)
+            XCTAssertNil(nextPaginationKey)
+            XCTAssertEqual(4, results!.count)
+            expectation5.fulfill()
+        }
+        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testFailedQueryWithNotDefinedAlias404Error() {
+
+        let updateExpectation = self.expectation(description: "updateFirmwareVersion")
+        onboardedApi.update(firmwareVersion: "v3") {
+            error -> Void in
+            updateExpectation.fulfill()
+        }
+        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+
+        let query = HistoryStatesQuery(
+            ALIAS1,
+            clause: AllClause())
+
+        let expectation = self.expectation(description: "testError404")
+        onboardedApi.query(query) {
+            (results: [HistoryState]?, nextPaginationKey:String?, error) in
+            XCTAssertNil(results)
+            XCTAssertNil(nextPaginationKey)
+            XCTAssertEqual(
+                ThingIFError.errorResponse(
+                    required: ErrorResponse(
+                        404,
+                        errorCode: "TRAIT_ALIAS_NOT_FOUND",
+                        errorMessage: "The trait alias was not found")),
+                error)
+            expectation.fulfill()
+        }
+        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
+            XCTAssertNil(error)
+        }
+    }
+}


### PR DESCRIPTION
ThingIFAPI.query(HisotryStatesQuery)用のラージテストを追加しました。レビューをお願いします。
内容はAndroid側と同じです。