### PR TITLE
Make internal OperationBlock and AlertPresentation.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Operations/BlockOperation.swift
+++ b/ThingIFSDK/ThingIFSDK/Operations/BlockOperation.swift
@@ -9,7 +9,7 @@ This code shows how to create a simple subclass of Operation.
 import Foundation
 
 /// A closure type that takes a closure as its parameter.
-typealias OperationBlock = (@escaping (Void) -> Void) -> Void
+internal typealias OperationBlock = (@escaping (Void) -> Void) -> Void
 
 /// A sublcass of `Operation` to execute a closure.
 class BlockOperation: Operation {

--- a/ThingIFSDK/ThingIFSDK/Operations/MutuallyExclusive.swift
+++ b/ThingIFSDK/ThingIFSDK/Operations/MutuallyExclusive.swift
@@ -36,4 +36,4 @@ struct MutuallyExclusive<T>: OperationCondition {
 enum Alert { }
 
 /// A condition describing that the targeted operation may present an alert.
-typealias AlertPresentation = MutuallyExclusive<Alert>
+internal typealias AlertPresentation = MutuallyExclusive<Alert>


### PR DESCRIPTION
API document contained `OperationBlock` and `AlertPresentation` but they are not API. To force not to access these types, I make them internal.

Related PR: #296 