### PR TITLE
Rollback to guard let.

### DIFF
--- a/ThingIFSDK/ThingIFSDKLargeTests/NotOnboardedYetTestsBase.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/NotOnboardedYetTestsBase.swift
@@ -55,7 +55,6 @@ class NotOnboardedYetTestsBase: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        self.continueAfterFailure = false
         let setting = self.setting
         self.userInfo = createPseudoUser(
                 setting.appID,

--- a/ThingIFSDK/ThingIFSDKLargeTests/NotOnboardedYetTestsBase.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/NotOnboardedYetTestsBase.swift
@@ -55,6 +55,7 @@ class NotOnboardedYetTestsBase: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        self.continueAfterFailure = false
         let setting = self.setting
         self.userInfo = createPseudoUser(
                 setting.appID,

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIScheduleTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIScheduleTriggerTests.swift
@@ -60,8 +60,10 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
         self.waitForExpectations(timeout: TEST_TIMEOUT) { error in
             XCTAssertNil(error)
         }
-        XCTAssertNotNil(gotTriggerID)
-        let triggerID1 = gotTriggerID!
+        guard let triggerID1 = gotTriggerID else {
+            XCTFail("triggerID must get.")
+            return
+        }
 
         let humidityAliasActions = [
           AliasAction(ALIAS2, actions: [Action("setPresetHumidity", value: 45)])
@@ -100,8 +102,10 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
         self.waitForExpectations(timeout: TEST_TIMEOUT) { error in
             XCTAssertNil(error)
         }
-        XCTAssertNotNil(gotTriggerID)
-        let triggerID2 = gotTriggerID!
+        guard let triggerID2 = gotTriggerID else {
+            XCTFail("triggerID must get.")
+            return
+        }
 
         expectation = self.expectation(description: "list trigger first")
         self.onboardedApi.listTriggers(100)  { triggers, paginationKey, error in
@@ -109,8 +113,10 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
             { () in
                 XCTAssertNil(error)
                 XCTAssertNil(paginationKey)
-                XCTAssertNotNil(triggers)
-                let triggers = triggers!
+                guard let triggers = triggers else {
+                    XCTFail("triggers must not be nil")
+                    return
+                }
 
                 XCTAssertEqual(
                   [triggerID1, triggerID2], triggers.map { $0.triggerID })
@@ -184,8 +190,10 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
             { () in
                 XCTAssertNil(error)
                 XCTAssertNil(paginationKey)
-                XCTAssertNotNil(triggers)
-                let triggers = triggers!
+                guard let triggers = triggers else {
+                    XCTFail("triggers must not be nil")
+                    return
+                }
 
                 XCTAssertEqual([triggerID2], triggers.map { $0.triggerID })
 

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIScheduleTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIScheduleTriggerTests.swift
@@ -60,8 +60,8 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
         self.waitForExpectations(timeout: TEST_TIMEOUT) { error in
             XCTAssertNil(error)
         }
+        XCTAssertNotNil(gotTriggerID)
         guard let triggerID1 = gotTriggerID else {
-            XCTFail("triggerID must get.")
             return
         }
 
@@ -102,8 +102,8 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
         self.waitForExpectations(timeout: TEST_TIMEOUT) { error in
             XCTAssertNil(error)
         }
+        XCTAssertNotNil(gotTriggerID)
         guard let triggerID2 = gotTriggerID else {
-            XCTFail("triggerID must get.")
             return
         }
 
@@ -113,8 +113,8 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
             { () in
                 XCTAssertNil(error)
                 XCTAssertNil(paginationKey)
+                XCTAssertNotNil(triggers)
                 guard let triggers = triggers else {
-                    XCTFail("triggers must not be nil")
                     return
                 }
 
@@ -190,8 +190,8 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
             { () in
                 XCTAssertNil(error)
                 XCTAssertNil(paginationKey)
+                XCTAssertNotNil(triggers)
                 guard let triggers = triggers else {
-                    XCTFail("triggers must not be nil")
                     return
                 }
 

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIScheduleTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIScheduleTriggerTests.swift
@@ -60,10 +60,8 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
         self.waitForExpectations(timeout: TEST_TIMEOUT) { error in
             XCTAssertNil(error)
         }
-        guard let triggerID1 = gotTriggerID else {
-            XCTFail("triggerID must get.")
-            return
-        }
+        XCTAssertNotNil(gotTriggerID)
+        let triggerID1 = gotTriggerID!
 
         let humidityAliasActions = [
           AliasAction(ALIAS2, actions: [Action("setPresetHumidity", value: 45)])
@@ -102,10 +100,8 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
         self.waitForExpectations(timeout: TEST_TIMEOUT) { error in
             XCTAssertNil(error)
         }
-        guard let triggerID2 = gotTriggerID else {
-            XCTFail("triggerID must get.")
-            return
-        }
+        XCTAssertNotNil(gotTriggerID)
+        let triggerID2 = gotTriggerID!
 
         expectation = self.expectation(description: "list trigger first")
         self.onboardedApi.listTriggers(100)  { triggers, paginationKey, error in
@@ -113,10 +109,8 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
             { () in
                 XCTAssertNil(error)
                 XCTAssertNil(paginationKey)
-                guard let triggers = triggers else {
-                    XCTFail("triggers must not be nil")
-                    return
-                }
+                XCTAssertNotNil(triggers)
+                let triggers = triggers!
 
                 XCTAssertEqual(
                   [triggerID1, triggerID2], triggers.map { $0.triggerID })
@@ -190,10 +184,8 @@ class ThingIFAPIScheduleTriggerTests: OnboardedTestsBase {
             { () in
                 XCTAssertNil(error)
                 XCTAssertNil(paginationKey)
-                guard let triggers = triggers else {
-                    XCTFail("triggers must not be nil")
-                    return
-                }
+                XCTAssertNotNil(triggers)
+                let triggers = triggers!
 
                 XCTAssertEqual([triggerID2], triggers.map { $0.triggerID })
 


### PR DESCRIPTION
According to [this comment](https://github.com/KiiPlatform/thing-if-iOSSDK/pull/432#discussion_r109824198), I changed `guard let` to `XCTAssertNotNil`.
Now I have remembered why I choose `guard let` rather than `XCTAssertNoNil`.

Following code which you wrote in [the comment](https://github.com/KiiPlatform/thing-if-iOSSDK/pull/432#discussion_r109824198) has possibility to abnomally stop test.

```swift
XCTAssertNotNit(triggers)
let triggers = triggers!
```

If `triggers` is nil, `let triggers = triggers!` causes runtime error. This stop all of tests. As a result, we may not get the reason to stop the tests because a test report may not be created.

So I think `guard let` is better than `XCTAssertNotNil` and unchecked unwrapping.

What do you think?

Related PR: #296 