### PR TITLE
Refactor tests

### DIFF
--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPILoginTests.swift
@@ -222,10 +222,13 @@ class GatewayAPILoginTests: GatewayAPITestBase {
               ],
               request.allHTTPHeaderFields!)
             //verify body
-            let expectedBody: Dictionary<String, Any> = [
-              "username": username,
-              "password": password];
-            self.verifyDict(expectedBody, actualData: request.httpBody!)
+            let expectedBody = ["username": username, "password": password];
+            XCTAssertEqual(
+              expectedBody,
+              try JSONSerialization.jsonObject(
+                with: request.httpBody!,
+                options: JSONSerialization.ReadingOptions.allowFragments)
+                as! [String : String])
         }
 
         // mock response

--- a/ThingIFSDK/ThingIFSDKTests/NotEqualsClauseInQueryTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/NotEqualsClauseInQueryTests.swift
@@ -48,7 +48,9 @@ class NotEqualsClauseInQueryTests: SmallTestBase {
         for (input, expected) in testCases {
             let actual = NotEqualsClauseInQuery(input)
             XCTAssertEqual(expected.field, actual.equals.field)
-            assertEqualsAny(expected.value, actual.equals.value)
+            XCTAssertEqual(
+              AnyWrapper(expected.value),
+              AnyWrapper(actual.equals.value))
             XCTAssertEqual(
               [
                 "type": "not",

--- a/ThingIFSDK/ThingIFSDKTests/NotEqualsClauseInTriggerTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/NotEqualsClauseInTriggerTests.swift
@@ -53,7 +53,10 @@ class NotEqualsClauseInTriggerTests: SmallTestBase {
             let actual = NotEqualsClauseInTrigger(input)
             let label = "label \(index)"
             XCTAssertEqual(expected.field, actual.equals.field, label)
-            assertEqualsAny(expected.value, actual.equals.value, label)
+            XCTAssertEqual(
+              AnyWrapper(expected.value),
+              AnyWrapper(actual.equals.value),
+              label)
             XCTAssertEqual(
               [
                 "type": "not",

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPushInstallationTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPushInstallationTests.swift
@@ -51,7 +51,7 @@ class ThingIFAPIPushInstallationTests: SmallTestBase {
             let urlResponse = HTTPURLResponse(url: URL(string: "https://api-development-jp.internal.kii.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
             
             // verify request
-            let requestVerifier: ((URLRequest) -> Void) = {(request) in
+            let requestVerifier = makeRequestVerifier() {(request) in
                 XCTAssertEqual(request.httpMethod, "POST")
                 
                 //verify header
@@ -93,7 +93,7 @@ class ThingIFAPIPushInstallationTests: SmallTestBase {
         let expectation = self.expectation(description: "testPushInstallation_success")
         //iotSession = NSURLSession.self
         // verify request
-        let requestVerifier: ((URLRequest) -> Void) = {(request) in
+        let requestVerifier = makeRequestVerifier() {(request) in
             XCTAssertEqual(request.httpMethod, "POST")
             
             //verify header
@@ -103,7 +103,13 @@ class ThingIFAPIPushInstallationTests: SmallTestBase {
             }
             //verify request body
             let expectedBody: [String: Any] = ["installationRegistrationID": self.deviceTokenString, "deviceType": "IOS","development": false]
-            self.verifyDict(expectedBody, actualData: request.httpBody!)
+            XCTAssertEqual(
+              expectedBody as NSDictionary,
+              try JSONSerialization.jsonObject(
+                with: request.httpBody!,
+                options: JSONSerialization.ReadingOptions.allowFragments)
+                as? NSDictionary)
+
             XCTAssertEqual(request.url?.absoluteString, setting.app.baseURL + "/api/apps/50a62843/installations")
         }
         
@@ -142,7 +148,7 @@ class ThingIFAPIPushInstallationTests: SmallTestBase {
         let expectation = self.expectation(description: "testPushInstallation_http_404")
         //iotSession = NSURLSession.self
         // verify request
-        let requestVerifier: ((URLRequest) -> Void) = {(request) in
+        let requestVerifier = makeRequestVerifier() {(request) in
             XCTAssertEqual(request.httpMethod, "POST")
             
             //verify header
@@ -152,7 +158,13 @@ class ThingIFAPIPushInstallationTests: SmallTestBase {
             }
             //verify request body
             let expectedBody: [String: Any] = ["installationRegistrationID": self.deviceTokenString, "deviceType": "IOS","development": false]
-            self.verifyDict(expectedBody, actualData: request.httpBody!)
+            XCTAssertEqual(
+              expectedBody as NSDictionary,
+              try JSONSerialization.jsonObject(
+                with: request.httpBody!,
+                options: JSONSerialization.ReadingOptions.allowFragments)
+                as? NSDictionary)
+
         }
         
         let dict = ["errorCode":"USER_NOT_FOUND","message":"error message"]
@@ -203,7 +215,7 @@ class ThingIFAPIPushInstallationTests: SmallTestBase {
         let expectation = self.expectation(description: "testPushInstallation_http_400")
         //iotSession = NSURLSession.self
         // verify request
-        let requestVerifier: ((URLRequest) -> Void) = {(request) in
+        let requestVerifier = makeRequestVerifier() {(request) in
             XCTAssertEqual(request.httpMethod, "POST")
             
             //verify header
@@ -213,7 +225,13 @@ class ThingIFAPIPushInstallationTests: SmallTestBase {
             }
             //verify request body
             let expectedBody: [String: Any] = ["installationRegistrationID": self.deviceTokenString, "deviceType": "IOS","development": false]
-            self.verifyDict(expectedBody, actualData: request.httpBody!)
+            XCTAssertEqual(
+              expectedBody as NSDictionary,
+              try JSONSerialization.jsonObject(
+                with: request.httpBody!,
+                options: JSONSerialization.ReadingOptions.allowFragments)
+                as? NSDictionary)
+
         }
         
         let dict = ["errorCode":"INVALID_INPUT_DATA","message":"error message"]
@@ -264,7 +282,7 @@ class ThingIFAPIPushInstallationTests: SmallTestBase {
         let expectation = self.expectation(description: "testPushInstallation_http_401")
         //iotSession = NSURLSession.self
         // verify request
-        let requestVerifier: ((URLRequest) -> Void) = {(request) in
+        let requestVerifier = makeRequestVerifier() {(request) in
             XCTAssertEqual(request.httpMethod, "POST")
             
             //verify header
@@ -274,7 +292,13 @@ class ThingIFAPIPushInstallationTests: SmallTestBase {
             }
             //verify request body
             let expectedBody: [String : Any] = ["installationRegistrationID": self.deviceTokenString, "deviceType": "IOS","development": false]
-            self.verifyDict(expectedBody, actualData: request.httpBody!)
+            XCTAssertEqual(
+              expectedBody as NSDictionary,
+              try JSONSerialization.jsonObject(
+                with: request.httpBody!,
+                options: JSONSerialization.ReadingOptions.allowFragments)
+                as? NSDictionary)
+
         }
         
         let dict = ["errorCode":"INVALID_INPUT_DATA","message":"error message"]

--- a/ThingIFSDK/ThingIFSDKTests/TriggerOptionsTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TriggerOptionsTests.swift
@@ -39,16 +39,13 @@ class TriggerOptionsTests: SmallTestBase {
     }
 
     func testInitWithMetadata() {
-        let metadata: Dictionary<String, Any> = [
-            "key1" : "value1",
-            "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let form = TriggerOptions(metadata: metadata)
 
         XCTAssertNotNil(form)
         XCTAssertNil(form.title)
         XCTAssertNil(form.triggerDescription)
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
     }
 
     func testInitWithTitleAndDescription() {
@@ -62,44 +59,35 @@ class TriggerOptionsTests: SmallTestBase {
     }
 
     func testInitWithTitleAndMetadata() {
-        let metadata: Dictionary<String, Any> = [
-            "key1" : "value1",
-            "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let form = TriggerOptions("title",
                                   metadata: metadata)
 
         XCTAssertNotNil(form)
         XCTAssertEqual(form.title, "title")
         XCTAssertNil(form.triggerDescription)
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
     }
 
     func testInitWithDescriptionAndMetadata() {
-        let metadata: Dictionary<String, Any> = [
-            "key1" : "value1",
-            "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let form = TriggerOptions(triggerDescription: "description",
                                   metadata: metadata)
         XCTAssertNotNil(form)
         XCTAssertNil(form.title)
         XCTAssertEqual(form.triggerDescription, "description")
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
     }
 
     func testInitWithAllFields() {
-        let metadata: Dictionary<String, Any> = [
-            "key1" : "value1",
-            "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let form = TriggerOptions("title",
                                   triggerDescription: "description",
                                   metadata: metadata)
         XCTAssertNotNil(form)
         XCTAssertEqual(form.title, "title")
         XCTAssertEqual(form.triggerDescription, "description")
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
     }
 
 }

--- a/ThingIFSDK/ThingIFSDKTests/TriggeredCommandFormTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TriggeredCommandFormTests.swift
@@ -99,16 +99,13 @@ class TriggeredCommandFormTest: SmallTestBase {
             ]
           )
         ]
-        let metadata: Dictionary<String, Any> = [
-          "key1" : "value1",
-          "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let form = TriggeredCommandForm(aliasActions,
                                         metadata: metadata)
         XCTAssertNotNil(form)
         XCTAssertEqual(form.aliasActions, aliasActions)
         XCTAssertNil(form.title)
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
     }
 
     func testInitWithTitleAndDescription() {
@@ -147,10 +144,7 @@ class TriggeredCommandFormTest: SmallTestBase {
             ]
           )
         ]
-        let metadata: Dictionary<String, Any> = [
-          "key1" : "value1",
-          "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let form = TriggeredCommandForm(aliasActions,
                                         title: "title",
                                         metadata: metadata)
@@ -158,7 +152,7 @@ class TriggeredCommandFormTest: SmallTestBase {
         XCTAssertEqual(form.aliasActions, aliasActions)
         XCTAssertEqual(form.title, "title")
         XCTAssertNil(form.commandDescription)
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
     }
 
     func testInitWithDescriptionAndMetadata() {
@@ -174,10 +168,7 @@ class TriggeredCommandFormTest: SmallTestBase {
             ]
           )
         ]
-        let metadata: Dictionary<String, Any> = [
-          "key1" : "value1",
-          "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let form = TriggeredCommandForm(aliasActions,
                                         commandDescription: "description",
                                         metadata: metadata)
@@ -185,7 +176,7 @@ class TriggeredCommandFormTest: SmallTestBase {
         XCTAssertEqual(form.aliasActions, aliasActions)
         XCTAssertNil(form.title)
         XCTAssertEqual(form.commandDescription, "description")
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
     }
 
     func testInitWithTargetID() {
@@ -275,10 +266,7 @@ class TriggeredCommandFormTest: SmallTestBase {
             ]
           )
         ]
-        let metadata: Dictionary<String, Any> = [
-          "key1" : "value1",
-          "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let targetID = TypedID(.thing, id: "id");
         let form = TriggeredCommandForm(aliasActions,
                                         targetID: targetID,
@@ -290,7 +278,7 @@ class TriggeredCommandFormTest: SmallTestBase {
         XCTAssertEqual(form.targetID, targetID)
         XCTAssertEqual(form.title, "title")
         XCTAssertEqual(form.commandDescription, "description")
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
     }
 
     func testInitWithTargetIDAndDescription() {
@@ -331,10 +319,7 @@ class TriggeredCommandFormTest: SmallTestBase {
             ]
           )
         ]
-        let metadata: Dictionary<String, Any> = [
-          "key1" : "value1",
-          "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let targetID = TypedID(.thing, id: "id");
         let form = TriggeredCommandForm(aliasActions,
                                         targetID: targetID,
@@ -344,7 +329,7 @@ class TriggeredCommandFormTest: SmallTestBase {
         XCTAssertEqual(form.aliasActions, aliasActions)
         XCTAssertEqual(form.targetID, targetID)
         XCTAssertEqual(form.commandDescription, "description")
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
         XCTAssertNil(form.title)
     }
 
@@ -361,10 +346,7 @@ class TriggeredCommandFormTest: SmallTestBase {
             ]
           )
         ]
-        let metadata: Dictionary<String, Any> = [
-          "key1" : "value1",
-          "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let targetID = TypedID(.thing, id: "id");
         let form = TriggeredCommandForm(aliasActions,
                                         targetID: targetID,
@@ -372,7 +354,7 @@ class TriggeredCommandFormTest: SmallTestBase {
         XCTAssertNotNil(form)
         XCTAssertEqual(form.aliasActions, aliasActions)
         XCTAssertEqual(form.targetID, targetID)
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
         XCTAssertNil(form.title)
         XCTAssertNil(form.commandDescription)
     }
@@ -390,10 +372,7 @@ class TriggeredCommandFormTest: SmallTestBase {
             ]
           )
         ]
-        let metadata: Dictionary<String, Any> = [
-          "key1" : "value1",
-          "key2" : "value2"
-        ]
+        let metadata = ["key1" : "value1", "key2" : "value2"]
         let targetID = TypedID(.thing, id: "id");
         let form = TriggeredCommandForm(aliasActions,
                                         targetID: targetID,
@@ -405,7 +384,7 @@ class TriggeredCommandFormTest: SmallTestBase {
         XCTAssertEqual(form.targetID, targetID);
         XCTAssertEqual(form.title, "title")
         XCTAssertEqual(form.commandDescription, "description")
-        verifyDict(form.metadata!, actualDict: metadata)
+        XCTAssertEqual(form.metadata as! [String : String], metadata)
     }
 
 }

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
@@ -72,6 +72,22 @@ struct EndNodeWrapper: EquatableWrapper {
 
 }
 
+struct AnyWrapper: EquatableWrapper {
+
+    internal let item: Any
+
+    init?(_ item: Any?) {
+        guard let item = item else {
+            return nil
+        }
+        self.item = item
+    }
+
+    public static func == (left: AnyWrapper, right: AnyWrapper) -> Bool {
+        return isSameAny(left, right)
+    }
+}
+
 extension TimeRange: Equatable, ToJsonObject {
 
     public static func == (left: TimeRange, right: TimeRange) -> Bool {

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Equatable.swift
@@ -9,7 +9,7 @@
 import Foundation
 @testable import ThingIFSDK
 
-public protocol EquatableWrapper: Equatable {
+public protocol EquatableWrapper: Equatable, CustomStringConvertible {
     associatedtype T
 
     var item: T { get }
@@ -21,6 +21,17 @@ extension EquatableWrapper where T: TargetThing {
         return left.item.typedID == right.item.typedID &&
           left.item.accessToken == right.item.accessToken &&
           left.item.vendorThingID == right.item.vendorThingID
+    }
+
+    public var description: String {
+        get {
+            var retval: [String : Any] = [
+              "typedID" : self.item.typedID,
+              "vendorThingID" : self.item.vendorThingID
+            ]
+            retval["accessToken"] = self.item.accessToken
+            return retval.description
+        }
     }
 }
 
@@ -84,7 +95,16 @@ struct AnyWrapper: EquatableWrapper {
     }
 
     public static func == (left: AnyWrapper, right: AnyWrapper) -> Bool {
-        return isSameAny(left, right)
+        return isSameAny(left.item, right.item)
+    }
+
+    public var description: String {
+        get {
+            guard let item = self.item as? CustomStringConvertible else {
+                return "concrete type of this Any does not adopt CustomStringConvertible"
+            }
+            return item.description
+        }
     }
 }
 

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -118,46 +118,4 @@ extension XCTestCase {
         }
     }
 
-    func assertEqualsAny(
-      _ expected:  Any?,
-      _ actual: Any?,
-      _ message: String? = nil,
-      _ file: StaticString = #file,
-      _ line: UInt = #line)
-    {
-        assertOnlyOneNil(expected, actual, message, file, line)
-        if expected == nil && actual == nil {
-            return
-        }
-
-        if expected is String && actual is String {
-            assertEqualsWrapper(
-              expected as! String,
-              actual as! String,
-              message,
-              file: file,
-              line: line)
-            return
-        } else if expected is Int && actual is Int {
-            assertEqualsWrapper(
-              expected as! Int,
-              actual as! Int,
-              message,
-              file: file,
-              line: line)
-            return
-        } else if expected is Bool && actual is Bool {
-            assertEqualsWrapper(
-              expected as! Bool,
-              actual as! Bool,
-              message,
-              file: file,
-              line: line)
-            return
-        } else {
-            fail(message, file, line)
-            return
-        }
-    }
-
 }

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -159,22 +159,5 @@ extension XCTestCase {
             return
         }
     }
-    
-    func verifyDict(_ expectedDict:Dictionary<String, Any>, actualDict: Dictionary<String, Any>?, errorMessage: String? = nil){
-        guard let actualDict2 = actualDict else {
-            XCTFail("actualDict must not be nil")
-            return
-        }
-
-        let s: String
-        if let message = errorMessage {
-            s = message + ", expected=" +
-              expectedDict.description + "actual" + actualDict2.description
-        } else {
-            s = "expected=" + expectedDict.description +
-              "actual" + actualDict2.description
-        }
-        XCTAssertTrue(NSDictionary(dictionary: expectedDict).isEqual(to: actualDict2), s)
-    }
 
 }

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -46,33 +46,6 @@ extension XCTestCase {
         } as (URLRequest) -> Void
     }
 
-    internal func fail(
-      _ message: String? = nil,
-      _ file: StaticString = #file,
-      _ line: UInt = #line)
-    {
-        if (message == nil) {
-            XCTFail(file: file, line: line)
-        } else {
-            XCTFail(message!, file: file, line: line)
-        }
-    }
-
-    internal func assertOnlyOneNil(
-      _ expected: Any?,
-      _ actual: Any?,
-      _ message: String? = nil,
-      _ file: StaticString = #file,
-      _ line: UInt = #line)
-    {
-        if expected == nil && actual == nil {
-            return
-        } else if expected != nil && actual != nil {
-            return
-        }
-        fail(message, file, line)
-    }
-
     func assertEqualsWithAccuracyOrNil<T: FloatingPoint>(
       _ expected:  T?,
       _ actual: T?,
@@ -81,8 +54,14 @@ extension XCTestCase {
       _ file: StaticString = #file,
       _ line: UInt = #line)
     {
-        assertOnlyOneNil(expected, actual, message, file, line)
         if expected == nil && actual == nil {
+            return
+        } else if expected == nil || actual == nil {
+            if (message == nil) {
+                XCTFail(file: file, line: line)
+            } else {
+                XCTFail(message!, file: file, line: line)
+            }
             return
         }
 

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -159,40 +159,7 @@ extension XCTestCase {
             return
         }
     }
-
-    func verifyArray(_ expected: [Any]?,
-                     actual: [Any]?,
-                     message: String? = nil)
-    {
-        if expected == nil && actual == nil {
-            return
-        }
-        guard let expected2 = expected, let actual2 = actual else {
-            XCTFail("one of expected or actual is nil")
-            return
-        }
-
-        let error_message: String
-        if let message2 = message {
-            error_message = message2 + ", expected=" + expected2.description +
-              "actual=" + actual2.description
-        } else {
-            error_message = "expected=" + expected2.description +
-              "actual=" + actual2.description
-        }
-        XCTAssertEqual(NSArray(array: expected2), NSArray(array: actual2),
-                      error_message)
-    }
     
-    func verifyDict2(_ expectedDict:Dictionary<String, Any>?, _ actualDict: Dictionary<String, Any>?, _ errorMessage: String? = nil){
-        if expectedDict == nil && actualDict == nil {
-            return
-        }
-        verifyDict(expectedDict!,
-                   actualDict: actualDict,
-                   errorMessage: errorMessage)
-    }
-
     func verifyDict(_ expectedDict:Dictionary<String, Any>, actualDict: Dictionary<String, Any>?, errorMessage: String? = nil){
         guard let actualDict2 = actualDict else {
             XCTFail("actualDict must not be nil")
@@ -209,10 +176,6 @@ extension XCTestCase {
         }
         XCTAssertTrue(NSDictionary(dictionary: expectedDict).isEqual(to: actualDict2), s)
     }
-    func verifyNsDict(_ expectedDict:NSDictionary, actualDict:NSDictionary){
-        let s = "expected=" + expectedDict.description + "actual" + actualDict.description
-        XCTAssertTrue(expectedDict.isEqual(to: actualDict as! [AnyHashable: Any]), s)
-    }
     
     func verifyDict(_ expectedDict:Dictionary<String, Any>, actualData: Data){
         
@@ -225,14 +188,4 @@ extension XCTestCase {
         }
     }
 
-    func XCTAssertEqualDictionaries<S, T: Equatable>(_ first: [S:T], _ second: [S:T]) {
-        XCTAssert(first == second)
-    }
-
-    func XCTAssertEqualIoTAPIWithoutTarget(_ first: ThingIFAPI, _ second: ThingIFAPI) {
-        XCTAssertEqual(first.appID, second.appID)
-        XCTAssertEqual(first.appKey, second.appKey)
-        XCTAssertEqual(first.baseURL, second.baseURL)
-        XCTAssertEqual(first.installationID, second.installationID)
-    }
 }

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -73,20 +73,6 @@ extension XCTestCase {
         fail(message, file, line)
     }
 
-    internal func assertEqualsWrapper<T : Equatable>(
-      _ expected: T,
-      _ actual: T,
-      _ message: String? = nil,
-      file: StaticString = #file,
-      line: UInt = #line)
-    {
-        if message == nil {
-            XCTAssertEqual(expected, actual, file: file, line: line)
-        } else {
-            XCTAssertEqual(expected, actual, message!, file: file, line: line)
-        }
-    }
-
     func assertEqualsWithAccuracyOrNil<T: FloatingPoint>(
       _ expected:  T?,
       _ actual: T?,

--- a/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
+++ b/ThingIFSDK/ThingIFSDKTests/XCTest+Utils.swift
@@ -176,16 +176,5 @@ extension XCTestCase {
         }
         XCTAssertTrue(NSDictionary(dictionary: expectedDict).isEqual(to: actualDict2), s)
     }
-    
-    func verifyDict(_ expectedDict:Dictionary<String, Any>, actualData: Data){
-        
-        do{
-            let actualDict: NSDictionary = try JSONSerialization.jsonObject(with: actualData, options: JSONSerialization.ReadingOptions.allowFragments) as! NSDictionary
-            let s = "\nexpected=" + expectedDict.description + "\nactual" + actualDict.description
-            XCTAssertTrue(NSDictionary(dictionary: expectedDict).isEqual(to: actualDict as! [AnyHashable: Any]), s)
-        }catch(_){
-            XCTFail()
-        }
-    }
 
 }


### PR DESCRIPTION
Refactor test utilities

* Remove unused test utilities
* Replace `verifyDict` to `XCTAssertEqual`
* Replace `assertEqualsAny` to `XCTAssertEqual` and `AnyWrapper`.

Related PR: #296 