### PR TITLE
replace buggy SDK API.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Operations/GroupOperation.swift
+++ b/ThingIFSDK/ThingIFSDK/Operations/GroupOperation.swift
@@ -98,7 +98,7 @@ extension GroupOperation: OperationQueueDelegate {
     }
     
     final func operationQueue(_ operationQueue: OperationQueue, operationDidFinish operation: Foundation.Operation, withErrors errors: [NSError]) {
-        aggregatedErrors.append(contentsOf: errors)
+        aggregatedErrors = aggregatedErrors + errors
         
         if operation === finishingOperation {
             internalQueue.isSuspended = true


### PR DESCRIPTION
# Problem
- Testcase is failed/crashed on iOS 10.3 simulator

# Root cause and fix
- it seems Array `append(contents​Of:​)` has a problem on ios 10.3, replacing with `+` operator