### PR TITLE
change getAliasAction to getAliasActions in Command.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Command.swift
+++ b/ThingIFSDK/ThingIFSDK/Command.swift
@@ -87,7 +87,7 @@ public struct Command {
      - Parameter alias: Alias to get action.
      - Returns Array of `AliasAction`.
      */
-    public func getAliasAction(_ alias: String) -> [AliasAction] {
+    public func getAliasActions(_ alias: String) -> [AliasAction] {
         return self.aliasActions.filter { $0.alias == alias }
     }
 

--- a/ThingIFSDK/ThingIFSDKTests/CommandTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/CommandTests.swift
@@ -106,11 +106,11 @@ class CommandTests: SmallTestBase {
 
         XCTAssertEqual(
           [actionA, aliasActionsameAliasAsA],
-          actual.getAliasAction("alias"))
+          actual.getAliasActions("alias"))
         XCTAssertEqual(
           [actionDifferentAliasFromA],
-          actual.getAliasAction("different"))
-        XCTAssertEqual([], actual.getAliasAction("noalias"))
+          actual.getAliasActions("different"))
+        XCTAssertEqual([], actual.getAliasActions("noalias"))
     }
 
     func testGetActionResult() {


### PR DESCRIPTION
CommandのgetAliasActionをgetAliasActionsへ修正しました。レビューをお願いします。

Issue: #447 