### PR TITLE
Mock user defaults

### DIFF
--- a/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI+Persistence.swift
+++ b/ThingIFSDK/ThingIFSDK/Gateway/GatewayAPI+Persistence.swift
@@ -56,7 +56,7 @@ extension GatewayAPI {
         // try to get iotAPI from NSUserDefaults
 
         guard let dict =
-                UserDefaults.standard.dictionary(forKey: baseKey) else {
+                iotUserDefaults.standard.dictionary(forKey: baseKey) else {
             throw ThingIFError.apiNotStored(tag: tag)
         }
 
@@ -85,36 +85,36 @@ extension GatewayAPI {
         return retval
     }
 
-    /** Clear all saved instances in the NSUserDefaults.
+    /** Clear all saved instances in the NSiotUserDefaults.
      */
     open static func removeAllStoredInstances() -> Void
     {
-        UserDefaults.standard.removeObject(
+        iotUserDefaults.standard.removeObject(
           forKey: GatewayAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE)
-        UserDefaults.standard.synchronize()
+        iotUserDefaults.standard.synchronize()
     }
 
-    /** Remove saved specified instance in the NSUserDefaults.
+    /** Remove saved specified instance in the NSiotUserDefaults.
 
      - Parameter tag: tag of the GatewayAPI instance or nil for default tag
      */
     open static func removeStoredInstances(
       _ tag : String? = nil) -> Void
     {
-        if var dict = UserDefaults.standard.dictionary(
+        if var dict = iotUserDefaults.standard.dictionary(
              forKey: GatewayAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE) {
             dict[GatewayAPI.getStoredSDKVersionKey(tag)] = nil
             dict[GatewayAPI.getStoredInstanceKey(tag)] = nil
-            UserDefaults.standard.set(
+            iotUserDefaults.standard.set(
               dict,
               forKey: GatewayAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE)
-            UserDefaults.standard.synchronize()
+            iotUserDefaults.standard.synchronize()
         }
     }
 
     /** Save this instance
 
-     This method use NSUserDefaults. Should not use the key
+     This method use NSiotUserDefaults. Should not use the key
      "GatewayAPI_INSTANCE", this key is reserved.
      */
     open func saveInstance() -> Void {
@@ -127,16 +127,16 @@ extension GatewayAPI {
         // first. This may be bug of iOS. We should investigate the
         // reason in future.
         // https://github.com/KiiPlatform/thing-if-iOSSDK/issues/221
-        var dict = UserDefaults.standard.dictionary(
+        var dict = iotUserDefaults.standard.dictionary(
           forKey: GatewayAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE) ?? [ : ]
         dict[GatewayAPI.getStoredInstanceKey(self.tag)] = data
         dict[GatewayAPI.getStoredSDKVersionKey(self.tag)] =
           SDKVersion.sharedInstance.versionString
 
-        UserDefaults.standard.set(
+        iotUserDefaults.standard.set(
           dict,
           forKey: GatewayAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE)
-        UserDefaults.standard.synchronize()
+        iotUserDefaults.standard.synchronize()
     }
 
     private static func isLoadable(_ storedSDKVersion: String?) -> Bool {

--- a/ThingIFSDK/ThingIFSDK/IoTOperations/IoTRequestOperation.swift
+++ b/ThingIFSDK/ThingIFSDK/IoTOperations/IoTRequestOperation.swift
@@ -75,6 +75,7 @@ func buildNewRequest(_ method : HTTPMethod,urlString: String,requestHeaderDict: 
 
 //use for dependency injection
 var iotSession = URLSession.self
+var iotUserDefaults = UserDefaults.self
 
 class IoTRequestOperation<T>: GroupOperation {
     init(request : IotRequest<T>){

--- a/ThingIFSDK/ThingIFSDK/ThingIFAPI+Persistence.swift
+++ b/ThingIFSDK/ThingIFSDK/ThingIFAPI+Persistence.swift
@@ -55,7 +55,7 @@ extension ThingIFAPI {
 
         // try to get iotAPI from NSUserDefaults
         guard let dict =
-                UserDefaults.standard.dictionary(forKey: baseKey) else {
+                iotUserDefaults.standard.dictionary(forKey: baseKey) else {
             throw ThingIFError.apiNotStored(tag: tag)
         }
 
@@ -89,26 +89,26 @@ extension ThingIFAPI {
         self.saveToUserDefault()
     }
 
-    /** Clear all saved instances in the NSUserDefaults.
+    /** Clear all saved instances in the NSiotUserDefaults.
     */
     open static func removeAllStoredInstances() {
         let baseKey = ThingIFAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE
-        UserDefaults.standard.removeObject(forKey: baseKey)
-        UserDefaults.standard.synchronize()
+        iotUserDefaults.standard.removeObject(forKey: baseKey)
+        iotUserDefaults.standard.synchronize()
     }
 
-    /** Remove saved specified instance in the NSUserDefaults.
+    /** Remove saved specified instance in the NSiotUserDefaults.
     - Parameter tag: tag of the ThingIFAPI instance or nil for default tag
     */
     open static func removeStoredInstances(_ tag : String? = nil) -> Void {
         let baseKey = ThingIFAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE
         let versionKey = ThingIFAPI.getStoredSDKVersionKey(tag)
         let key = ThingIFAPI.getStoredInstanceKey(tag)
-        if var dict = UserDefaults.standard.dictionary(forKey: baseKey) {
+        if var dict = iotUserDefaults.standard.dictionary(forKey: baseKey) {
             dict[versionKey] = nil
             dict[key] = nil
-            UserDefaults.standard.set(dict, forKey: baseKey)
-            UserDefaults.standard.synchronize()
+            iotUserDefaults.standard.set(dict, forKey: baseKey)
+            iotUserDefaults.standard.synchronize()
         }
     }
 
@@ -145,16 +145,16 @@ extension ThingIFAPI {
         // first. This may be bug of iOS. We should investigate the
         // reason in future.
         // https://github.com/KiiPlatform/thing-if-iOSSDK/issues/221
-        var dict = UserDefaults.standard.dictionary(
+        var dict = iotUserDefaults.standard.dictionary(
           forKey: ThingIFAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE) ?? [ : ]
         dict[ThingIFAPI.getStoredInstanceKey(self.tag)] = data
         dict[ThingIFAPI.getStoredSDKVersionKey(self.tag)] =
           SDKVersion.sharedInstance.versionString
-        UserDefaults.standard.set(
+        iotUserDefaults.standard.set(
           dict,
           forKey: ThingIFAPI.SHARED_NSUSERDEFAULT_KEY_INSTANCE)
 
-        UserDefaults.standard.synchronize()
+        iotUserDefaults.standard.synchronize()
     }
 
     static func isLoadable(_ storedSDKVersion: String?) -> Bool {

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPILoadInstanceErrorTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPILoadInstanceErrorTests.swift
@@ -10,12 +10,6 @@ import XCTest
 @testable import ThingIFSDK
 
 class GatewayAPILoadInstanceErrorTests: SmallTestBase {
-    override func setUp() {
-        super.setUp()
-        //removing all gateway stored instance
-        GatewayAPI.removeAllStoredInstances()
-
-    }
 
     func testLoadStoredInstanceError(){
 

--- a/ThingIFSDK/ThingIFSDKTests/GatewayAPIPersistenceTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/GatewayAPIPersistenceTests.swift
@@ -120,10 +120,10 @@ class GatewayAPIPersistenceTests: GatewayAPITestBase {
         }
 
         let baseKey = "GatewayAPI_INSTANCE"
-        if var dict = UserDefaults.standard.dictionary(forKey: baseKey) {
+        if var dict = iotUserDefaults.standard.dictionary(forKey: baseKey) {
             dict["GatewayAPI_VERSION"] = nil
-            UserDefaults.standard.set(dict, forKey: baseKey)
-            UserDefaults.standard.synchronize()
+            iotUserDefaults.standard.set(dict, forKey: baseKey)
+            iotUserDefaults.standard.synchronize()
         }
 
         XCTAssertThrowsError(try GatewayAPI.loadWithStoredInstance()) { error in
@@ -168,10 +168,10 @@ class GatewayAPIPersistenceTests: GatewayAPITestBase {
         }
 
         let baseKey = "GatewayAPI_INSTANCE"
-        if var dict = UserDefaults.standard.dictionary(forKey: baseKey) {
+        if var dict = iotUserDefaults.standard.dictionary(forKey: baseKey) {
             dict["GatewayAPI_VERSION"] = "0.0.0"
-            UserDefaults.standard.set(dict, forKey: baseKey)
-            UserDefaults.standard.synchronize()
+            iotUserDefaults.standard.set(dict, forKey: baseKey)
+            iotUserDefaults.standard.synchronize()
         }
 
         XCTAssertThrowsError(try GatewayAPI.loadWithStoredInstance()) { error in
@@ -216,10 +216,10 @@ class GatewayAPIPersistenceTests: GatewayAPITestBase {
         }
 
         let baseKey = "GatewayAPI_INSTANCE"
-        if var dict = UserDefaults.standard.dictionary(forKey: baseKey) {
+        if var dict = iotUserDefaults.standard.dictionary(forKey: baseKey) {
             dict["GatewayAPI_VERSION"] = "1000.0.0"
-            UserDefaults.standard.set(dict, forKey: baseKey)
-            UserDefaults.standard.synchronize()
+            iotUserDefaults.standard.set(dict, forKey: baseKey)
+            iotUserDefaults.standard.synchronize()
         }
 
         XCTAssertEqual(api, try GatewayAPI.loadWithStoredInstance())

--- a/ThingIFSDK/ThingIFSDKTests/SmallTestBase.swift
+++ b/ThingIFSDK/ThingIFSDKTests/SmallTestBase.swift
@@ -4,6 +4,9 @@ import XCTest
 class SmallTestBase: XCTestCase {
     override func setUp() {
         super.setUp()
+        iotUserDefaults = FakeUserDefaults.self
+        //removing all gateway stored instance
+        GatewayAPI.removeAllStoredInstances()
         sharedMockSession.mockResponse = (data: nil, urlResponse: nil, error: nil)
         sharedMockSession.requestVerifier = {(request) in }
         sharedMockMultipleSession.responsePairs = [MockResponsePair]()

--- a/ThingIFSDK/ThingIFSDKTests/TestHelpers.swift
+++ b/ThingIFSDK/ThingIFSDKTests/TestHelpers.swift
@@ -77,4 +77,71 @@ class MockMultipleSession: URLSession {
         return MockTask()
     }
 }
+let defaults = FakeUserDefaults()
+class FakeUserDefaults : UserDefaults {
+
+    typealias FakeDefaults = Dictionary<String, Any?>
+    var data : FakeDefaults
+
+    override init?(suiteName suitename: String?) {
+        data = FakeDefaults()
+        super.init(suiteName: "UnitTest")
+    }
+
+    override class var standard: UserDefaults { return defaults }
+
+    override func synchronize() -> Bool {
+        return true
+    }
+
+    override func object(forKey defaultName: String) -> Any? {
+        return data[defaultName] ?? nil
+    }
+
+    override func value(forKeyPath keyPath: String) -> Any? {
+        return data[keyPath] ?? nil
+    }
+    override func value(forKey key: String) -> Any? {
+        return data[key] ?? nil
+    }
+
+    override func bool(forKey defaultName: String) -> Bool {
+        return data[defaultName] as! Bool
+    }
+
+    override func integer(forKey defaultName: String) -> Int {
+        return data[defaultName] as! Int
+    }
+
+    override func float(forKey defaultName: String) -> Float {
+        return data[defaultName] as! Float
+    }
+
+    override func dictionary(forKey defaultName: String) -> [String : Any]? {
+        return data[defaultName] as? Dictionary
+    }
+
+    override func setValue(_ value: Any?, forKey key: String) {
+        data[key] = value
+    }
+    override func set(_ url: URL?, forKey defaultName: String) {
+        data[defaultName] = url
+    }
+    override func set(_ value: Any?, forKey defaultName: String) {
+        data[defaultName] = value
+    }
+
+    override func removeObject(forKey defaultName: String) {
+        data.removeValue(forKey: defaultName)
+    }
+
+}
+
+extension UserDefaults {
+
+    @objc class func transientDefaults() -> FakeUserDefaults {
+        return FakeUserDefaults(suiteName: "UnitTest")!
+    }
+
+}
 

--- a/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPersistenceTests.swift
+++ b/ThingIFSDK/ThingIFSDKTests/ThingIFAPIPersistenceTests.swift
@@ -19,7 +19,7 @@ class ThingIFAPIPersistenceTests: SmallTestBase {
     }
 
     func testSavedInstanceWithInit() throws {
-        let persistance = UserDefaults.standard
+        let persistance = iotUserDefaults.standard
         let baseKey = "ThingIFAPI_INSTANCE"
         let setting = TestSetting()
         let app = setting.app
@@ -316,7 +316,7 @@ class ThingIFAPIPersistenceTests: SmallTestBase {
 
     func testInvalidSavedInstance() throws {
 
-        let persistance = UserDefaults.standard
+        let persistance = iotUserDefaults.standard
         let baseKey = "ThingIFAPI_INSTANCE"
         let versionKey = "ThingIFAPI_VERSION"
         let sdkVersion = SDKVersion.sharedInstance.versionString
@@ -407,10 +407,10 @@ class ThingIFAPIPersistenceTests: SmallTestBase {
 
         let baseKey = "ThingIFAPI_INSTANCE"
         let versionKey = "ThingIFAPI_VERSION"
-        if var dict = UserDefaults.standard.dictionary(forKey: baseKey) {
+        if var dict = iotUserDefaults.standard.dictionary(forKey: baseKey) {
             dict[versionKey] = nil
-            UserDefaults.standard.set(dict, forKey: baseKey)
-            UserDefaults.standard.synchronize()
+            iotUserDefaults.standard.set(dict, forKey: baseKey)
+            iotUserDefaults.standard.synchronize()
         }
 
         XCTAssertThrowsError(try ThingIFAPI.loadWithStoredInstance()) { error in
@@ -452,10 +452,10 @@ class ThingIFAPIPersistenceTests: SmallTestBase {
 
         let baseKey = "ThingIFAPI_INSTANCE"
         let versionKey = "ThingIFAPI_VERSION" + "_\(tagName)"
-        if var dict = UserDefaults.standard.dictionary(forKey: baseKey) {
+        if var dict = iotUserDefaults.standard.dictionary(forKey: baseKey) {
             dict[versionKey] = "0.0.0"
-            UserDefaults.standard.set(dict, forKey: baseKey)
-            UserDefaults.standard.synchronize()
+            iotUserDefaults.standard.set(dict, forKey: baseKey)
+            iotUserDefaults.standard.synchronize()
         }
 
         XCTAssertThrowsError(try ThingIFAPI.loadWithStoredInstance(tagName)) {
@@ -497,10 +497,10 @@ class ThingIFAPIPersistenceTests: SmallTestBase {
 
         let baseKey = "ThingIFAPI_INSTANCE"
         let versionKey = "ThingIFAPI_VERSION"
-        if var dict = UserDefaults.standard.dictionary(forKey: baseKey) {
+        if var dict = iotUserDefaults.standard.dictionary(forKey: baseKey) {
             dict[versionKey] = "1000.0.0"
-            UserDefaults.standard.set(dict, forKey: baseKey)
-            UserDefaults.standard.synchronize()
+            iotUserDefaults.standard.set(dict, forKey: baseKey)
+            iotUserDefaults.standard.synchronize()
         }
 
         XCTAssertEqual(api, try ThingIFAPI.loadWithStoredInstance())


### PR DESCRIPTION
# Background
- UserDefaults is needed to mock, since it is persisted on bundle (test/app bundle) so it will be expensive operation and less relevant on small-test

# Changes
- implement dependency injection just like `NSURLSession`
- update testcase