### PR TITLE
lock Target and installationID.

### DIFF
--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI.swift
@@ -35,15 +35,34 @@ open class ThingIFAPI: Equatable {
     /** owner of target */
     open let owner: Owner
 
+    private let lockQueue : DispatchQueue = DispatchQueue(label: "ThingIFAPILock")
+    private var safeTarget: Target?
+    private var safeInstallationID: String?
+
     /** Get installationID if the push is already installed.
     null will be returned if the push installation has not been done.
 
     - Returns: Installation ID used in IoT Cloud.
     */
-    open internal(set) var installationID: String?
+    open internal(set) var installationID: String? {
+        get{
+            return lockQueue.sync{ safeInstallationID }
+        }
+        set(newInstallationID){
+            lockQueue.sync{ safeInstallationID = newInstallationID }
+        }
+    }
 
     /** target */
-    open internal(set) var target: Target?
+    open internal(set) var target: Target? {
+        get{
+            return lockQueue.sync{ safeTarget }
+        }
+        set(newTarget){
+            lockQueue.sync{ safeTarget = newTarget }
+        }
+    }
+
 
     /** Checks whether on boarding is done. */
     open var onboarded: Bool {
@@ -67,7 +86,7 @@ open class ThingIFAPI: Equatable {
     {
         self.app = app
         self.owner = owner
-        self.target = target
+        self.safeTarget = target
         self.tag = tag
     }
 


### PR DESCRIPTION
This can prevent data race condition.