### PR TITLE
Large tests for listTriggeredServerCodeResults

### DIFF
--- a/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIServerCodeTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/ThingIFAPIServerCodeTriggerTests.swift
@@ -413,6 +413,26 @@ class ThingIFAPIServerCodeTriggerTests: OnboardedTestsBase {
         }
     }
 
+    /*
+     testListTriggerServerCodeResults and
+     testListTriggerServerCodeResultsWithError requires deployed
+     server code. We already deployed server code for these tests in
+     current application.
+
+     If you change application, you need to deploy server code before
+     execute these tests.
+
+     The server codes which we deploy are followings:
+
+     function server_code_for_trigger(params, context) {
+       return 100;
+     }
+
+     function server_code_for_trigger_error(params, context) {
+       reference.error = 100;
+       return 100;
+     }
+     */
     func testListTriggerServerCodeResults() {
 
         var createdTriggerID: String?

--- a/ThingIFSDK/ThingIFSDKLargeTests/Utilities.swift
+++ b/ThingIFSDK/ThingIFSDKLargeTests/Utilities.swift
@@ -271,3 +271,100 @@ internal struct CommandToCheck: Equatable, CustomStringConvertible {
         fatalError()
     }
 }
+
+/*
+ TriggeredServerCodeResult version of Checking received
+ TriggeredServerCodeResult. The reason to create this, Please refer
+ TriggerToCheck.
+
+ TriggeredServerCodeResultToCheck ignores executeAt field because of
+ following reasons:
+
+ 1. executeAt is server dependent, we can not know the value in advance.
+ 2. executeAt is not optional so we do not need to check nil.
+ */
+internal struct TriggeredServerCodeResultToCheck:
+  Equatable, CustomStringConvertible
+{
+    private let data: (
+      checker: (
+        succeeded: Bool,
+        endpoint: String?,
+        error: ServerError?,
+        returnedValue: Any?
+      )?,
+      checkee: TriggeredServerCodeResult?
+    )
+
+    init(
+      _ succeeded: Bool,
+      endpoint: String? = nil,
+      error: ServerError? = nil,
+      returnedValue: Any? = nil)
+    {
+        self.init((succeeded, endpoint, error, returnedValue), checkee: nil)
+    }
+
+    init?(_ result: TriggeredServerCodeResult?) {
+        guard let result = result else {
+            return nil
+        }
+        self.init(nil, checkee: result)
+    }
+
+    private init(
+      _ checker: (
+        succeeded: Bool,
+        endpoint: String?,
+        error: ServerError?,
+        returnedValue: Any?
+      )?,
+      checkee: TriggeredServerCodeResult?)
+    {
+        self.data = (checker, checkee)
+    }
+
+    public static func == (
+      left: TriggeredServerCodeResultToCheck,
+      right: TriggeredServerCodeResultToCheck) -> Bool
+    {
+        guard let checker = left.data.checker ?? right.data.checker,
+              let checkee = left.data.checkee ?? right.data.checkee else {
+            fatalError()
+        }
+
+        if checker.succeeded != checkee.succeeded {
+            return false
+        }
+        if checker.endpoint != checkee.endpoint {
+            return false
+        }
+        if checker.error != checkee.error {
+            return false
+        }
+        if !isSameAny(checker.returnedValue, checkee.returnedValue) {
+            return false
+        }
+        return true
+    }
+
+    public var description: String {
+        get {
+            if let checker = self.data.checker {
+                var retval: [String : Any] = ["succeeded" : checker.succeeded]
+                retval["endpoint"] = checker.endpoint
+                retval["error"] = checker.error
+                retval["returnedValue"] = checker.returnedValue
+                return retval.description
+            } else if let checkee = self.data.checkee {
+                var retval: [String : Any] = ["succeeded" : checkee.succeeded]
+                retval["endpoint"] = checkee.endpoint
+                retval["error"] = checkee.error
+                retval["returnedValue"] = checkee.returnedValue
+                return retval.description
+            }
+            fatalError()
+        }
+    }
+
+}

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
@@ -201,7 +201,7 @@ extension AllClause: Equatable {
 
 }
 
-func isSameAny(_ left: Any?, _ right: Any?) -> Bool {
+internal func isSameAny(_ left: Any?, _ right: Any?) -> Bool {
     if left == nil && right == nil {
         return true
     } else if left == nil || right == nil {


### PR DESCRIPTION
I added large tests for `ThingIFAPI.listTriggeredServerCodeResults()`.

Related PR: #296 