### PR TITLE
Migration to Circleci 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,3 +91,32 @@ jobs:
         path: /tmp/circleci-artifacts
     - store_artifacts:
         path: /tmp/circleci-test-results
+    - persist_to_workspace:
+        root: .
+        paths:
+            - ThingIF.podspec
+            - ThingIFSDK/Documentation
+            - circleci_scripts
+  deploy:
+    working_directory: ~/deploy
+    macos:
+      xcode: '9.4.0'
+    steps:
+      - attach_workspace:
+          at: .
+      - run: bash circleci_scripts/release_doc.sh
+      - run: pod trunk push --verbose
+
+workflows:
+  version: 2
+  deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+){0,2}([-+].+)?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,11 @@ jobs:
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-      default_destination: platform=iOS Simulator,name=iPhone 6,OS=9.0
+      default_destination: platform=iOS Simulator,name=iPhone 6,OS=11.2
     # The `macos` block requests that builds will run on a machine running
     # macOS with the specified version of Xcode installed
     macos:
-      xcode: '8.1'
+      xcode: '9.4.0'
     steps:
     # Machine Setup
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    working_directory: ~/KiiPlatform/thing-if-iOSSDK
+    parallelism: 1
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      default_destination: platform=iOS Simulator,name=iPhone 6,OS=9.0
+    # The `macos` block requests that builds will run on a machine running
+    # macOS with the specified version of Xcode installed
+    macos:
+      xcode: '8.1'
+    steps:
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    - checkout
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
+    - run:
+        working_directory: ~/KiiPlatform/thing-if-iOSSDK
+        command: xcodebuild -version
+    # Dependencies
+    #   This would typically go in either a build or a build-and-test job when using workflows
+    # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    # This is based on your 1.0 configuration file or project settings
+    - run: sudo gem install jazzy
+    - run: sudo gem install ocunit2junit
+    - run: sudo gem install rubygems-update
+    - run: sudo update_rubygems
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # This is a broad list of cache paths to include many possible development environments
+        # You can probably delete some of these entries
+        - vendor/bundle
+        - ~/virtualenvs
+        - ~/.m2
+        - ~/.ivy2
+        - ~/.bundle
+        - ~/.go_workspace
+        - ~/.gradle
+        - ~/.cache/bower
+    # Test
+    #   This would typically be a build job when using workflows, possibly combined with build
+    # This is based on your 1.0 configuration file or project settings
+    - run: cd ThingIFSDK; make all
+    - run: cp ThingIFSDK/Documentation/*.zip $CIRCLE_ARTIFACTS
+    - run: cp -fr ThingIFSDK/Documentation/docs $CIRCLE_ARTIFACTS/
+    # This is based on your 1.0 configuration file or project settings
+    - run: if [ ! -n "$DESTINATION" ]; then DESTINATION=$default_destination; fi; cd ThingIFSDK; python testScripts/xcodebuildtest.py  --destination "${DESTINATION}"
+    - run: cp ThingIFSDK/test-reports/*.xml $CIRCLE_TEST_REPORTS/
+    # Deployment
+    # Your existing circle.yml file contains deployment steps.
+    # The config translation tool does not support translating deployment steps
+    # since deployment in CircleCI 2.0 are better handled through workflows.
+    # See the documentation for more information https://circleci.com/docs/2.0/workflows/
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
+    - run: find $HOME/Library/Developer/Xcode/DerivedData -name '*.xcactivitylog' -exec cp {} $CIRCLE_ARTIFACTS/xcactivitylog \; || true
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/ThingIFSDK/Documentation/generateDocs.py
+++ b/ThingIFSDK/Documentation/generateDocs.py
@@ -35,7 +35,6 @@ class SwiftDocGenerator(object):
         self.author_url = settings["author_url"]
         self.github_url = settings["github_url"]
         self.output = settings["output"]
-        self.swift_version = settings["swift-version"]
 
         # for archive
         self.docArchivePrefix = settings["doc-archive-prefix"]
@@ -52,7 +51,7 @@ class SwiftDocGenerator(object):
             for ignore in self.ignores:
                 ignoreList.append(ignore)
 
-        processArg = ["jazzy", '-c','--output', self.output, '--xcodebuild-arguments', '-project,../{0}'.format(self.project), '--author', self.author, '--author_url', self.author_url, '--github_url', self.github_url, '--swift-version', self.swift_version, '--exclude', ','.join(ignoreList)]
+        processArg = ["jazzy", '-c','--output', self.output, '--xcodebuild-arguments', '-project,../{0}'.format(self.project), '--author', self.author, '--author_url', self.author_url, '--github_url', self.github_url, '--exclude', ','.join(ignoreList)]
 
         processArg = filter(bool, processArg)
         print("Command: " + " ".join(processArg))

--- a/ThingIFSDK/Documentation/jazzy-options.js
+++ b/ThingIFSDK/Documentation/jazzy-options.js
@@ -6,7 +6,6 @@
     "author_url": "http://kii.com",
     "github_url": "https://github.com/KiiPlatform/thing-if-iOSSDK",
     "output": "docs",
-    "swift-version": "4.1.2",
 
     "doc-archive-prefix": "ThingIFSDK-Documentation",
 

--- a/ThingIFSDK/Documentation/jazzy-options.js
+++ b/ThingIFSDK/Documentation/jazzy-options.js
@@ -6,7 +6,7 @@
     "author_url": "http://kii.com",
     "github_url": "https://github.com/KiiPlatform/thing-if-iOSSDK",
     "output": "docs",
-    "swift-version": "3.0.2",
+    "swift-version": "4.1.2",
 
     "doc-archive-prefix": "ThingIFSDK-Documentation",
 


### PR DESCRIPTION
Other than deployment part, config.yml is generated by [migration tool](https://github.com/CircleCI-Public/circleci-config-generator)

## Limitation

Deployment is not tested. Need confirmation next time we release the SDK.

## Notes

`jazzy` documentation execution was failed with `--swift-version` option. It requires Xcode is indexed with Spotlight.  I have just removed the `--swift-version` option when execute `jazzy`.

`--swift-version` effect is not very clear though, We don't have to worry about it since Swift 3 and 4 are compatible.

Generated API document  is stored in this [artifact](https://1692-40101539-gh.circle-artifacts.com/0/tmp/circleci-artifacts/docs/index.html)