### PR TITLE
Leave tasks in main queue.

### DIFF
--- a/ThingIFSDK/ThingIFSDK.xcodeproj/xcshareddata/xcschemes/ThingIFSDK.xcscheme
+++ b/ThingIFSDK/ThingIFSDK.xcodeproj/xcshareddata/xcschemes/ThingIFSDK.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -49,6 +50,11 @@
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction

--- a/ThingIFSDK/ThingIFSDK/Operations/OperationCondition.swift
+++ b/ThingIFSDK/ThingIFSDK/Operations/OperationCondition.swift
@@ -87,7 +87,9 @@ struct OperationConditionEvaluator {
             conditionGroup.enter()
             condition.evaluateForOperation(operation) { result in
                 results[index] = result
-                conditionGroup.leave()
+                DispatchQueue.main.async {
+                    conditionGroup.leave()
+                }
             }
         }
         


### PR DESCRIPTION
_**This is not a PR to merge. Don't marge this.**_

### Summary

This PR only point out a way to avoid over commit error but I did not found root cause.
I think this PR assists to find a root cause. We might investigate `DispatchGroup.leave()` more.

### Background of this investigation

In #462, @rizakii found and tried to fix a bug about over commit of tasks. In that PR, he made 2 changes:

1. Add add QoS to tasks. That is [here](https://github.com/KiiPlatform/thing-if-iOSSDK/pull/462/files#diff-f205eb849e9d7e1918fa31f9dee13016R62).
2. Execute callbacks in main queue like [here](https://github.com/KiiPlatform/thing-if-iOSSDK/pull/462/files#diff-f205eb849e9d7e1918fa31f9dee13016R36)

I talked about that PR with riza, He said that I add QoS to tasks according to [this site]( http://stackoverflow.com/questions/27948618/consistent-dispatch-queue-com-apple-root-default-qos-overcommit-crash). He also said that executing callbacks in main queue is not concerned with that PR so I offered him to remove changes about executing callbacks in main queue. He removed the changes but over commit happened again.

As a result, I assumed that only executing callbacks in main queue avoids over commit error and Adding QoS has not effort.

### What I do

I fixed 2 point against riza's PR:

1. Remove QoS to tasks which riza added
2. Search root point of the callbacks and execute only the root point in main queue.

Theses 2 fixes resolves over commit error in my environment.

### Consideration

In my investigation, Executing [DispatchGroup.leave()](https://developer.apple.com/reference/dispatch/dispatchgroup/1452872-leave) in main queue resolves the over commit error.

API document of [DispatchGroup.leave()](https://developer.apple.com/reference/dispatch/dispatchgroup/1452872-leave)  said that _**"Calling this function decrements the current count of outstanding tasks in the group."**_ in discussion.

In my knowledge, over commit error occurs when a task queue contains a lot of tasks which task manager can not handle. If `DispatchGroup.leave()` fails to decrement the count of tasks, over commit error might occur.

### Conclusion

I could not find a root cause of this bug but I think `DispatchGroup.leave()` is one candidate of a point to happen root cause.

I think we might investigate `DispatchGroup.leave()` more.