### PR TITLE
Refactor large tests

### DIFF
--- a/ThingIFSDK/ThingIFSDKLargeTests/OnboardAPITests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/OnboardAPITests.swift
@@ -20,28 +20,28 @@ class OnboardAPITests: NotOnboardedYetTestsBase {
     }
 
     func testOnboardWithVendorThingIDAndThingIDSuccess() {
-        var expectation = self.expectation(description: "testOnboardWithVendorThingIDAndThingIDSuccess")
         let vendorThingID = "vid-" + String(Date().timeIntervalSince1970)
         let vendorThingIdOptions = OnboardWithVendorThingIDOptions(
           DEFAULT_THING_TYPE,
           firmwareVersion: DEFAULT_FIRMWAREVERSION,
           position: .standalone)
-        self.api?.onboardWith(
-          vendorThingID: vendorThingID,
-          thingPassword: "password",
-          options: vendorThingIdOptions) {
-            target, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(target)
-            XCTAssertEqual(.thing, target!.typedID.type)
-            XCTAssertNotEqual(target!.accessToken, nil)
-            expectation.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            self.api?.onboardWith(
+              vendorThingID: vendorThingID,
+              thingPassword: "password",
+              options: vendorThingIdOptions) {
+                target, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(target)
+                XCTAssertEqual(.thing, target!.typedID.type)
+                XCTAssertNotEqual(target!.accessToken, nil)
+            }
         }
 
-        expectation = self.expectation(description: "testOnboardWithVendorThingIDAndThingIDSuccess")
         let api = ThingIFAPI(
           self.app!,
           owner: Owner(
@@ -50,65 +50,65 @@ class OnboardAPITests: NotOnboardedYetTestsBase {
               id: self.userInfo["userID"]! as! String),
             accessToken: self.userInfo["_accessToken"]! as! String))
         let thingIdOptions = OnboardWithThingIDOptions(.standalone)
-        api.onboardWith(
-          thingID: self.api!.target!.typedID.id,
-          thingPassword: "password",
-          options: thingIdOptions) {
-            target, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(target)
-            XCTAssertEqual(.thing, target!.typedID.type)
-            XCTAssertEqual(self.api!.target!.typedID.id, target!.typedID.id)
-            XCTAssertNotEqual(target!.accessToken, nil)
-            expectation.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            api.onboardWith(
+              thingID: self.api!.target!.typedID.id,
+              thingPassword: "password",
+              options: thingIdOptions) {
+                target, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(target)
+                XCTAssertEqual(.thing, target!.typedID.type)
+                XCTAssertEqual(self.api!.target!.typedID.id, target!.typedID.id)
+                XCTAssertNotEqual(target!.accessToken, nil)
+            }
         }
     }
 
     func testOnboardEndnodeWithGatewaySuccess() throws {
-        var expectation = self.expectation(
-          description: "testOnboardEndnodeWithGatewaySuccess")
         // Register gateway.
         let gatewayVendorThingID =
           "gvid-" + String(Date().timeIntervalSince1970)
-        self.api!.onboardWith(
-          vendorThingID: gatewayVendorThingID,
-          thingPassword: "password",
-          options: OnboardWithVendorThingIDOptions(
-            DEFAULT_THING_TYPE,
-            firmwareVersion: DEFAULT_FIRMWAREVERSION,
-            position: .gateway)) {
-            target, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(target)
-            XCTAssertEqual(TypedID.Types.thing, target?.typedID.type)
-            XCTAssertNotNil(target?.accessToken)
-            expectation.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            self.api!.onboardWith(
+              vendorThingID: gatewayVendorThingID,
+              thingPassword: "password",
+              options: OnboardWithVendorThingIDOptions(
+                self.DEFAULT_THING_TYPE,
+                firmwareVersion: self.DEFAULT_FIRMWAREVERSION,
+                position: .gateway)) {
+                target, error in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(target)
+                XCTAssertEqual(TypedID.Types.thing, target?.typedID.type)
+                XCTAssertNotNil(target?.accessToken)
+            }
         }
 
-        expectation = self.expectation(
-          description: "testOnboardEndnodeWithGatewaySuccess")
         let endnodeVendorThingID =
           "vid-" + String(Date().timeIntervalSince1970)
         let pendingEndnode =
           try PendingEndNode(["vendorThingID" : endnodeVendorThingID])
-        self.api!.onboard(
-          pendingEndnode,
-          endnodePassword: "password") {
-            target, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(target)
-            XCTAssertEqual(TypedID.Types.thing, target?.typedID.type)
-            XCTAssertNotNil(target?.accessToken)
-            expectation.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            self.api!.onboard(
+              pendingEndnode,
+              endnodePassword: "password") {
+                target, error in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(target)
+                XCTAssertEqual(TypedID.Types.thing, target?.typedID.type)
+                XCTAssertNotNil(target?.accessToken)
+            }
         }
     }
 

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIAggregateTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIAggregateTests.swift
@@ -56,6 +56,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
+                sleep(2)
             }
         }
 
@@ -103,6 +104,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
+                sleep(2)
             }
         }
 
@@ -155,6 +157,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
+                sleep(2)
             }
         }
 
@@ -207,6 +210,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
+                sleep(2)
             }
         }
 
@@ -255,6 +259,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
+                sleep(2)
             }
         }
 

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIAggregateTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIAggregateTests.swift
@@ -56,7 +56,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
-                sleep(2)
+                sleep(1)
             }
         }
 
@@ -104,7 +104,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
-                sleep(2)
+                sleep(1)
             }
         }
 
@@ -157,7 +157,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
-                sleep(2)
+                sleep(1)
             }
         }
 
@@ -210,7 +210,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
-                sleep(2)
+                sleep(1)
             }
         }
 
@@ -259,7 +259,7 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
                     }
                     XCTAssertNil(error)
                 }
-                sleep(2)
+                sleep(1)
             }
         }
 

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIAggregateTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIAggregateTests.swift
@@ -29,10 +29,15 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             "power",
             fieldType:Aggregation.FieldType.bool)
 
-        onboardedApi.aggregate(query, aggregation: aggregation) {
-            (results: [AggregatedResult<Bool>]?, error) in
-            XCTAssertNil(error)
-            XCTAssertEqual([], results!)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.aggregate(query, aggregation: aggregation) {
+                (results: [AggregatedResult<Bool>]?, error) in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertEqual([], results!)
+            }
         }
     }
 
@@ -42,14 +47,15 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             [ "power" : true, "currentTemperature" : 26]
         ]
 
-        states.forEach {
-            let expectation = self.expectation(description: "updateTargetState")
-            onboardedApi.updateTargetState(ALIAS1, state: $0) {
-                (error) in
-                expectation.fulfill()
-            }
-            self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-                XCTAssertNil(error)
+        for state in states {
+            self.executeAsynchronous { expectation in
+                self.onboardedApi.updateTargetState(self.ALIAS1, state: state) {
+                    (error) in
+                    defer {
+                        expectation.fulfill()
+                    }
+                    XCTAssertNil(error)
+                }
             }
         }
 
@@ -63,17 +69,22 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             "currentTemperature",
             fieldType:Aggregation.FieldType.integer)
 
-        onboardedApi.aggregate(query, aggregation: aggregation) {
-            (results: [AggregatedResult<Int>]?, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(results)
-            XCTAssertEqual(1, results?.count)
-            let result = results![0]
-            XCTAssertNotNil(result)
-            XCTAssertTrue(timeRange.from >= result.timeRange.from)
-            XCTAssertTrue(timeRange.to <= result.timeRange.to)
-            XCTAssertEqual(2, result.value)
-            XCTAssertEqual(0, result.aggregatedObjects.count)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.aggregate(query, aggregation: aggregation) {
+                (results: [AggregatedResult<Int>]?, error) in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(results)
+                XCTAssertEqual(1, results?.count)
+                let result = results![0]
+                XCTAssertNotNil(result)
+                XCTAssertTrue(timeRange.from >= result.timeRange.from)
+                XCTAssertTrue(timeRange.to <= result.timeRange.to)
+                XCTAssertEqual(2, result.value)
+                XCTAssertEqual(0, result.aggregatedObjects.count)
+            }
         }
     }
 
@@ -83,14 +94,15 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             [ "power" : true, "currentTemperature" : 26]
         ]
 
-        states.forEach {
-            let expectation = self.expectation(description: "updateTargetState")
-            onboardedApi.updateTargetState(ALIAS1, state: $0) {
-                (error) in
-                expectation.fulfill()
-            }
-            self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-                XCTAssertNil(error)
+        for state in states {
+            self.executeAsynchronous { expectation in
+                self.onboardedApi.updateTargetState(self.ALIAS1, state: state) {
+                    (error) in
+                    defer {
+                        expectation.fulfill()
+                    }
+                    XCTAssertNil(error)
+                }
             }
         }
 
@@ -104,21 +116,27 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             "currentTemperature",
             fieldType:Aggregation.FieldType.integer)
 
-        onboardedApi.aggregate(query, aggregation: aggregation) {
-            (results: [AggregatedResult<Int>]?, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(results)
-            XCTAssertEqual(1, results?.count)
-            let result = results![0]
-            XCTAssertNotNil(result)
-            XCTAssertTrue(timeRange.from >= result.timeRange.from)
-            XCTAssertTrue(timeRange.to <= result.timeRange.to)
-            XCTAssertEqual(26, result.value)
-            XCTAssertEqual(1, result.aggregatedObjects.count)
-            XCTAssertEqual(
-                states[1] as NSDictionary,
-                result.aggregatedObjects[0].state as NSDictionary)
-            XCTAssertNotNil(result.aggregatedObjects[0].createdAt)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.aggregate(query, aggregation: aggregation) {
+                (results: [AggregatedResult<Int>]?, error) in
+                defer {
+                    expectation.fulfill()
+                }
+
+                XCTAssertNil(error)
+                XCTAssertNotNil(results)
+                XCTAssertEqual(1, results?.count)
+                let result = results![0]
+                XCTAssertNotNil(result)
+                XCTAssertTrue(timeRange.from >= result.timeRange.from)
+                XCTAssertTrue(timeRange.to <= result.timeRange.to)
+                XCTAssertEqual(26, result.value)
+                XCTAssertEqual(1, result.aggregatedObjects.count)
+                XCTAssertEqual(
+                  states[1] as NSDictionary,
+                  result.aggregatedObjects[0].state as NSDictionary)
+                XCTAssertNotNil(result.aggregatedObjects[0].createdAt)
+            }
         }
     }
 
@@ -128,14 +146,15 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             [ "power" : true, "currentTemperature" : 26]
         ]
 
-        states.forEach {
-            let expectation = self.expectation(description: "updateTargetState")
-            onboardedApi.updateTargetState(ALIAS1, state: $0) {
-                (error) in
-                expectation.fulfill()
-            }
-            self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-                XCTAssertNil(error)
+        for state in states {
+            self.executeAsynchronous { expectation in
+                self.onboardedApi.updateTargetState(self.ALIAS1, state: state) {
+                    (error) in
+                    defer {
+                        expectation.fulfill()
+                    }
+                    XCTAssertNil(error)
+                }
             }
         }
 
@@ -149,21 +168,27 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             "currentTemperature",
             fieldType:Aggregation.FieldType.integer)
 
-        onboardedApi.aggregate(query, aggregation: aggregation) {
-            (results: [AggregatedResult<Int>]?, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(results)
-            XCTAssertEqual(1, results?.count)
-            let result = results![0]
-            XCTAssertNotNil(result)
-            XCTAssertTrue(timeRange.from >= result.timeRange.from)
-            XCTAssertTrue(timeRange.to <= result.timeRange.to)
-            XCTAssertEqual(23, result.value)
-            XCTAssertEqual(1, result.aggregatedObjects.count)
-            XCTAssertEqual(
-                states[0] as NSDictionary,
-                result.aggregatedObjects[0].state as NSDictionary)
-            XCTAssertNotNil(result.aggregatedObjects[0].createdAt)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.aggregate(query, aggregation: aggregation) {
+                (results: [AggregatedResult<Int>]?, error) in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(results)
+                XCTAssertEqual(1, results?.count)
+                let result = results![0]
+                XCTAssertNotNil(result)
+                XCTAssertTrue(timeRange.from >= result.timeRange.from)
+                XCTAssertTrue(timeRange.to <= result.timeRange.to)
+                XCTAssertEqual(23, result.value)
+                XCTAssertEqual(1, result.aggregatedObjects.count)
+                XCTAssertEqual(
+                  states[0] as NSDictionary,
+                  result.aggregatedObjects[0].state as NSDictionary)
+                XCTAssertNotNil(result.aggregatedObjects[0].createdAt)
+            }
         }
     }
 
@@ -173,14 +198,15 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             [ "power" : true, "currentTemperature" : 28]
         ]
 
-        states.forEach {
-            let expectation = self.expectation(description: "updateTargetState")
-            onboardedApi.updateTargetState(ALIAS1, state: $0) {
-                (error) in
-                expectation.fulfill()
-            }
-            self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-                XCTAssertNil(error)
+        for state in states {
+            self.executeAsynchronous { expectation in
+                self.onboardedApi.updateTargetState(self.ALIAS1, state: state) {
+                    (error) in
+                    defer {
+                        expectation.fulfill()
+                    }
+                    XCTAssertNil(error)
+                }
             }
         }
 
@@ -194,17 +220,23 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             "currentTemperature",
             fieldType:Aggregation.FieldType.integer)
 
-        onboardedApi.aggregate(query, aggregation: aggregation) {
-            (results: [AggregatedResult<Int>]?, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(results)
-            XCTAssertEqual(1, results?.count)
-            let result = results![0]
-            XCTAssertNotNil(result)
-            XCTAssertTrue(timeRange.from >= result.timeRange.from)
-            XCTAssertTrue(timeRange.to <= result.timeRange.to)
-            XCTAssertEqual(25, result.value)
-            XCTAssertEqual(0, result.aggregatedObjects.count)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.aggregate(query, aggregation: aggregation) {
+                (results: [AggregatedResult<Int>]?, error) in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(results)
+                XCTAssertEqual(1, results?.count)
+                let result = results![0]
+                XCTAssertNotNil(result)
+                XCTAssertTrue(timeRange.from >= result.timeRange.from)
+                XCTAssertTrue(timeRange.to <= result.timeRange.to)
+                XCTAssertEqual(25, result.value)
+                XCTAssertEqual(0, result.aggregatedObjects.count)
+            }
         }
     }
 
@@ -214,14 +246,15 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             [ "power" : true, "currentTemperature" : 26]
         ]
 
-        states.forEach {
-            let expectation = self.expectation(description: "updateTargetState")
-            onboardedApi.updateTargetState(ALIAS1, state: $0) {
-                (error) in
-                expectation.fulfill()
-            }
-            self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-                XCTAssertNil(error)
+        for state in states {
+            self.executeAsynchronous { expectation in
+                self.onboardedApi.updateTargetState(self.ALIAS1, state: state) {
+                    (error) in
+                    defer {
+                        expectation.fulfill()
+                    }
+                    XCTAssertNil(error)
+                }
             }
         }
 
@@ -235,17 +268,23 @@ class ThingIFAPIAggregateTests: OnboardedTestsBase
             "currentTemperature",
             fieldType:Aggregation.FieldType.integer)
 
-        onboardedApi.aggregate(query, aggregation: aggregation) {
-            (results: [AggregatedResult<Int>]?, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(results)
-            XCTAssertEqual(1, results?.count)
-            let result = results![0]
-            XCTAssertNotNil(result)
-            XCTAssertTrue(timeRange.from >= result.timeRange.from)
-            XCTAssertTrue(timeRange.to <= result.timeRange.to)
-            XCTAssertEqual(49, result.value)
-            XCTAssertEqual(0, result.aggregatedObjects.count)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.aggregate(query, aggregation: aggregation) {
+                (results: [AggregatedResult<Int>]?, error) in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(results)
+                XCTAssertEqual(1, results?.count)
+                let result = results![0]
+                XCTAssertNotNil(result)
+                XCTAssertTrue(timeRange.from >= result.timeRange.from)
+                XCTAssertTrue(timeRange.to <= result.timeRange.to)
+                XCTAssertEqual(49, result.value)
+                XCTAssertEqual(0, result.aggregatedObjects.count)
+            }
         }
     }
 }

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPICommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPICommandTests.swift
@@ -25,6 +25,9 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
         self.executeAsynchronous { expectation in
             self.onboardedApi.listCommands() { commands, paginationKey, error in
 
+                defer {
+                    expectation.fulfill()
+                }
                 XCTAssertNil(paginationKey)
                 XCTAssertNil(error)
                 XCTAssertNotNil(commands)
@@ -32,7 +35,6 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
                     // commands must be empty.
                     XCTAssertEqual([], commands)
                 }
-                expectation.fulfill()
             }
         }
 
@@ -50,6 +52,9 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
         self.executeAsynchronous { expectation in
             self.onboardedApi.postNewCommand(
               CommandForm(temperatureAliasActions)) { command, error in
+                defer {
+                    expectation.fulfill()
+                }
                 XCTAssertNil(error)
 
                 // To check command is valid or not, We use CommandToCheck.
@@ -70,7 +75,6 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
                     // Command must be inserted to set as new Item..
                     XCTAssertTrue(createdCommands.insert(command).inserted)
                 }
-                expectation.fulfill()
             }
         }
 
@@ -85,6 +89,10 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
                 title: "dummy titile",
                 commandDescription: "dummy description",
                 metadata: ["k" : "v"])) { command, error in
+
+                defer {
+                    expectation.fulfill()
+                }
 
                 XCTAssertNil(error)
 
@@ -109,7 +117,6 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
                     // Command must be inserted to set as new Item..
                     XCTAssertTrue(createdCommands.insert(command).inserted)
                 }
-                expectation.fulfill()
             }
         }
 
@@ -119,9 +126,11 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
                 self.onboardedApi.getCommand(
                   createdCommand.commandID!) { command, error in
 
+                    defer {
+                        expectation.fulfill()
+                    }
                     XCTAssertNil(error)
                     XCTAssertEqual(createdCommand, command)
-                    expectation.fulfill()
                 }
             }
         }
@@ -139,6 +148,9 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
         self.executeAsynchronous { expectation in
             self.onboardedApi.postNewCommand(
               CommandForm(anotherTemperatureAliasActions)) { command, error in
+                defer {
+                    expectation.fulfill()
+                }
                 XCTAssertNil(error)
 
                 // To check command is valid or not, We use CommandToCheck.
@@ -159,7 +171,6 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
                     // Command must be inserted to set as new Item..
                     XCTAssertTrue(createdCommands.insert(command).inserted)
                 }
-                expectation.fulfill()
             }
         }
 
@@ -167,13 +178,15 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
         self.executeAsynchronous { expectation in
             self.onboardedApi.listCommands() { commands, paginationKey, error in
 
+                defer {
+                    expectation.fulfill()
+                }
                 XCTAssertNil(paginationKey)
                 XCTAssertNil(error)
                 XCTAssertNotNil(commands)
                 if let commands = commands {
                     XCTAssertEqual(createdCommands, Set(commands))
                 }
-                expectation.fulfill()
             }
         }
 
@@ -184,20 +197,21 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
             self.onboardedApi.listCommands(1) {
                 commands, paginationKey, error in
 
-                { () in
-                    XCTAssertNotNil(paginationKey)
-                    XCTAssertNil(error)
-                    XCTAssertNotNil(commands)
-                    guard let commands = commands else {
-                        return
-                    }
-                    XCTAssertEqual(1, commands.count)
-                    XCTAssertTrue(createdCommands.contains(commands[0]))
+                defer {
+                    expectation.fulfill()
+                }
 
-                    gotPaginationKey = paginationKey
-                    gotComand = commands[0]
-                }()
-                expectation.fulfill()
+                XCTAssertNotNil(paginationKey)
+                XCTAssertNil(error)
+                XCTAssertNotNil(commands)
+                guard let commands = commands else {
+                    return
+                }
+                XCTAssertEqual(1, commands.count)
+                XCTAssertTrue(createdCommands.contains(commands[0]))
+
+                gotPaginationKey = paginationKey
+                gotComand = commands[0]
             }
         }
 
@@ -214,17 +228,18 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
 
                 commands, paginationKey, error in
 
-                { () in
-                    XCTAssertNil(paginationKey)
-                    XCTAssertNil(error)
-                    XCTAssertNotNil(commands)
-                    guard let commands = commands else {
-                        return
-                    }
-                    XCTAssertEqual(2, commands.count)
-                    XCTAssertEqual(createdCommands, Set(commands))
-                }()
-                expectation.fulfill()
+                defer {
+                    expectation.fulfill()
+                }
+
+                XCTAssertNil(paginationKey)
+                XCTAssertNil(error)
+                XCTAssertNotNil(commands)
+                guard let commands = commands else {
+                    return
+                }
+                XCTAssertEqual(2, commands.count)
+                XCTAssertEqual(createdCommands, Set(commands))
             }
         }
     }
@@ -232,6 +247,10 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
     func testFailToGetCommand() {
         self.executeAsynchronous { expectation in
             self.onboardedApi.getCommand("dummyID") { command, error in
+
+                defer {
+                    expectation.fulfill()
+                }
 
                 XCTAssertNil(command)
                 XCTAssertEqual(
@@ -243,7 +262,6 @@ class ThingIFAPICommandTests: OnboardedTestsBase {
                   ),
                   error
                 )
-                expectation.fulfill()
             }
         }
     }

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIPushInstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIPushInstallationTests.swift
@@ -22,36 +22,34 @@ class ThingIFAPIPushInstallationTests: OnboardedTestsBase {
 
         let dummyDevice = NSUUID().uuidString.data(using: .ascii)!
 
-        let expectation = self.expectation(description: "testInstallPushNoDevelopmentFlagSuccess")
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.installPush(dummyDevice) {
+                installationID, error in
 
-        onboardedApi.installPush(dummyDevice) { (installationID, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(installationID)
-            expectation.fulfill()
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(installationID)
+            }
         }
-
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
-        }
-
     }
 
     func testInstallPushDevelopmentSuccess() {
 
         let dummyDevice = NSUUID().uuidString.data(using: .ascii)!
 
-        let expectation = self.expectation(description: "testInstallPushDevelopmentSuccess")
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.installPush(dummyDevice, development: true) {
+                installationID, error in
 
-        onboardedApi.installPush(dummyDevice, development: true) { (installationID, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(installationID)
-            expectation.fulfill()
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(installationID)
+            }
         }
-
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
-        }
-        
     }
-    
+
 }

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIPushUnnstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIPushUnnstallationTests.swift
@@ -21,26 +21,25 @@ class ThingIFAPIPushUninstallationTests: OnboardedTestsBase {
     func testUninstallPushSuccess()  {
         let dummyDevice = NSUUID().uuidString.data(using: .ascii)!
 
-        let expectation = self.expectation(description: "install before uninstall")
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.installPush(dummyDevice) {
+                installationID, error in
 
-        onboardedApi.installPush(dummyDevice) { (installationID, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(installationID)
-            expectation.fulfill()
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(installationID)
+            }
         }
 
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
-        }
-
-        let expectation2 = self.expectation(description: "testUninstallPushSuccess")
-        onboardedApi.uninstallPush { (error) in
-            XCTAssertNil(error)
-            expectation2.fulfill()
-        }
-
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.uninstallPush { error in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+            }
         }
 
     }
@@ -48,44 +47,42 @@ class ThingIFAPIPushUninstallationTests: OnboardedTestsBase {
     func testUninstallPushWithInstallationIDSuccess()  {
         let dummyDevice = NSUUID().uuidString.data(using: .ascii)!
 
-        let expectation = self.expectation(description: "install before uninstall")
         var installationID : String?
 
-        onboardedApi.installPush(dummyDevice) { (retInstallationID, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(retInstallationID)
-            installationID = retInstallationID
-            expectation.fulfill()
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.installPush(dummyDevice) {
+                retInstallationID, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNotNil(retInstallationID)
+                installationID = retInstallationID
+            }
         }
 
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.uninstallPush(installationID) { error in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+            }
         }
 
-        let expectation2 = self.expectation(description: "testUninstallPushSuccess")
-        onboardedApi.uninstallPush(installationID) { (error) in
-            XCTAssertNil(error)
-            expectation2.fulfill()
-        }
-
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
-        }
-        
     }
 
     func testUninstallPushError() {
 
-        let expectation = self.expectation(description: "testUninstallPushError")
-        onboardedApi.uninstallPush { (error) in
-            XCTAssertNotNil(error)
-            expectation.fulfill()
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.uninstallPush { error in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNotNil(error)
+            }
         }
 
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
-        }
-        
     }
-    
 }

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIQueryGroupedTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIQueryGroupedTests.swift
@@ -36,14 +36,15 @@ class ThingIFAPIQueryGroupedTests: OnboardedTestsBase {
         // update first 4 states
         let start = Date()
         for (index, state) in airState1.enumerated() {
-            let expectation =
-              self.expectation(description: "updateState\(index)")
-            onboardedApi.updateTargetState(ALIAS1, state: state) {
-                (error) in
-                expectation.fulfill()
-            }
-            self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-                XCTAssertNil(error)
+            self.executeAsynchronous { expectation in
+                self.onboardedApi.updateTargetState(self.ALIAS1, state: state) {
+                    (error) in
+
+                    defer {
+                        expectation.fulfill()
+                    }
+                    XCTAssertNil(error)
+                }
             }
             sleep(1)
         }
@@ -53,62 +54,62 @@ class ThingIFAPIQueryGroupedTests: OnboardedTestsBase {
         // update second 4 states
         sleep(2)
         for (index, state) in airState2.enumerated() {
-            let expectation =
-              self.expectation(description: "updateState\(index)")
-            onboardedApi.updateTargetState(ALIAS1, state: state) {
-                (error) in
-                expectation.fulfill()
-            }
-            self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-                XCTAssertNil(error)
+            self.executeAsynchronous { expectation in
+                self.onboardedApi.updateTargetState(self.ALIAS1, state: state) {
+                    (error) in
+                    defer {
+                        expectation.fulfill()
+                    }
+                    XCTAssertNil(error)
+                }
             }
             sleep(1)
         }
         let end = Date()
 
-        let expectation1 =
-          self.expectation(description: "query with only time range ")
-        self.onboardedApi.query(
-          GroupedHistoryStatesQuery(
-            ALIAS1,
-            timeRange: TimeRange(start, to: end))) { states, error in
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.query(
+              GroupedHistoryStatesQuery(
+                self.ALIAS1,
+                timeRange: TimeRange(start, to: end))) { states, error in
 
-            XCTAssertNil(error)
-            XCTAssertGreaterThanOrEqual(states!.count, 2)
+                defer {
+                    expectation.fulfill()
+                }
 
-            var actualStates: [[String : Any]] = []
-            states!.forEach { actualStates += $0.objects.map { $0.state } }
-            XCTAssertEqual(
-              (airState1 + airState2) as NSArray,
-              actualStates as NSArray)
-            expectation1.fulfill()
+                XCTAssertNil(error)
+                XCTAssertGreaterThanOrEqual(states!.count, 2)
+
+                var actualStates: [[String : Any]] = []
+                states!.forEach { actualStates += $0.objects.map { $0.state } }
+                XCTAssertEqual(
+                  (airState1 + airState2) as NSArray,
+                  actualStates as NSArray)
+            }
         }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
-        }
 
-        let expectation2 =
-          self.expectation(description: "query with clause")
-        self.onboardedApi.query(
-          GroupedHistoryStatesQuery(
-            ALIAS1,
-            timeRange: TimeRange(start, to: end),
-            clause: RangeClauseInQuery.greaterThanOrEqualTo(
-              "currentTemperature",
-              limit: 23))) { states, error in
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.query(
+              GroupedHistoryStatesQuery(
+                self.ALIAS1,
+                timeRange: TimeRange(start, to: end),
+                clause: RangeClauseInQuery.greaterThanOrEqualTo(
+                  "currentTemperature",
+                  limit: 23))) { states, error in
 
-            XCTAssertNil(error)
-            XCTAssertGreaterThanOrEqual(states!.count, 1)
+                defer {
+                    expectation.fulfill()
+                }
 
-            var actualStates: [[String : Any]] = []
-            states!.forEach { actualStates += $0.objects.map { $0.state } }
-            XCTAssertEqual(
-              airState1 as NSArray,
-              actualStates as NSArray)
-            expectation2.fulfill()
+                XCTAssertNil(error)
+                XCTAssertGreaterThanOrEqual(states!.count, 1)
+
+                var actualStates: [[String : Any]] = []
+                states!.forEach { actualStates += $0.objects.map { $0.state } }
+                XCTAssertEqual(
+                  airState1 as NSArray,
+                  actualStates as NSArray)
+            }
         }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
-        }
-  }
+    }
 }

--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIQueryUngroupedTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIQueryUngroupedTests.swift
@@ -23,16 +23,17 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             ALIAS1,
             clause: AllClause())
 
-        let expectation = self.expectation(description: "testSuccessQueryEmptyResults")
-        onboardedApi.query(query) {
-            (results: [HistoryState]?, nextPaginationKey:String?, error) in
-            XCTAssertNil(error)
-            XCTAssertNil(nextPaginationKey)
-            XCTAssertEqual([], results!)
-            expectation.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.query(query) {
+                results, nextPaginationKey, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNil(nextPaginationKey)
+                XCTAssertEqual([], results!)
+            }
         }
     }
 
@@ -45,14 +46,15 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
         ]
 
         // update 4 states
-        states.forEach {
-            let expectation = self.expectation(description: "updateTargetState")
-            onboardedApi.updateTargetState(ALIAS1, state: $0) {
-                (error) in
-                expectation.fulfill()
-            }
-            self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-                XCTAssertNil(error)
+        for state in states {
+            self.executeAsynchronous { expectation in
+                self.onboardedApi.updateTargetState(self.ALIAS1, state: state) {
+                    (error) in
+                    defer {
+                        expectation.fulfill()
+                    }
+                    XCTAssertNil(error)
+                }
             }
             sleep(1)
         }
@@ -61,24 +63,25 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
         let query1 = HistoryStatesQuery(
             ALIAS1,
             clause: AllClause())
-        let expectation1 = self.expectation(description: "testSuccessQueryThingUpdateStates1")
-        onboardedApi.query(query1) {
-            (results: [HistoryState]?, nextPaginationKey:String?, error) in
-            XCTAssertNil(error)
-            XCTAssertNil(nextPaginationKey)
-            XCTAssertEqual(4, results!.count)
-            XCTAssertEqual(states[0] as NSDictionary, results![0].state as NSDictionary)
-            XCTAssertNotNil(results![0].createdAt)
-            XCTAssertEqual(states[1] as NSDictionary, results![1].state as NSDictionary)
-            XCTAssertNotNil(results![1].createdAt)
-            XCTAssertEqual(states[2] as NSDictionary, results![2].state as NSDictionary)
-            XCTAssertNotNil(results![2].createdAt)
-            XCTAssertEqual(states[3] as NSDictionary, results![3].state as NSDictionary)
-            XCTAssertNotNil(results![3].createdAt)
-            expectation1.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.query(query1) {
+                results, nextPaginationKey, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNil(nextPaginationKey)
+                XCTAssertEqual(4, results!.count)
+                XCTAssertEqual(states[0] as NSDictionary, results![0].state as NSDictionary)
+                XCTAssertNotNil(results![0].createdAt)
+                XCTAssertEqual(states[1] as NSDictionary, results![1].state as NSDictionary)
+                XCTAssertNotNil(results![1].createdAt)
+                XCTAssertEqual(states[2] as NSDictionary, results![2].state as NSDictionary)
+                XCTAssertNotNil(results![2].createdAt)
+                XCTAssertEqual(states[3] as NSDictionary, results![3].state as NSDictionary)
+                XCTAssertNotNil(results![3].createdAt)
+            }
         }
 
         // query with empty result returned
@@ -86,16 +89,18 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             ALIAS1,
             clause: RangeClauseInQuery.greaterThan("currentTemperature", limit: 30),
             firmwareVersion: "v1")
-        let expectation2 = self.expectation(description: "testSuccessQueryThingUpdateStates2")
-        onboardedApi.query(query2) {
-            (results: [HistoryState]?, nextPaginationKey:String?, error) in
-            XCTAssertNil(error)
-            XCTAssertNil(nextPaginationKey)
-            XCTAssertEqual(0, results!.count)
-            expectation2.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.query(query2) {
+                results, nextPaginationKey, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNil(nextPaginationKey)
+                XCTAssertEqual(0, results!.count)
+            }
         }
 
         // query with bestEffortLimit
@@ -104,22 +109,24 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             clause: AllClause(),
             firmwareVersion: "v1",
             bestEffortLimit: 3)
-        let expectation3 = self.expectation(description: "testSuccessQueryThingUpdateStates3")
-        onboardedApi.query(query3) {
-            (results: [HistoryState]?, nextPaginationKey:String?, error) in
-            XCTAssertNil(error)
-            XCTAssertEqual("100/3", nextPaginationKey)
-            XCTAssertEqual(3, results!.count)
-            XCTAssertEqual(states[0] as NSDictionary, results![0].state as NSDictionary)
-            XCTAssertNotNil(results![0].createdAt)
-            XCTAssertEqual(states[1] as NSDictionary, results![1].state as NSDictionary)
-            XCTAssertNotNil(results![1].createdAt)
-            XCTAssertEqual(states[2] as NSDictionary, results![2].state as NSDictionary)
-            XCTAssertNotNil(results![2].createdAt)
-            expectation3.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.query(query3) {
+                results, nextPaginationKey, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertEqual("100/3", nextPaginationKey)
+                XCTAssertEqual(3, results!.count)
+                XCTAssertEqual(states[0] as NSDictionary, results![0].state as NSDictionary)
+                XCTAssertNotNil(results![0].createdAt)
+                XCTAssertEqual(states[1] as NSDictionary, results![1].state as NSDictionary)
+                XCTAssertNotNil(results![1].createdAt)
+                XCTAssertEqual(states[2] as NSDictionary, results![2].state as NSDictionary)
+                XCTAssertNotNil(results![2].createdAt)
+            }
         }
 
         // query with pagination key
@@ -127,29 +134,31 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             ALIAS1,
             clause: AllClause(),
             nextPaginationKey: "100/3")
-        let expectation4 = self.expectation(description: "testSuccessQueryThingUpdateStates4")
-        onboardedApi.query(query4) {
-            (results: [HistoryState]?, nextPaginationKey:String?, error) in
-            XCTAssertNil(error)
-            XCTAssertNil(nextPaginationKey)
-            XCTAssertEqual(1, results!.count)
-            XCTAssertEqual(states[3] as NSDictionary, results![0].state as NSDictionary)
-            XCTAssertNotNil(results![0].createdAt)
-            expectation4.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.query(query4) {
+                results, nextPaginationKey, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNil(nextPaginationKey)
+                XCTAssertEqual(1, results!.count)
+                XCTAssertEqual(states[3] as NSDictionary, results![0].state as NSDictionary)
+                XCTAssertNotNil(results![0].createdAt)
+            }
         }
 
         // update thing new versio, in v3, ALIAS1 is not defined.
-        let updateExpectation = self.expectation(description: "updateFirmwareVersion")
-        onboardedApi.update(firmwareVersion: "v3") {
-            error in
-            XCTAssertNil(error)
-            updateExpectation.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.update(firmwareVersion: "v3") {
+                error in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+            }
         }
 
         // query with older firmwareVersion, in v3, ALIAS1 is not defined.
@@ -157,58 +166,62 @@ class ThingIFAPIQueryUngroupedTests: OnboardedTestsBase {
             ALIAS1,
             clause: AllClause(),
             firmwareVersion: "v1")
-        let expectation5 = self.expectation(description: "testSuccessQueryThingUpdateStates5")
-        onboardedApi.query(query5) {
-            (results: [HistoryState]?, nextPaginationKey:String?, error) in
-            XCTAssertNil(error)
-            XCTAssertNil(nextPaginationKey)
-            XCTAssertEqual(4, results!.count)
-            XCTAssertEqual(states[0] as NSDictionary, results![0].state as NSDictionary)
-            XCTAssertNotNil(results![0].createdAt)
-            XCTAssertEqual(states[1] as NSDictionary, results![1].state as NSDictionary)
-            XCTAssertNotNil(results![1].createdAt)
-            XCTAssertEqual(states[2] as NSDictionary, results![2].state as NSDictionary)
-            XCTAssertNotNil(results![2].createdAt)
-            XCTAssertEqual(states[3] as NSDictionary, results![3].state as NSDictionary)
-            XCTAssertNotNil(results![3].createdAt)
-            expectation5.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.query(query5) {
+                results, nextPaginationKey, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+                XCTAssertNil(nextPaginationKey)
+                XCTAssertEqual(4, results!.count)
+                XCTAssertEqual(states[0] as NSDictionary, results![0].state as NSDictionary)
+                XCTAssertNotNil(results![0].createdAt)
+
+                XCTAssertEqual(states[1] as NSDictionary, results![1].state as NSDictionary)
+                XCTAssertNotNil(results![1].createdAt)
+                XCTAssertEqual(states[2] as NSDictionary, results![2].state as NSDictionary)
+                XCTAssertNotNil(results![2].createdAt)
+                XCTAssertEqual(states[3] as NSDictionary, results![3].state as NSDictionary)
+                XCTAssertNotNil(results![3].createdAt)
+            }
         }
     }
 
     func testFailedQueryWithNotDefinedAlias404Error() {
         // update thing new versio, in v3, ALIAS1 is not defined.
-        let updateExpectation = self.expectation(description: "updateFirmwareVersion")
-        onboardedApi.update(firmwareVersion: "v3") {
-            error -> Void in
-            updateExpectation.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.update(firmwareVersion: "v3") { error in
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(error)
+            }
         }
 
         let query = HistoryStatesQuery(
             ALIAS1,
             clause: AllClause())
 
-        let expectation = self.expectation(description: "testError404")
-        onboardedApi.query(query) {
-            (results: [HistoryState]?, nextPaginationKey:String?, error) in
-            XCTAssertNil(results)
-            XCTAssertNil(nextPaginationKey)
-            XCTAssertEqual(
-                ThingIFError.errorResponse(
+        self.executeAsynchronous { expectation in
+            self.onboardedApi.query(query) {
+                results, nextPaginationKey, error in
+
+                defer {
+                    expectation.fulfill()
+                }
+                XCTAssertNil(results)
+                XCTAssertNil(nextPaginationKey)
+                XCTAssertEqual(
+                  ThingIFError.errorResponse(
                     required: ErrorResponse(
-                        404,
-                        errorCode: "TRAIT_ALIAS_NOT_FOUND",
-                        errorMessage: "The trait alias was not found")),
-                error)
-            expectation.fulfill()
-        }
-        self.waitForExpectations(timeout: TEST_TIMEOUT) { (error) -> Void in
-            XCTAssertNil(error)
+                      404,
+                      errorCode: "TRAIT_ALIAS_NOT_FOUND",
+                      errorMessage: "The trait alias was not found")),
+                  error)
+            }
         }
     }
 }

--- a/ThingIFSDK/ThingIFSDKLargeTests/Utilities.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/Utilities.swift
@@ -9,6 +9,19 @@
 import Foundation
 import ThingIFSDK
 
+/*
+ Struct to check received trigger.
+
+ In large tests, It is hard for us to use '==' of Trigger because we can
+ not know values of some properties which are received from server in
+ advance. For example, triggerID, created, modified and so on.
+
+ TriggerToCheck is a struct to check all of properties in Trigger with
+ '==' operator. Introducing TriggerToCheck gives us following 2 benefits:
+
+ 1. Summarize checking Trigger logic in one place.
+ 2. XCode point out failure positions with using XCTAssertEqual.
+ */
 internal struct TriggerToCheck: Equatable, CustomStringConvertible {
 
     private let data: (
@@ -110,6 +123,8 @@ internal struct TriggerToCheck: Equatable, CustomStringConvertible {
 
 }
 
+// Command version of Checking received command.
+// The reason to create this, Please refer TriggerToCheck.
 internal struct CommandToCheck: Equatable, CustomStringConvertible {
 
     private let data: (

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -15,11 +15,15 @@ extension XCTestCase {
     func executeAsynchronous(
       description: String = "Asynchronous test executing",
       timeout: TimeInterval = 5.0,
+      file: StaticString = #file,
+      line: UInt = #line,
       _ executing: @escaping (XCTestExpectation) -> Void) -> Void
     {
         let expectation = self.expectation(description: description)
         executing(expectation)
-        self.waitForExpectations(timeout: timeout) { XCTAssertNil($0) }
+        self.waitForExpectations(timeout: timeout) {
+            XCTAssertNil($0, file: file, line: line)
+        }
     }
 
     internal func makeRequestVerifier(


### PR DESCRIPTION
* Replace `expectation.fulfill()` to `defer { expectation.fulfill() }`
* Use `executeAsynchronous`
* Add sleep when sending target state.
* Add comment to `TriggerToCheck` and `CommandToCheck` struct.

Related PR: #296 